### PR TITLE
[ci] Update CI bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -645,6 +645,7 @@ jobs:
             npm pack
             mv mui-material-0.0.0-canary.${CIRCLE_SHA1}.tgz ../../../mui-material.tgz
       - when:
+          condition: true
           # don't run on PRs
           # condition:
           #   not:
@@ -674,6 +675,7 @@ jobs:
           path: size-snapshot.json
           destination: size-snapshot.json
       - when:
+          condition: true
           # don't run on PRs
           # condition:
           #   not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -652,17 +652,17 @@ jobs:
                 # "^pull/\d+" is not valid YAML
                 # "^pull/\\d+" matches neither 'pull/1' nor 'main'
                 # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
-                pattern: "^pull/.+$"
+                pattern: '^pull/.+$'
                 value: << pipeline.git.branch >>
           steps:
             # Upload distributables to S3
             - aws-s3/copy:
                 arguments: --acl public-read
-                aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS
+                aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS_TMP
                 aws-region: AWS_REGION_ARTIFACTS
-                aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS
+                aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS_TMP
                 from: mui-material.tgz
-                to: s3://mui-org-material-ui/artifacts/$CIRCLE_BRANCH/$CIRCLE_SHA1/
+                to: s3://mui-org-ci/artifacts/$CIRCLE_BRANCH/$CIRCLE_SHA1/
       - store_artifacts:
           path: mui-material.tgz
           destination: mui-material.tgz
@@ -681,25 +681,25 @@ jobs:
                 # "^pull/\d+" is not valid YAML
                 # "^pull/\\d+" matches neither 'pull/1' nor 'main'
                 # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
-                pattern: "^pull/.+$"
+                pattern: '^pull/.+$'
                 value: << pipeline.git.branch >>
           steps:
             # persist size snapshot on S3
             - aws-s3/copy:
                 arguments: --acl public-read --content-type application/json
-                aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS
+                aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS_TMP
                 aws-region: AWS_REGION_ARTIFACTS
-                aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS
+                aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS_TMP
                 from: size-snapshot.json
-                to: s3://mui-org-material-ui/artifacts/$CIRCLE_BRANCH/$CIRCLE_SHA1/
+                to: s3://mui-org-ci/artifacts/$CIRCLE_BRANCH/$CIRCLE_SHA1/
             # symlink size-snapshot to latest
             - aws-s3/copy:
                 arguments: --acl public-read --content-type application/json
-                aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS
+                aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS_TMP
                 aws-region: AWS_REGION_ARTIFACTS
-                aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS
+                aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS_TMP
                 from: size-snapshot.json
-                to: s3://mui-org-material-ui/artifacts/$CIRCLE_BRANCH/latest/
+                to: s3://mui-org-ci/artifacts/$CIRCLE_BRANCH/latest/
       - run:
           name: run danger on PRs
           command: yarn danger ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -646,14 +646,14 @@ jobs:
             mv mui-material-0.0.0-canary.${CIRCLE_SHA1}.tgz ../../../mui-material.tgz
       - when:
           # don't run on PRs
-          condition:
-            not:
-              matches:
-                # "^pull/\d+" is not valid YAML
-                # "^pull/\\d+" matches neither 'pull/1' nor 'main'
-                # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
-                pattern: '^pull/.+$'
-                value: << pipeline.git.branch >>
+          # condition:
+          #   not:
+          #     matches:
+          #       # "^pull/\d+" is not valid YAML
+          #       # "^pull/\\d+" matches neither 'pull/1' nor 'main'
+          #       # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
+          #       pattern: '^pull/.+$'
+          #       value: << pipeline.git.branch >>
           steps:
             # Upload distributables to S3
             - aws-s3/copy:
@@ -675,14 +675,14 @@ jobs:
           destination: size-snapshot.json
       - when:
           # don't run on PRs
-          condition:
-            not:
-              matches:
-                # "^pull/\d+" is not valid YAML
-                # "^pull/\\d+" matches neither 'pull/1' nor 'main'
-                # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
-                pattern: '^pull/.+$'
-                value: << pipeline.git.branch >>
+          # condition:
+          #   not:
+          #     matches:
+          #       # "^pull/\d+" is not valid YAML
+          #       # "^pull/\\d+" matches neither 'pull/1' nor 'main'
+          #       # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
+          #       pattern: '^pull/.+$'
+          #       value: << pipeline.git.branch >>
           steps:
             # persist size snapshot on S3
             - aws-s3/copy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -658,7 +658,6 @@ jobs:
           steps:
             # Upload distributables to S3
             - aws-s3/copy:
