### PR TITLE
[DateRangePicker] Close component on finishing range selection

### DIFF
--- a/packages/mui-lab/src/internal/pickers/PickersPopper.tsx
+++ b/packages/mui-lab/src/internal/pickers/PickersPopper.tsx
@@ -264,6 +264,7 @@ const PickersPopper = (props: PickerPopperProps) => {
         <TrapFocus
           open={open}
           disableAutoFocus
+          disableRestoreFocus
           disableEnforceFocus={role === 'tooltip'}
           isEnabled={() => true}
           {...TrapFocusProps}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #24828

Continuation of #25221 because I closed the PR by accident and couldn't push to the PR directly due to permission issue

credit to: @vedadeepta 

`usePickerState.ts` already sets `isOpen` to `false` on finishing range selection, but the state is immediately set to `true` right after because of restoring focus function in `Unstable_TrapFocus`.