### PR TITLE
[docs] Fix import example inside Unstyled Backdrop section

### DIFF
--- a/docs/src/pages/components/backdrop/backdrop.md
+++ b/docs/src/pages/components/backdrop/backdrop.md
@@ -23,5 +23,5 @@ The backdrop also comes with the unstyled package.
 It's ideal for doing heavy customizations and minimizing bundle size.
 
 ```js
-import Backdrop from '@mui/base/Backdrop';
+import BackdropUnstyled from '@mui/base/BackdropUnstyled';
 ```


### PR DESCRIPTION
Searched for this import but I could not find it:
```js
import Backdrop from '@mui/base/Backdrop';
```
I found this import though, which seems to be correct:
```js
import BackdropUnstyled from '@mui/base/BackdropUnstyled';
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
