### PR TITLE
[Badge] Add tests for `anchorOrigin` prop

### DIFF
--- a/packages/mui-material/src/Badge/Badge.test.js
+++ b/packages/mui-material/src/Badge/Badge.test.js
@@ -168,42 +168,74 @@ describe('<Badge />', () => {
 
   describe('prop: anchorOrigin', () => {
     it('should apply style for top left rectangular', () => {
-      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'left', vertical: 'top'}} />);
+      const { container } = render(
+        <Badge {...defaultProps} anchorOrigin={{ horizontal: 'left', vertical: 'top' }} />,
+      );
       expect(findBadge(container)).to.have.class(classes.anchorOriginTopLeftRectangular);
-    }); 
+    });
 
     it('should apply style for top right rectangular', () => {
-      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'right', vertical: 'top'}} />);
+      const { container } = render(
+        <Badge {...defaultProps} anchorOrigin={{ horizontal: 'right', vertical: 'top' }} />,
+      );
       expect(findBadge(container)).to.have.class(classes.anchorOriginTopRightRectangular);
     });
-    
+
     it('should apply style for bottom left rectangular', () => {
-      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'left', vertical: 'bottom'}} />);
+      const { container } = render(
+        <Badge {...defaultProps} anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }} />,
+      );
       expect(findBadge(container)).to.have.class(classes.anchorOriginBottomLeftRectangular);
     });
 
     it('should apply style for bottom right rectangular', () => {
-      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'right', vertical: 'bottom'}} />);
+      const { container } = render(
+        <Badge {...defaultProps} anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }} />,
+      );
       expect(findBadge(container)).to.have.class(classes.anchorOriginBottomRightRectangular);
     });
 
     it('should apply style for top left circular', () => {
-      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'left', vertical: 'top'}} overlap='circular' />);
+      const { container } = render(
+        <Badge
+          {...defaultProps}
+          anchorOrigin={{ horizontal: 'left', vertical: 'top' }}
+          overlap="circular"
+        />,
+      );
       expect(findBadge(container)).to.have.class(classes.anchorOriginTopLeftCircular);
     });
-    
+
     it('should apply style for top right circular', () => {
-      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'right', vertical: 'top'}} overlap='circular' />);
+      const { container } = render(
+        <Badge
+          {...defaultProps}
+          anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
+          overlap="circular"
+        />,
+      );
       expect(findBadge(container)).to.have.class(classes.anchorOriginTopRightCircular);
     });
 
     it('should apply style for bottom left circular', () => {
-      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'left', vertical: 'bottom'}} overlap='circular' />);
+      const { container } = render(
+        <Badge
+          {...defaultProps}
+          anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+          overlap="circular"
+        />,
+      );
       expect(findBadge(container)).to.have.class(classes.anchorOriginBottomLeftCircular);
     });
 
     it('should apply style for bottom right circular', () => {
-      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'right', vertical: 'bottom'}} overlap='circular' />);
+      const { container } = render(
+        <Badge
+          {...defaultProps}
+          anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+          overlap="circular"
+        />,
+      );
       expect(findBadge(container)).to.have.class(classes.anchorOriginBottomRightCircular);
     });
   });

--- a/packages/mui-material/src/Badge/Badge.test.js
+++ b/packages/mui-material/src/Badge/Badge.test.js
@@ -166,6 +166,96 @@ describe('<Badge />', () => {
     });
   });
 
