### PR TITLE
[LoadingButton] Label progressbar by the LoadingButton

### DIFF
--- a/docs/translations/api-docs/loading-button/loading-button.json
+++ b/docs/translations/api-docs/loading-button/loading-button.json
@@ -5,7 +5,7 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "disabled": "If <code>true</code>, the component is disabled.",
     "loading": "If <code>true</code>, the loading indicator is shown.",
-    "loadingIndicator": "Element placed before the children if the button is in loading state.",
+    "loadingIndicator": "Element placed before the children if the button is in loading state. The node should contain an element with <code>role=&quot;progressbar&quot;</code> with an accessible name. By default we render a <code>CircularProgress</code> that is labelled by the button itself.",
     "loadingPosition": "The loading indicator can be positioned on the start, end, or the center of the button.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
     "variant": "The variant to use."

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.d.ts
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.d.ts
@@ -36,6 +36,8 @@ export type LoadingButtonTypeMap<
     loading?: boolean;
     /**
      * Element placed before the children if the button is in loading state.
+     * The node should contain an element with `role="progressbar"` with an accessible name.
+     * By default we render a `CircularProgress` that is labelled by the button itself.
      * @default <CircularProgress color="inherit" size={16} />
      */
     loadingIndicator?: React.ReactNode;

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { chainPropTypes } from '@mui/utils';
-import { capitalize } from '@mui/material/utils';
+import { capitalize, unstable_useId as useId } from '@mui/material/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { styled, useThemeProps } from '@mui/material/styles';
 import Button from '@mui/material/Button';
@@ -134,19 +134,23 @@ const LoadingButtonLoadingIndicator = styled('div', {
     }),
 }));
 
-const LoadingIndicator = <CircularProgress color="inherit" size={16} />;
-
 const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiLoadingButton' });
   const {
     children,
     disabled = false,
+    id: idProp,
     loading = false,
-    loadingIndicator = LoadingIndicator,
+    loadingIndicator: loadingIndicatorProp,
     loadingPosition = 'center',
     variant = 'text',
     ...other
   } = props;
+
+  const id = useId(idProp);
+  const loadingIndicator = loadingIndicatorProp ?? (
+    <CircularProgress aria-labelledby={id} color="inherit" size={16} />
+  );
 
   const ownerState = {
     ...props,
@@ -162,6 +166,7 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
   return (
     <LoadingButtonRoot
       disabled={disabled || loading}
+      id={id}
       ref={ref}
       {...other}
       variant={variant}
@@ -217,12 +222,18 @@ LoadingButton.propTypes /* remove-proptypes */ = {
    */
   disabled: PropTypes.bool,
   /**
+   * @ignore
+   */
+  id: PropTypes.string,
+  /**
    * If `true`, the loading indicator is shown.
    * @default false
    */
   loading: PropTypes.bool,
   /**
    * Element placed before the children if the button is in loading state.
+   * The node should contain an element with `role="progressbar"` with an accessible name.
+   * By default we render a `CircularProgress` that is labelled by the button itself.
    * @default <CircularProgress color="inherit" size={16} />
    */
   loadingIndicator: PropTypes.node,

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.test.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, describeConformance, screen } from 'test/utils';
+import { createRenderer, describeConformance, screen, within } from 'test/utils';
 import { expect } from 'chai';
 import Button from '@mui/material/Button';
 import LoadingButton, { loadingButtonClasses as classes } from '@mui/lab/LoadingButton';
@@ -44,6 +44,14 @@ describe('<LoadingButton />', () => {
       render(<LoadingButton disabled={false} loading />);
 
       expect(screen.getByRole('button')).to.have.property('disabled', true);
+    });
+
+    it('renders a progressbar that is labelled by the button', () => {
+      render(<LoadingButton loading>Submit</LoadingButton>);
+
+      const button = screen.getByRole('button');
+      const progressbar = within(button).getByRole('progressbar');
+      expect(progressbar).toHaveAccessibleName('Submit');
     });
   });
 


### PR DESCRIPTION
Pending screen reader testing based on https://codesandbox.io/s/loadingbuttonstransition-material-demo-forked-rf2hm?file=/demo.js: https://codesandbox.io/s/loadingbuttonstransition-material-demo-forked-49ok6
Preview: https://deploy-preview-30002--material-ui.netlify.app/components/buttons/

NVDA currently doesn't announce indeterminate progress bars. But the spec is there so eventually there will be some implementation. We shouldn't make any claims about the progressbar of LoadingButton. For now fixing issues with automated a11y testing tools is reason enough to merge this.

Note that loading buttons that just read "loading..." are problematic to begin with and won't get better with the proposed implementation. The problem with a generic "loading..." is that it's just redundant. We already see that it's redundant and screen readers no that something is loading. The question is what is loading. For example, we document a "Fetch Data" button that switches to "loading..." when it's pending. But then we no longer know what exactly is loading which can be problematic depending on what triggered its pending state or how long ago that was. In this particular example "Fetch Data" -> "Fetching Data" is probably the clearer label and we'll get a proper SR announcement along the lines of "progress, Fetching Data...". The "..." is still redundant but it's slightly less confusing than before.

Closes https://github.com/mui-org/material-ui/issues/28206