### PR TITLE
[docs] Add tip to help access the docs of a previous version when finding answers in StackOverflow

### DIFF
--- a/docs/src/pages/getting-started/support/support.md
+++ b/docs/src/pages/getting-started/support/support.md
@@ -13,7 +13,7 @@ StackOverflow is also visited from time to time by the maintainers of MUI.
 
 [Post a question](https://stackoverflow.com/questions/tagged/mui)
 
-> 💡 **Tip**: If you're using an old MUI version and go to StackOverflow for support on it, you may find answers with links that redirect you to content that doesn't exist anymore on the latest version. So, to easily access any previous version, just add `v[number]` at the beginning of the URL, like so: [v4.mui.com](https://v4.mui.com/).
+> 💡 **Tip**: If you're using an older version and use external resources (such as StackOverflow) for help with it, you may find answers with links that direct you to content that no longer exists in the latest version of the documentation. To easily access any previous version of the docs, simply add `v[number]` at the beginning of the URL, like so: [v4.mui.com](https://v4.mui.com/).
 
 ### GitHub
 

--- a/docs/src/pages/getting-started/support/support.md
+++ b/docs/src/pages/getting-started/support/support.md
@@ -13,6 +13,8 @@ StackOverflow is also visited from time to time by the maintainers of MUI.
 
 [Post a question](https://stackoverflow.com/questions/tagged/mui)
 
+> 💡 **Tip**: If you're using an old MUI version and go to StackOverflow for support on it, you may find answers with links that redirect you to content that doesn't exist anymore on the latest version. So, to easily access any previous version, just add `v[number]` at the beginning of the URL, like so: [v4.mui.com](https://v4.mui.com/).
+
 ### GitHub
 
 MUI uses GitHub issues as a bug and feature request tracker.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Tackles the problem reported at https://github.com/mui-org/material-ui/issues/29764.

This tip could be generally helpful, not only when in this StackOverflow use-case, so wondering if we should place it somewhere else. Open to suggestions :)

Deploy preview: https://deploy-preview-30101--material-ui.netlify.app/getting-started/support/#stackoverflow