### PR TITLE
[Stack] Document system props in Stack API

### DIFF
--- a/docs/pages/api-docs/stack.json
+++ b/docs/pages/api-docs/stack.json
@@ -31,5 +31,5 @@
   "filename": "/packages/mui-material/src/Stack/Stack.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/components/stack/\">Stack</a></li></ul>",
-  "cssComponent": false
+  "cssComponent": true
 }

--- a/docs/scripts/buildApi.ts
+++ b/docs/scripts/buildApi.ts
@@ -60,7 +60,7 @@ interface ReactApi extends ReactDocgenApi {
   styles: Styles;
 }
 
-const cssComponents = ['Box', 'Grid', 'Typography'];
+const cssComponents = ['Box', 'Grid', 'Typography', 'Stack'];
 
 function writePrettifiedFile(
   filename: string,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR add documentation about system props to [Stack API docs](https://mui.com/api/stack/) just like in [Typography API docs](https://mui.com/api/typography/)

> As a CSS utility, the Typography component also supports all system properties. You can use them as props directly on the component.
