### PR TITLE
[docs] Explain how Paper changes shade in dark mode

### DIFF
--- a/docs/src/pages/components/paper/paper.md
+++ b/docs/src/pages/components/paper/paper.md
@@ -27,3 +27,7 @@ If you need an outlined surface, use the `variant` prop.
 The elevation can be used to establish a hierachy between other content. In practical terms, the elevation controls the size of the shadow applied to the surface. In dark mode, raising the elevation also makes the surface lighter.
 
 {{"demo": "pages/components/paper/Elevation.js", "bg": "inline"}}
+
+The change of shade in dark mode is done by applying a semi-transparent gradient to the `background-image` property.
+It may be confusing when overriding the Paper's styles, as setting just the `background-color` will not affect the elevation-related shading.
+To ignore the shading and set the background color that is not affected by elevation in dark mode, override the `background` property (or both `background-color` and `background-image`).

--- a/docs/src/pages/components/paper/paper.md
+++ b/docs/src/pages/components/paper/paper.md
@@ -29,5 +29,5 @@ The elevation can be used to establish a hierachy between other content. In prac
 {{"demo": "pages/components/paper/Elevation.js", "bg": "inline"}}
 
 The change of shade in dark mode is done by applying a semi-transparent gradient to the `background-image` property.
-It may be confusing when overriding the Paper's styles, as setting just the `background-color` will not affect the elevation-related shading.
+This can lead to confusion when overriding the styles of `Paper`, as setting just the `background-color` property will not affect the elevation-related shading.
 To ignore the shading and set the background color that is not affected by elevation in dark mode, override the `background` property (or both `background-color` and `background-image`).


### PR DESCRIPTION
Added a brief explanation about both background-color and background-image being used by Paper in dark mode.

Closes #29134.