### PR TITLE
[Accordion] Add a test for handling `square` prop

### DIFF
--- a/packages/mui-material/src/Accordion/Accordion.test.js
+++ b/packages/mui-material/src/Accordion/Accordion.test.js
@@ -129,6 +129,11 @@ describe('<Accordion />', () => {
     expect(queryByText('Hello')).to.equal(null);
   });
 
+  it('should handle the square prop', () => {
+    const { container } = render(<Accordion square>{minimalChildren}</Accordion>);
+    expect(container.firstChild).not.to.have.class(classes.rounded);
+  });
+
   describe('prop: children', () => {
     describe('first child', () => {
       beforeEach(() => {

--- a/packages/mui-material/src/Accordion/Accordion.test.js
+++ b/packages/mui-material/src/Accordion/Accordion.test.js
@@ -129,7 +129,17 @@ describe('<Accordion />', () => {
     expect(queryByText('Hello')).to.equal(null);
   });
 
-  it('should handle the square prop', () => {
+  it('should handle the `square` prop', () => {
+    const { container } = render(<Accordion square>{minimalChildren}</Accordion>);
+    expect(container.firstChild).not.toHaveComputedStyle({
+      borderBottomLeftRadius: '4px',
+      borderBottomRightRadius: '4px',
+      borderTopLeftRadius: '4px',
+      borderTopRightRadius: '4px',
+    });
+  });
+
+  it('when `square` prop is passed, it should not have the rounded class', () => {
     const { container } = render(<Accordion square>{minimalChildren}</Accordion>);
     expect(container.firstChild).not.to.have.class(classes.rounded);
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

[Accordion.test.js](https://github.com/mui-org/material-ui/blob/master/packages/mui-material/src/Accordion/Accordion.test.js) was missing a test to verify the functionality of the `square` prop

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
