### PR TITLE
[fix] size:snapshot for mui-material-next and mui-joy components

### DIFF
--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -62,7 +62,7 @@ async function getWebpackEntries() {
     const componentName = path.basename(path.dirname(componentPath));
 
     return {
-      name: componentName,
+      id: componentName,
       path: path.relative(workspaceRoot, path.dirname(componentPath)),
     };
   });
@@ -73,7 +73,7 @@ async function getWebpackEntries() {
       const componentName = path.basename(path.dirname(componentPath));
 
       return {
-        name: componentName,
+        id: componentName,
         path: path.relative(workspaceRoot, path.dirname(componentPath)),
       };
     },
@@ -153,12 +153,12 @@ async function getWebpackEntries() {
       path: path.join(path.relative(workspaceRoot, materialPackagePath), 'legacy/index.js'),
     },
     {
-      name: '@mui/material-next',
+      id: '@mui/material-next',
       path: path.join(path.relative(workspaceRoot, materialNextPackagePath), 'index.js'),
     },
     ...materialNextComponents,
     {
-      name: '@mui/joy',
+      id: '@mui/joy',
       path: path.join(path.relative(workspaceRoot, joyPackagePath), 'index.js'),
     },
     ...joyComponents,

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -62,7 +62,7 @@ async function getWebpackEntries() {
     const componentName = path.basename(path.dirname(componentPath));
 
     return {
-      id: componentName,
+      id: `@mui/material-next/${componentName}`,
       path: path.relative(workspaceRoot, path.dirname(componentPath)),
     };
   });
@@ -73,7 +73,7 @@ async function getWebpackEntries() {
       const componentName = path.basename(path.dirname(componentPath));
 
       return {
-        id: componentName,
+        id: `@mui/joy/${componentName}`,
         path: path.relative(workspaceRoot, path.dirname(componentPath)),
       };
     },


### PR DESCRIPTION
While working on https://github.com/mui-org/material-ui/pull/30080, I noticed this in the build for `yarn size:snapshot`
```
...
Compiling 210-220: "SwitchUnstyled", "TabPanelUnstyled", "TabUnstyled", "TablePaginationUnstyled", "TabsListUnstyled", "TabsUnstyled", "TextareaAutosize", "Unstable_TrapFocus", "@material-ui/utils", "@material-ui/core.legacy"
Compiling 220-230: "undefined", "undefined", "undefined", "undefined", "undefined", "undefined", "undefined", "undefined", "undefined", "undefined"
Done in 231.85s.
CircleCI received exit code 0
```

### To do
- [x]  It doesn't look like this creates unique entries. ~Will have to look into that~ I namespaced them using their package name

![Screenshot 2021-12-08 at 10 26 42](https://user-images.githubusercontent.com/2109932/145183371-5fbd3440-ada0-402d-9a57-e734bd03c185.png)
