### PR TITLE
[Select] Should not crash when an empty array is passed with `multiple` enabled

### DIFF
--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -819,6 +819,20 @@ describe('<Select />', () => {
       expect(getByRole('button')).to.have.text('Ten, Twenty, Thirty');
     });
 
+    it('should not throw an error for an empty multiple list', () => {
+      const { getByRole } = render(
+        <Select multiple value={[]}>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>
+            <strong>Twenty</strong>
+          </MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+      // A zero-width string is added for empty values
+      expect(getByRole('button')).to.have.text('\u200B');
+    });
+
     it('selects value based on their stringified equality when theyre not objects', () => {
       const { getAllByRole } = render(
         <Select multiple open value={['10', '20']}>

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -323,10 +323,10 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
 
   // No need to display any value if the field is empty.
   if (isFilled({ value }) || displayEmpty) {
-    if (Array.isArray(value) && value.length === 0) {
-      display = '';
-    } else if (renderValue) {
+    if (renderValue) {
       display = renderValue(value);
+    } else if (Array.isArray(value) && value.length === 0) {
+      display = '';
     } else {
       computeDisplay = true;
     }

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -418,7 +418,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
 
   if (computeDisplay) {
     if (multiple) {
-      display = displayMultiple.reduce((prev, curr) => [prev, ', ', curr]);
+      display = displayMultiple.reduce((prev, curr) => [prev, ', ', curr], "");
     } else {
       display = displaySingle;
     }

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -418,7 +418,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
 
   if (computeDisplay) {
     if (multiple) {
-      display = displayMultiple.reduce((prev, curr) => [prev, ', ', curr], "");
+      display = displayMultiple.reduce((prev, curr) => [prev, ', ', curr], '');
     } else {
       display = displaySingle;
     }

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -418,7 +418,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
 
   if (computeDisplay) {
     if (multiple) {
-      display = displayMultiple.reduce((prev, curr) => [prev, ', ', curr], '');
+      display = displayMultiple.join(', ');
     } else {
       display = displaySingle;
     }

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -323,7 +323,9 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
 
   // No need to display any value if the field is empty.
   if (isFilled({ value }) || displayEmpty) {
-    if (renderValue) {
+    if (Array.isArray(value) && value.length === 0) {
+      display = '';
+    } else if (renderValue) {
       display = renderValue(value);
     } else {
       computeDisplay = true;
@@ -418,7 +420,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
 
   if (computeDisplay) {
     if (multiple) {
-      display = displayMultiple.reduce((prev, curr) => (prev ? [prev, ', ', curr] : curr), null);
+      display = displayMultiple.reduce((prev, curr) => [prev, ', ', curr]);
     } else {
       display = displaySingle;
     }

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -325,8 +325,6 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   if (isFilled({ value }) || displayEmpty) {
     if (renderValue) {
       display = renderValue(value);
-    } else if (Array.isArray(value) && value.length === 0) {
-      display = '';
     } else {
       computeDisplay = true;
     }
@@ -420,7 +418,11 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
 
   if (computeDisplay) {
     if (multiple) {
-      display = displayMultiple.reduce((prev, curr) => [prev, ', ', curr]);
+      if (value.length === 0) {
+        display = '';
+      } else {
+        display = displayMultiple.reduce((prev, curr) => [prev, ', ', curr]);
+      }
     } else {
       display = displaySingle;
     }

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -418,7 +418,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
 
   if (computeDisplay) {
     if (multiple) {
-      display = displayMultiple.join(', ');
+      display = displayMultiple.reduce((prev, curr) => (prev ? [prev, ', ', curr] : curr), null);
     } else {
       display = displaySingle;
     }


### PR DESCRIPTION
Fixes #29836

📦  https://codesandbox.io/s/mui-issue-latest-forked-4pg71

For the case that an empty list is passed for multiple, a fallback needs to be passed to the reduce.
Otherwise the first element is selected, which is undefined in this case ( empty list ) and it crashes the code.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


[References](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Reduce_of_empty_array_with_no_initial_value)