+  describe('prop: anchorOrigin', () => {
+    it('should apply style for top left rectangular', () => {
+      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'left', vertical: 'top'}} />);
+      expect(findBadge(container)).toHaveComputedStyle({
+        top: '0px',
+        left: '0px',
+        transform: 'scale(1) translate(-50%, -50%)',
+        transformOrigin: '0% 0%',
+      });
+      expect(findBadge(container)).to.have.class(classes.anchorOriginTopLeftRectangular);
+    }); 
+
+    it('should apply style for top right rectangular', () => {
+      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'right', vertical: 'top'}} />);
+      expect(findBadge(container)).toHaveComputedStyle({
+        top: '0px',
+        right: '0px',
+        transform: 'scale(1) translate(50%, -50%)',
+        transformOrigin: '100% 0%',
+      });
+      expect(findBadge(container)).to.have.class(classes.anchorOriginTopRightRectangular);
+    });
+    
+    it('should apply style for bottom left rectangular', () => {
+      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'left', vertical: 'bottom'}} />);
+      expect(findBadge(container)).toHaveComputedStyle({
+        bottom: '0px',
+        left: '0px',
+        transform: 'scale(1) translate(-50%, 50%)',
+        transformOrigin: '0% 100%',
+      });
+      expect(findBadge(container)).to.have.class(classes.anchorOriginBottomLeftRectangular);
+    });
+
+    it('should apply style for bottom right rectangular', () => {
+      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'right', vertical: 'bottom'}} />);
+      expect(findBadge(container)).toHaveComputedStyle({
+        bottom: '0px',
+        right: '0px',
+        transform: 'scale(1) translate(50%, 50%)',
+        transformOrigin: '100% 100%',
+      });
+      expect(findBadge(container)).to.have.class(classes.anchorOriginBottomRightRectangular);
+    });
+
+    it('should apply style for top left circular', () => {
+      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'left', vertical: 'top'}} overlap='circular' />);
+      expect(findBadge(container)).toHaveComputedStyle({
+        top: '14%',
+        left: '14%',
+        transform: 'scale(1) translate(-50%, -50%)',
+        transformOrigin: '0% 0%',
+      });
+      expect(findBadge(container)).to.have.class(classes.anchorOriginTopLeftCircular);
+    });
+    
+    it('should apply style for top right circular', () => {
+      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'right', vertical: 'top'}} overlap='circular' />);
+      expect(findBadge(container)).toHaveComputedStyle({
+        top: '14%',
+        right: '14%',
+        transform: 'scale(1) translate(50%, -50%)',
+        transformOrigin: '100% 0%',
+      });
+      expect(findBadge(container)).to.have.class(classes.anchorOriginTopRightCircular);
+    });
+
+    it('should apply style for bottom left circular', () => {
+      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'left', vertical: 'bottom'}} overlap='circular' />);
+      expect(findBadge(container)).toHaveComputedStyle({
+        bottom: '14%',
+        left: '14%',
+        transform: 'scale(1) translate(-50%, 50%)',
+        transformOrigin: '0% 100%',
+      });
+      expect(findBadge(container)).to.have.class(classes.anchorOriginBottomLeftCircular);
+    });
+
+    it('should apply style for bottom right circular', () => {
+      const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'right', vertical: 'bottom'}} overlap='circular' />);
+      expect(findBadge(container)).toHaveComputedStyle({
+        bottom: '14%',
+        right: '14%',
+        transform: 'scale(1) translate(50%, 50%)',
+        transformOrigin: '100% 100%',
+      });
+      expect(findBadge(container)).to.have.class(classes.anchorOriginBottomRightCircular);
+    });
+  });
+
   it('retains anchorOrigin, content, color, max, overlap and variant when invisible is true for consistent disappearing transition', () => {
     const { container, setProps } = render(
       <Badge {...defaultProps} color="secondary" variant="dot" />,

--- a/packages/mui-material/src/Badge/Badge.test.js
+++ b/packages/mui-material/src/Badge/Badge.test.js
@@ -169,89 +169,41 @@ describe('<Badge />', () => {
   describe('prop: anchorOrigin', () => {
     it('should apply style for top left rectangular', () => {
       const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'left', vertical: 'top'}} />);
-      expect(findBadge(container)).toHaveComputedStyle({
-        top: '0px',
-        left: '0px',
-        transform: 'scale(1) translate(-50%, -50%)',
-        transformOrigin: '0% 0%',
-      });
       expect(findBadge(container)).to.have.class(classes.anchorOriginTopLeftRectangular);
     }); 
 
     it('should apply style for top right rectangular', () => {
       const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'right', vertical: 'top'}} />);
-      expect(findBadge(container)).toHaveComputedStyle({
-        top: '0px',
-        right: '0px',
-        transform: 'scale(1) translate(50%, -50%)',
-        transformOrigin: '100% 0%',
-      });
       expect(findBadge(container)).to.have.class(classes.anchorOriginTopRightRectangular);
     });
     
     it('should apply style for bottom left rectangular', () => {
       const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'left', vertical: 'bottom'}} />);
-      expect(findBadge(container)).toHaveComputedStyle({
-        bottom: '0px',
-        left: '0px',
-        transform: 'scale(1) translate(-50%, 50%)',
-        transformOrigin: '0% 100%',
-      });
       expect(findBadge(container)).to.have.class(classes.anchorOriginBottomLeftRectangular);
     });
 
     it('should apply style for bottom right rectangular', () => {
       const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'right', vertical: 'bottom'}} />);
-      expect(findBadge(container)).toHaveComputedStyle({
-        bottom: '0px',
-        right: '0px',
-        transform: 'scale(1) translate(50%, 50%)',
-        transformOrigin: '100% 100%',
-      });
       expect(findBadge(container)).to.have.class(classes.anchorOriginBottomRightRectangular);
     });
 
     it('should apply style for top left circular', () => {
       const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'left', vertical: 'top'}} overlap='circular' />);
-      expect(findBadge(container)).toHaveComputedStyle({
-        top: '14%',
-        left: '14%',
-        transform: 'scale(1) translate(-50%, -50%)',
-        transformOrigin: '0% 0%',
-      });
       expect(findBadge(container)).to.have.class(classes.anchorOriginTopLeftCircular);
     });
     
     it('should apply style for top right circular', () => {
       const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'right', vertical: 'top'}} overlap='circular' />);
-      expect(findBadge(container)).toHaveComputedStyle({
-        top: '14%',
-        right: '14%',
-        transform: 'scale(1) translate(50%, -50%)',
-        transformOrigin: '100% 0%',
-      });
       expect(findBadge(container)).to.have.class(classes.anchorOriginTopRightCircular);
     });
 
     it('should apply style for bottom left circular', () => {
       const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'left', vertical: 'bottom'}} overlap='circular' />);
-      expect(findBadge(container)).toHaveComputedStyle({
-        bottom: '14%',
-        left: '14%',
-        transform: 'scale(1) translate(-50%, 50%)',
-        transformOrigin: '0% 100%',
-      });
       expect(findBadge(container)).to.have.class(classes.anchorOriginBottomLeftCircular);
     });
 
     it('should apply style for bottom right circular', () => {
       const { container } = render(<Badge {...defaultProps} anchorOrigin={{horizontal: 'right', vertical: 'bottom'}} overlap='circular' />);
-      expect(findBadge(container)).toHaveComputedStyle({
-        bottom: '14%',
-        right: '14%',
-        transform: 'scale(1) translate(50%, 50%)',
-        transformOrigin: '100% 100%',
-      });
       expect(findBadge(container)).to.have.class(classes.anchorOriginBottomRightCircular);
     });
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Add tests to `Badge` to verify correct styles are applied for different values of the `anchorOrigin` prop and their interactions with `overlap`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
