### PR TITLE
[docs] Add to migration v4 to v5 docs on CSS specificity

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -27,6 +27,7 @@ The **why** is covered in the [release blog post](/blog/mui-core-v5/).
 - [Handling Breaking Changes](#handling-breaking-changes)
 - [Migrate theme's `styleOverrides` to emotion](#migrate-themes-styleoverrides-to-emotion)
 - [Migrate from JSS](#migrate-from-jss)
+- [CSS specificity](#css-specificity)
 - [Troubleshooting](#troubleshooting)
 
 > 💡 Aim to create small commits on any changes to help the migration go more smoothly.
@@ -2589,6 +2590,36 @@ npm uninstall @mui/styles
 
 // or with `yarn`
 yarn remove @mui/styles
+```
+
+## CSS Specificity
+
+If you want to apply styles to components by importing a css file, you need to bump up specificity in order to always select the correct component. Consider the following example.
+
+```js
+import './style.css';
+import Chip from '@mui/material/Chip';
+
+const ChipWithGreenIcon = () => (
+  <Chip classes={{ deleteIcon: 'green' }} label="delete icon is green" onDelete={() => {}} />
+)
+```
+
+In this example, in order to correctly apply a particular style to the delete icon of `Chip`, you need to select the component as specifically as follows:
+
+```css
+.MuiChip-root .green {
+  color: green;
+}
+```
+
+The following will not correctly apply the style to the delete icon:
+
+
+```css
+.green {
+  color: green;
+}
 ```
 
 ## Troubleshooting

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -2601,8 +2601,12 @@ import './style.css';
 import Chip from '@mui/material/Chip';
 
 const ChipWithGreenIcon = () => (
-  <Chip classes={{ deleteIcon: 'green' }} label="delete icon is green" onDelete={() => {}} />
-)
+  <Chip
+    classes={{ deleteIcon: 'green' }}
+    label="delete icon is green"
+    onDelete={() => {}}
+  />
+);
 ```
 
 In this example, in order to correctly apply a particular style to the delete icon of `Chip`, you need to select the component as specifically as follows:
@@ -2614,7 +2618,6 @@ In this example, in order to correctly apply a particular style to the delete ic
 ```
 
 The following will not correctly apply the style to the delete icon:
-
 
 ```css
 .green {

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -2609,7 +2609,7 @@ const ChipWithGreenIcon = () => (
 );
 ```
 
-In this example, in order to correctly apply a particular style to the delete icon of `Chip`, you need to select the component as specifically as follows:
+In this example, in order to correctly apply a particular style to the delete icon of `Chip`, you need to bump the specificity as shown below:
 
 ```css
 .MuiChip-root .green {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui-org/material-ui/issues/29757

Add to migration v4 to v5 README on that users have to bump up css specificity in v5.