### PR TITLE
[website] Correct the Careers page description

### DIFF
--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -527,7 +527,7 @@ export default function Careers() {
     <BrandingProvider>
       <Head
         title="Careers - MUI"
-        description="MUI (formerly MUI) started back in 2014 to unify React and Material Design. Today, MUI has grown to become one of the world's most popular React libraries – used by a vibrant community of more than 2M developers in over 180 countries."
+        description="MUI (formerly Material-UI) started back in 2014 to unify React and Material Design. Today, MUI has grown to become one of the world's most popular React libraries – used by a vibrant community of more than 2M developers in over 180 countries."
       />
       <AppHeader />
       <main>


### PR DESCRIPTION
"Material-UI" -> "MUI" renames went too far.