### PR TITLE
[docs] Add missing global state classes to API docs generator

### DIFF
--- a/docs/pages/api-docs/slider-unstyled.json
+++ b/docs/pages/api-docs/slider-unstyled.json
@@ -94,7 +94,7 @@
       "trackFalse": "MuiSlider-trackFalse",
       "trackInverted": "MuiSlider-trackInverted",
       "thumb": "MuiSlider-thumb",
-      "active": "MuiSlider-active",
+      "active": "Mui-active",
       "focusVisible": "Mui-focusVisible",
       "valueLabel": "MuiSlider-valueLabel",
       "valueLabelOpen": "MuiSlider-valueLabelOpen",

--- a/docs/pages/api-docs/slider.json
+++ b/docs/pages/api-docs/slider.json
@@ -106,7 +106,11 @@
       "thumbColorSecondary",
       "thumbSizeSmall"
     ],
-    "globalClasses": { "disabled": "Mui-disabled", "focusVisible": "Mui-focusVisible" },
+    "globalClasses": {
+      "disabled": "Mui-disabled",
+      "active": "Mui-active",
+      "focusVisible": "Mui-focusVisible"
+    },
     "name": "MuiSlider"
   },
   "spread": true,

--- a/docs/pages/api-docs/step-connector.json
+++ b/docs/pages/api-docs/step-connector.json
@@ -22,7 +22,11 @@
       "lineHorizontal",
       "lineVertical"
     ],
-    "globalClasses": { "disabled": "Mui-disabled" },
+    "globalClasses": {
+      "active": "Mui-active",
+      "completed": "Mui-completed",
+      "disabled": "Mui-disabled"
+    },
     "name": "MuiStepConnector"
   },
   "spread": true,

--- a/docs/pages/api-docs/step-icon.json
+++ b/docs/pages/api-docs/step-icon.json
@@ -15,7 +15,7 @@
   "name": "StepIcon",
   "styles": {
     "classes": ["root", "text", "active", "completed", "error"],
-    "globalClasses": { "error": "Mui-error" },
+    "globalClasses": { "active": "Mui-active", "completed": "Mui-completed", "error": "Mui-error" },
     "name": "MuiStepIcon"
   },
   "spread": true,

--- a/docs/pages/api-docs/step-label.json
+++ b/docs/pages/api-docs/step-label.json
@@ -30,7 +30,12 @@
       "alternativeLabel",
       "labelContainer"
     ],
-    "globalClasses": { "error": "Mui-error", "disabled": "Mui-disabled" },
+    "globalClasses": {
+      "active": "Mui-active",
+      "completed": "Mui-completed",
+      "error": "Mui-error",
+      "disabled": "Mui-disabled"
+    },
     "name": "MuiStepLabel"
   },
   "spread": true,

--- a/docs/pages/api-docs/step.json
+++ b/docs/pages/api-docs/step.json
@@ -18,7 +18,7 @@
   "name": "Step",
   "styles": {
     "classes": ["root", "horizontal", "vertical", "alternativeLabel", "completed"],
-    "globalClasses": {},
+    "globalClasses": { "completed": "Mui-completed" },
     "name": "MuiStep"
   },
   "spread": true,

--- a/docs/pages/api-docs/table-sort-label.json
+++ b/docs/pages/api-docs/table-sort-label.json
@@ -19,7 +19,7 @@
   "name": "TableSortLabel",
   "styles": {
     "classes": ["root", "active", "icon", "iconDirectionDesc", "iconDirectionAsc"],
-    "globalClasses": {},
+    "globalClasses": { "active": "Mui-active" },
     "name": "MuiTableSortLabel"
   },
   "spread": true,

--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -24,7 +24,7 @@ import createDescribeableProp, {
 } from 'docs/src/modules/utils/createDescribeableProp';
 import generatePropDescription from 'docs/src/modules/utils/generatePropDescription';
 import parseStyles, { Styles } from 'docs/src/modules/utils/parseStyles';
-import createGenerateClassName from '@mui/styles/createGenerateClassName';
+import generateUtilityClass from '@mui/base/generateUtilityClass';
 import * as ttp from 'typescript-to-proptypes';
 import { getLineFeed, getUnstyledFilename } from './helpers';
 
@@ -61,8 +61,6 @@ interface ReactApi extends ReactDocgenApi {
 }
 
 const cssComponents = ['Box', 'Grid', 'Typography'];
-
-const generateClassName = createGenerateClassName();
 
 function writePrettifiedFile(
   filename: string,
@@ -486,18 +484,11 @@ async function buildDocs(options: {
     reactApi.styles.name = generateMuiName(reactApi.name);
   }
   reactApi.styles.classes.forEach((key) => {
-    reactApi.styles.globalClasses[key] = generateClassName(
-      // @ts-expect-error
-      {
-        key,
-      },
-      {
-        options: {
-          name: reactApi.styles.name || generateMuiName(name),
-          theme: {},
-        },
-      },
+    const globalClass = generateUtilityClass(
+      reactApi.styles.name || generateMuiName(reactApi.name),
+      key,
     );
+    reactApi.styles.globalClasses[key] = globalClass;
   });
 
   const propErrors: Array<[propName: string, error: Error]> = [];

--- a/packages/mui-styles/src/createGenerateClassName/createGenerateClassName.js
+++ b/packages/mui-styles/src/createGenerateClassName/createGenerateClassName.js
@@ -10,13 +10,15 @@ import { unstable_nested as nested } from '@mui/private-theming/ThemeProvider';
  * being untouched by simple user overrides.
  */
 const stateClasses = [
+  'active',
   'checked',
+  'completed',
   'disabled',
   'error',
+  'expanded',
   'focused',
   'focusVisible',
   'required',
-  'expanded',
   'selected',
 ];
 

--- a/packages/mui-styles/src/createGenerateClassName/createGenerateClassName.js
+++ b/packages/mui-styles/src/createGenerateClassName/createGenerateClassName.js
@@ -10,15 +10,13 @@ import { unstable_nested as nested } from '@mui/private-theming/ThemeProvider';
  * being untouched by simple user overrides.
  */
 const stateClasses = [
-  'active',
   'checked',
-  'completed',
   'disabled',
   'error',
-  'expanded',
   'focused',
   'focusVisible',
   'required',
+  'expanded',
   'selected',
 ];
 


### PR DESCRIPTION
The API docs generator did not treat `active` and `completed` as global state classes. It resulted in API docs for several components being invalid. This PR adds the missing classes and updates all the affected API pages.

Fixes #29825.