### PR TITLE
[docs] Remove the 'WIP' icon from the 'Group & Pivot' page title

### DIFF
--- a/docs/src/pages.ts
+++ b/docs/src/pages.ts
@@ -172,7 +172,7 @@ const pages: readonly MuiPage[] = [
           { pathname: '/components/data-grid/localization' },
           { pathname: '/components/data-grid/virtualization' },
           { pathname: '/components/data-grid/accessibility' },
-          { pathname: '/components/data-grid/group-pivot', title: '🚧 Group & Pivot' },
+          { pathname: '/components/data-grid/group-pivot', title: 'Group & Pivot' },
         ],
       },
       {

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -253,7 +253,7 @@
     "/components/data-grid/localization": "Localization",
     "/components/data-grid/virtualization": "Virtualization",
     "/components/data-grid/accessibility": "Accessibility",
-    "/components/data-grid/group-pivot": "🚧 Group & Pivot",
+    "/components/data-grid/group-pivot": "Group & Pivot",
     "/components/lab": "Lab",
     "/components/about-the-lab": "About the lab 🧪",
     "/components/lab-pickers": "Date / Time",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


We released the 1st feature of this page last week so we have to remove this icon :+1: 