### PR TITLE
[docs] Improve wording in StackOverflow section of support page

### DIFF
--- a/docs/src/pages/getting-started/support/support.md
+++ b/docs/src/pages/getting-started/support/support.md
@@ -9,7 +9,7 @@ The community is your first stop for questions and advice about the framework. W
 ### StackOverflow
 
 For crowdsourced answers from expert MUI developers in our community.
-StackOverflow is also visited, from time to time, by the maintainers of MUI.
+StackOverflow is also visited from time to time by the maintainers of MUI.
 
 [Post a question](https://stackoverflow.com/questions/tagged/material-ui)
 

--- a/docs/src/pages/getting-started/support/support.md
+++ b/docs/src/pages/getting-started/support/support.md
@@ -9,7 +9,7 @@ The community is your first stop for questions and advice about the framework. W
 ### StackOverflow
 
 For crowdsourced answers from expert MUI developers in our community.
-StackOverflow is also frequented, from time to time, by the maintainers of MUI.
+StackOverflow is also visited, from time to time, by the maintainers of MUI.
 
 [Post a question](https://stackoverflow.com/questions/tagged/material-ui)
 


### PR DESCRIPTION
This document has a contradictory statement in "StackOverflow is also frequented, from time to time, by the maintainers of MUI."  Something can only be "frequented" if it is visited frequently.  By contrast, "from time to time" implies the visits are only occasional, not frequent, and perhaps closer to seldom.  I'm assuming the intent was to suggest MUI maintainers only occasionally visit, so I propose "visited" in place of "frequented," but if the truth is that MUI maintainers frequently visit, then perhaps just drop the "from time to time" altogether instead.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
