### PR TITLE
[fix] Fail the build when the dangerjs script errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,7 +701,7 @@ jobs:
                 to: s3://mui-org-ci/artifacts/$CIRCLE_BRANCH/latest/
       - run:
           name: run danger on PRs
-          command: yarn danger ci
+          command: yarn danger ci --fail-on-errors=true
           environment:
             DANGER_COMMAND: 'reportBundleSize'
   test_benchmark:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,7 +701,7 @@ jobs:
                 to: s3://mui-org-ci/artifacts/$CIRCLE_BRANCH/latest/
       - run:
           name: run danger on PRs
-          command: yarn danger ci --fail-on-errors=true
+          command: yarn danger ci --fail-on-errors
           environment:
             DANGER_COMMAND: 'reportBundleSize'
   test_benchmark:

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -151,6 +151,8 @@ async function reportBundleSize() {
   } else {
     markdown(`[No bundle size changes](${detailedComparisonUrl})`);
   }
+
+  throw new Error('KABOOM!');
 }
 
 async function run() {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -151,8 +151,6 @@ async function reportBundleSize() {
   } else {
     markdown(`[No bundle size changes](${detailedComparisonUrl})`);
   }
-
-  throw new Error('KABOOM!');
 }
 
 async function run() {


### PR DESCRIPTION
Make sure to return a non-zero exit code when the danger command errors to avoid failures going unnoticed. Like in workflow: https://app.circleci.com/pipelines/github/mui-org/material-ui/59709/workflows/977019ed-7315-4f51-9da7-f0627e17b23f/jobs/327719