### PR TITLE
[fix] Update snapshots and s3 fallback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -657,9 +657,9 @@ jobs:
           steps:
             # Upload distributables to S3
             - aws-s3/copy:
-                aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS_TMP
+                aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS
                 aws-region: AWS_REGION_ARTIFACTS
-                aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS_TMP
+                aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS
                 from: mui-material.tgz
                 to: s3://mui-org-ci/artifacts/$CIRCLE_BRANCH/$CIRCLE_SHA1/
       - store_artifacts:
@@ -686,17 +686,17 @@ jobs:
             # persist size snapshot on S3
             - aws-s3/copy:
                 arguments: --content-type application/json
-                aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS_TMP
+                aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS
                 aws-region: AWS_REGION_ARTIFACTS
-                aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS_TMP
+                aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS
                 from: size-snapshot.json
                 to: s3://mui-org-ci/artifacts/$CIRCLE_BRANCH/$CIRCLE_SHA1/
             # symlink size-snapshot to latest
             - aws-s3/copy:
                 arguments: --content-type application/json
-                aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS_TMP
+                aws-access-key-id: AWS_ACCESS_KEY_ID_ARTIFACTS
                 aws-region: AWS_REGION_ARTIFACTS
-                aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS_TMP
+                aws-secret-access-key: AWS_SECRET_ACCESS_KEY_ARTIFACTS
                 from: size-snapshot.json
                 to: s3://mui-org-ci/artifacts/$CIRCLE_BRANCH/latest/
       - run:

--- a/scripts/sizeSnapshot/loadComparison.js
+++ b/scripts/sizeSnapshot/loadComparison.js
@@ -6,30 +6,10 @@ const path = require('path');
 const fetch = require('node-fetch');
 const lodash = require('lodash');
 
-const artifactServerLegacy = 'https://s3.eu-central-1.amazonaws.com/mui-org-material-ui';
-const artifactServer = 'https://s3.eu-central-1.amazonaws.com/mui-org-ci';
+const ARTIFACT_SERVER = 'https://s3.eu-central-1.amazonaws.com/mui-org-ci';
 
 async function loadCurrentSnapshot() {
   return fse.readJSON(path.join(__dirname, '../../size-snapshot.json'));
-}
-
-/**
- * @param {string} bucket - the bucket url to load from
- * @param {string} commitId - the sha of a commit
- * @param {string} ref - the branch containing that commit
- */
-async function loadSnapshotFromBucket(bucket, commitId, ref) {
-  if (ref === undefined) {
-    throw new TypeError(
-      `Need a ref for that commit. Did you mean \`loadSnapshot(commitId, 'master')\`?`,
-    );
-  }
-  const url = `${bucket}/artifacts/${ref}/${commitId}/size-snapshot.json`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch "${url}", HTTP ${response.status}`);
-  }
-  return response.json();
 }
 
 /**
@@ -37,11 +17,17 @@ async function loadSnapshotFromBucket(bucket, commitId, ref) {
  * @param {string} ref - the branch containing that commit
  */
 async function loadSnapshot(commitId, ref) {
-  try {
-    return await loadSnapshotFromBucket(artifactServer, commitId, ref);
-  } catch (err) {
-    return loadSnapshotFromBucket(artifactServerLegacy, commitId, ref);
+  if (ref === undefined) {
+    throw new TypeError(
+      `Need a ref for that commit. Did you mean \`loadSnapshot(commitId, 'master')\`?`,
+    );
   }
+  const url = `${ARTIFACT_SERVER}/artifacts/${ref}/${commitId}/size-snapshot.json`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch "${url}", HTTP ${response.status}`);
+  }
+  return response.json();
 }
 
 const nullSnapshot = { parsed: 0, gzip: 0 };


### PR DESCRIPTION
Follow up on https://github.com/mui-org/material-ui/pull/30080

The main credentials are updated on cci, the bucket is copied, we can revert to the previous situation but with new bucket configured