### PR TITLE
[website] Refactor page context with next router

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -196,6 +196,7 @@ export default function AppTableOfContents(props) {
   const itemLink = (item, secondary) => (
     <NavItem
       display="block"
+      // always replace the #* in the url because `router.asPath` might contain previous #
       href={`${router.asPath.replace(/#.*/, '')}#${item.hash}`}
       underline="none"
       onClick={handleClick(item.hash)}

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -1,11 +1,11 @@
 /* eslint-disable react/no-danger */
 import * as React from 'react';
+import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import throttle from 'lodash/throttle';
 import { styled, alpha } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import Link from 'docs/src/modules/components/Link';
-import PageContext from 'docs/src/modules/components/PageContext';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 
 const Nav = styled('nav')(({ theme }) => {
@@ -114,10 +114,10 @@ function flatten(headings) {
 export default function AppTableOfContents(props) {
   const { toc } = props;
   const t = useTranslate();
+  const router = useRouter();
 
   const items = React.useMemo(() => flatten(toc), [toc]);
 
-  const { activePage } = React.useContext(PageContext);
   const [activeState, setActiveState] = React.useState(null);
   const clickedRef = React.useRef(false);
   const unsetClickedRef = React.useRef(null);
@@ -196,7 +196,7 @@ export default function AppTableOfContents(props) {
   const itemLink = (item, secondary) => (
     <NavItem
       display="block"
-      href={`${activePage.linkProps?.linkAs ?? activePage.pathname}#${item.hash}`}
+      href={`${router.asPath.replace(/#.*/, '')}#${item.hash}`}
       underline="none"
       onClick={handleClick(item.hash)}
       active={activeState === item.hash}

--- a/docs/src/modules/components/Link.tsx
+++ b/docs/src/modules/components/Link.tsx
@@ -93,7 +93,8 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props,
     userLanguage !== 'en' &&
     pathname &&
     pathname.indexOf('/') === 0 &&
-    pathname.indexOf('/blog') !== 0
+    pathname.indexOf('/blog') !== 0 &&
+    !pathname.startsWith(`/${userLanguage}/`)
   ) {
     linkAs = `/${userLanguage}${linkAs}`;
   }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The issue is I got unexpected error when copy installation page to `docs/pages/material/getting-started/installation` (it should not throw error).

The error occurs in AppTableOfContent because there is no active page. However, it does not make sense that the AppTableOfContent should know about the active page. Instead, it should just read the browser URL (provided by nextjs) and apply a hash to the URL when clicked. 

I feel that this is simpler and easier to maintain, so open this small PR to check that I don't miss anything important.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