-                arguments: --acl public-read
                 aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS_TMP
                 aws-region: AWS_REGION_ARTIFACTS
                 aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS_TMP
@@ -688,7 +687,7 @@ jobs:
           steps:
             # persist size snapshot on S3
             - aws-s3/copy:
-                arguments: --acl public-read --content-type application/json
+                arguments: --content-type application/json
                 aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS_TMP
                 aws-region: AWS_REGION_ARTIFACTS
                 aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS_TMP
@@ -696,7 +695,7 @@ jobs:
                 to: s3://mui-org-ci/artifacts/$CIRCLE_BRANCH/$CIRCLE_SHA1/
             # symlink size-snapshot to latest
             - aws-s3/copy:
-                arguments: --acl public-read --content-type application/json
+                arguments: --content-type application/json
                 aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS_TMP
                 aws-region: AWS_REGION_ARTIFACTS
                 aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS_TMP

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -645,16 +645,15 @@ jobs:
             npm pack
             mv mui-material-0.0.0-canary.${CIRCLE_SHA1}.tgz ../../../mui-material.tgz
       - when:
-          condition: true
           # don't run on PRs
-          # condition:
-          #   not:
-          #     matches:
-          #       # "^pull/\d+" is not valid YAML
-          #       # "^pull/\\d+" matches neither 'pull/1' nor 'main'
-          #       # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
-          #       pattern: '^pull/.+$'
-          #       value: << pipeline.git.branch >>
+          condition:
+            not:
+              matches:
+                # "^pull/\d+" is not valid YAML
+                # "^pull/\\d+" matches neither 'pull/1' nor 'main'
+                # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
+                pattern: '^pull/.+$'
+                value: << pipeline.git.branch >>
           steps:
             # Upload distributables to S3
             - aws-s3/copy:
@@ -674,16 +673,15 @@ jobs:
           path: size-snapshot.json
           destination: size-snapshot.json
       - when:
-          condition: true
           # don't run on PRs
-          # condition:
-          #   not:
-          #     matches:
-          #       # "^pull/\d+" is not valid YAML
-          #       # "^pull/\\d+" matches neither 'pull/1' nor 'main'
-          #       # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
-          #       pattern: '^pull/.+$'
-          #       value: << pipeline.git.branch >>
+          condition:
+            not:
+              matches:
+                # "^pull/\d+" is not valid YAML
+                # "^pull/\\d+" matches neither 'pull/1' nor 'main'
+                # Note that we want to include 'pull/1', 'pull/1/head' and ''pull/1/merge'
+                pattern: '^pull/.+$'
+                value: << pipeline.git.branch >>
           steps:
             # persist size snapshot on S3
             - aws-s3/copy:

--- a/scripts/sizeSnapshot/loadComparison.js
+++ b/scripts/sizeSnapshot/loadComparison.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fetch = require('node-fetch');
 const lodash = require('lodash');
 
-const artifactServer = 'https://s3.eu-central-1.amazonaws.com/mui-org-material-ui';
+const artifactServer = 'https://s3.eu-central-1.amazonaws.com/mui-org-ci';
 
 async function loadCurrentSnapshot() {
   return fse.readJSON(path.join(__dirname, '../../size-snapshot.json'));


### PR DESCRIPTION
We're closing the account under which the bucket was created and ownership of buckets can't be transferred. So we're recreating it.

On the new bucket I'm also using bucket policies to control object access instead of putting object ACL.

will have to update the dashboard as well: https://github.com/mui-org/mui-contributor-dashboard/blob/9010a86de7aee24aabc2dbb0ef421c8f6a267395/src/pages/SizeComparison.tsx#L150

To Do after merging:
- [ ] Update `AWS_ACCESS_KEY_ID_ARTIFACTS` and `AWS_SECRET_ACCESS_KEY_ARTIFACTS` in circle env vars to the new credentials for the `circleci` user
- [ ] copy old bucket's files (`aws s3 cp s3://mui-org-material-ui/artifacts/master/ s3://mui-org-ci/artifacts/master/ --recursive`)
- [ ] Open a follow up PR to replace the `..._TMP` vars in the circleci config with the original ones and remove the `_TMP` vars from circleci and the bucket fallback
- [ ] close the old account (how much will it cost to delete the bucket?)