### PR TITLE
[LoadingButton] Fix `variant` default prop not inheriting from `MuiButton` theme slot

### DIFF
--- a/docs/pages/api-docs/loading-button.json
+++ b/docs/pages/api-docs/loading-button.json
@@ -20,13 +20,6 @@
         "name": "union",
         "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
-    },
-    "variant": {
-      "type": {
-        "name": "enum",
-        "description": "'contained'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'text'"
-      },
-      "default": "'text'"
     }
   },
   "name": "LoadingButton",

--- a/docs/translations/api-docs/loading-button/loading-button.json
+++ b/docs/translations/api-docs/loading-button/loading-button.json
@@ -7,8 +7,7 @@
     "loading": "If <code>true</code>, the loading indicator is shown.",
     "loadingIndicator": "Element placed before the children if the button is in loading state.",
     "loadingPosition": "The loading indicator can be positioned on the start, end, or the center of the button.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
-    "variant": "The variant to use."
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -106,7 +106,7 @@ const LoadingButtonLoadingIndicator = styled('div', {
       left: 14,
     }),
   ...(ownerState.loadingPosition === 'start' &&
-    ownerState.variant === 'text' && {
+    (!ownerState.variant || ownerState.variant === 'text') && {
       left: 6,
     }),
   ...(ownerState.loadingPosition === 'center' && {
@@ -119,7 +119,7 @@ const LoadingButtonLoadingIndicator = styled('div', {
       right: 14,
     }),
   ...(ownerState.loadingPosition === 'end' &&
-    ownerState.variant === 'text' && {
+    (!ownerState.variant || ownerState.variant === 'text') && {
       right: 6,
     }),
   ...(ownerState.loadingPosition === 'start' &&
@@ -144,7 +144,6 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
     loading = false,
     loadingIndicator = LoadingIndicator,
     loadingPosition = 'center',
-    variant = 'text',
     ...other
   } = props;
 
@@ -154,7 +153,6 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
     loading,
     loadingIndicator,
     loadingPosition,
-    variant,
   };
 
   const classes = useUtilityClasses(ownerState);
@@ -164,7 +162,6 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
       disabled={disabled || loading}
       ref={ref}
       {...other}
-      variant={variant}
       classes={classes}
       ownerState={ownerState}
     >

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -248,11 +248,6 @@ LoadingButton.propTypes /* remove-proptypes */ = {
     PropTypes.func,
     PropTypes.object,
   ]),
-  /**
-   * The variant to use.
-   * @default 'text'
-   */
-  variant: PropTypes.oneOf(['contained', 'outlined', 'text']),
 };
 
 export default LoadingButton;

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.test.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.test.js
@@ -66,7 +66,7 @@ describe('<LoadingButton />', () => {
     });
   });
 
-  it('should be able to derive defaultProps from MuiButton', () => {
+  it('should be able to derive variant defaultProp from MuiButton', () => {
     const theme = createTheme({
       components: {
         MuiButton: {

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.test.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { createRenderer, describeConformance, screen } from 'test/utils';
 import { expect } from 'chai';
-import Button from '@mui/material/Button';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import Button, { buttonClasses } from '@mui/material/Button';
 import LoadingButton, { loadingButtonClasses as classes } from '@mui/lab/LoadingButton';
 
 describe('<LoadingButton />', () => {
@@ -63,5 +64,25 @@ describe('<LoadingButton />', () => {
 
       expect(screen.getByRole('button')).to.have.text('loading...Test');
     });
+  });
+
+  it('should be able to derive defaultProps from MuiButton', () => {
+    const theme = createTheme({
+      components: {
+        MuiButton: {
+          defaultProps: {
+            variant: 'contained',
+          },
+        },
+      },
+    });
+
+    render(
+      <ThemeProvider theme={theme}>
+        <LoadingButton />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByRole('button')).to.have.class(buttonClasses.contained);
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #29740 