### PR TITLE
Ensure that onClick propagates when non-native button is clicked

### DIFF
--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -242,7 +242,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
     ) {
       event.preventDefault();
       if (onClick) {
-        onClick(event);
+        buttonRef.current.click();
       }
     }
   });
@@ -274,7 +274,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
       event.key === ' ' &&
       !event.defaultPrevented
     ) {
-      onClick(event);
+      buttonRef.current.click();
     }
   });
 

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -1054,7 +1054,6 @@ describe('<ButtonBase />', () => {
         });
 
         expect(onClickSpy.calledOnce).to.equal(true);
-        expect(onClickSpy.firstCall.args[0]).to.have.property('defaultPrevented', true);
       });
 
       it('does not call onClick if Enter was pressed on a child', () => {
@@ -1091,7 +1090,7 @@ describe('<ButtonBase />', () => {
         expect(onClickSpy.callCount).to.equal(0);
       });
 
-      it('prevents default with an anchor and empty href', () => {
+      it('calls onClick on enter for an anchor and empty href', () => {
         const onClickSpy = spy();
         const { getByRole } = render(
           <ButtonBase component="a" onClick={onClickSpy}>
@@ -1106,9 +1105,7 @@ describe('<ButtonBase />', () => {
         });
 
         expect(onClickSpy.calledOnce).to.equal(true);
-        expect(onClickSpy.firstCall.args[0]).to.have.property('defaultPrevented', true);
       });
-
       it('should ignore anchors with href', () => {
         const onClick = spy();
         const onKeyDown = spy();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This should solve #30144.  I don't believe there are any unintended negative consequences from programmatically clicking the button, but someone please double check me on that. Although, one concern could be this being a breaking change for someone who is checking to see if the button onClick function was triggered by a keyboard event? I'm open to suggestions for different fixes to this bug if we need to make sure we are still passing the keyboard event to the onClick handler.