### PR TITLE
[core] Transition to a new StackOverflow tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Yes, it's really all you need to get started as you can see in this live and int
 ## Questions
 
 For _how-to_ questions and other non-issues,
-please use [StackOverflow](https://stackoverflow.com/questions/tagged/material-ui) instead of GitHub issues.
+please use [StackOverflow](https://stackoverflow.com/questions/tagged/mui) instead of GitHub issues.
 There is a StackOverflow tag called "material-ui" that you can use to tag your questions.
 
 ## Examples

--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -701,10 +701,7 @@ function AboutContent() {
                 </li>
                 <li>
                   Answer questions on{' '}
-                  <Link href="https://stackoverflow.com/questions/tagged/mui">
-                    StackOverflow
-                  </Link>
-                  .
+                  <Link href="https://stackoverflow.com/questions/tagged/mui">StackOverflow</Link>.
                 </li>
               </Box>
               <Link href="https://github.com/mui-org/material-ui" variant="body2">

--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -701,7 +701,7 @@ function AboutContent() {
                 </li>
                 <li>
                   Answer questions on{' '}
-                  <Link href="https://stackoverflow.com/questions/tagged/material-ui">
+                  <Link href="https://stackoverflow.com/questions/tagged/mui">
                     StackOverflow
                   </Link>
                   .

--- a/docs/src/layouts/AppFooter.tsx
+++ b/docs/src/layouts/AppFooter.tsx
@@ -151,7 +151,7 @@ export default function AppFooter() {
             <IconButton
               target="_blank"
               rel="noopener noreferrer"
-              href="https://stackoverflow.com/questions/tagged/material-ui"
+              href="https://stackoverflow.com/questions/tagged/mui"
               aria-label="Stack Overflow"
               title="Stack Overflow"
               size="small"

--- a/docs/src/pages/getting-started/faq/faq-pt.md
+++ b/docs/src/pages/getting-started/faq/faq-pt.md
@@ -10,7 +10,7 @@ Existem muitas maneiras de apoiar o Material-UI:
 
 - **Espalhe a palavra**. Evangelize Material-UI [vinculando o material-ui.com](https://material-ui.com/) no seu site, todo backlink conta. Siga-nos no [Twitter](https://twitter.com/MaterialUI), curta e retuíte as notícias importantes. Ou apenas fale sobre nós com os seus amigos.
 - **Dê-nos sua opinião**. Conte-nos o que estamos fazendo bem ou onde podemos melhorar. Por favor vote (👍) nos issues do GitHub que você está mais interessado em ver resolvidos.
-- **Ajude novos usuários**. Você pode responder a perguntas no [StackOverflow](https://stackoverflow.com/questions/tagged/material-ui).
+- **Ajude novos usuários**. Você pode responder a perguntas no [StackOverflow](https://stackoverflow.com/questions/tagged/mui).
 - **Faça as alterações acontecerem**.
   - Edite a documentação. Cada página da versão em inglês tem um link "EDIT THIS PAGE" no canto superior direito.
   - Reporte erros ou recursos faltantes [criando uma issue](https://github.com/mui-org/material-ui/issues/new).

--- a/docs/src/pages/getting-started/faq/faq-zh.md
+++ b/docs/src/pages/getting-started/faq/faq-zh.md
@@ -10,7 +10,7 @@
 
 - **口口相传**。 通过在您的网站上 [链接到 material-ui.com](https://material-ui.com/) 来传播 Material-UI ，每个反向链接对我们来说都很重要。 在 [Twitter 上关注我们](https://twitter.com/MaterialUI) ，点赞并转发一些重要的新闻。 或者只是与您的朋友谈论我们。
 - **给我们反馈** 。 告诉我们一些做得好的地方或者可以改进的地方。 请给您最希望看到能够解决的问题投票（👍）。
-- **帮助新用户** 。 您可以在 [StackOverflow](https://stackoverflow.com/questions/tagged/material-ui) 中回答一些问题。
+- **帮助新用户** 。 您可以在 [StackOverflow](https://stackoverflow.com/questions/tagged/mui) 中回答一些问题。
 - **做出一些改变吧**。
   - 编辑文档。 每个页面右上角都有一个“编辑此页面”的链接。
   - 通过 [创建一个问题](https://github.com/mui-org/material-ui/issues/new) 来报告错误或缺少的功能 。

--- a/docs/src/pages/getting-started/faq/faq.md
+++ b/docs/src/pages/getting-started/faq/faq.md
@@ -12,7 +12,7 @@ There are many ways to support MUI:
   Follow us on [Twitter](https://twitter.com/MaterialUI), like and retweet the important news. Or just talk about us with your friends.
 - **Give us feedback**. Tell us what we're doing well or where we can improve. Please upvote (👍) the issues that you are the most interested in seeing solved.
 - **Help new users**. You can answer questions on
-  [StackOverflow](https://stackoverflow.com/questions/tagged/material-ui).
+  [StackOverflow](https://stackoverflow.com/questions/tagged/mui).
 - **Make changes happen**.
   - Edit the documentation. Every page has an "EDIT THIS PAGE" link in the top right.
   - Report bugs or missing features by [creating an issue](https://github.com/mui-org/material-ui/issues/new).

--- a/docs/src/pages/getting-started/support/support-pt.md
+++ b/docs/src/pages/getting-started/support/support-pt.md
@@ -10,7 +10,7 @@ A comunidade é sua primeira parada para perguntas e conselhos sobre o framework
 
 Para questões técnicas colaborativas, conte com o apoio de desenvolvedores de Material-UI especializados em nossa comunidade. Também frequentado pela equipe principal do Material-UI.
 
-[Poste uma pergunta](https://stackoverflow.com/questions/tagged/material-ui)
+[Poste uma pergunta](https://stackoverflow.com/questions/tagged/mui)
 
 ### GitHub <img src="/static/images/logos/github.svg" width="24" height="24" alt="GitHub logo" loading="lazy" />
 

--- a/docs/src/pages/getting-started/support/support-zh.md
+++ b/docs/src/pages/getting-started/support/support-zh.md
@@ -10,7 +10,7 @@
 
 而我们社区的 Material-UI 开发，会解决那些众包的技术问题。  以及一些 Material-UI 核心团队回答的常见问答。
 
-[发布一个问题](https://stackoverflow.com/questions/tagged/material-ui)
+[发布一个问题](https://stackoverflow.com/questions/tagged/mui)
 
 ### GitHub <img src="/static/images/logos/github.svg" width="24" height="24" alt="GitHub logo" loading="lazy" />
 

--- a/docs/src/pages/getting-started/support/support.md
+++ b/docs/src/pages/getting-started/support/support.md
@@ -11,7 +11,7 @@ The community is your first stop for questions and advice about the framework. W
 For crowdsourced answers from expert MUI developers in our community.
 StackOverflow is also visited from time to time by the maintainers of MUI.
 
-[Post a question](https://stackoverflow.com/questions/tagged/material-ui)
+[Post a question](https://stackoverflow.com/questions/tagged/mui)
 
 ### GitHub
 


### PR DESCRIPTION
*mui* is managed as a synonym of *material-ui* on StackOverflow: https://stackoverflow.com/tags/material-ui/synonyms. I propose we consolidate everything under mui. In the future, if we need to distinguish between different products then I think we could have sub-labels. For instance, Angular has:

- [angular](https://stackoverflow.com/questions/tagged/angular)
- [angular-material](https://stackoverflow.com/questions/tagged/angular-material)
- [angular-cdk](https://stackoverflow.com/questions/tagged/angular-cdk)

We could have `mui-base`, `mui-joy`, `mui-material`, `mui-studio`, `mui-x` in the future. We had a chat with Ryan about it on https://github.com/mui-org/material-ui-x/pull/2676#discussion_r716739659.

<img width="792" alt="Screenshot 2021-12-03 at 14 09 33" src="https://user-images.githubusercontent.com/3165635/144607864-d63ab8b1-6166-4408-85fe-8f83ec30bbb0.png">

This PR is part of #27825.