### PR TITLE
[docs] Explain the use of Select's label in FormControl

### DIFF
--- a/docs/src/pages/components/selects/selects.md
+++ b/docs/src/pages/components/selects/selects.md
@@ -37,6 +37,8 @@ It shares the same styles and many of the same props. Refer to the respective co
 
 {{"demo": "pages/components/selects/SelectLabels.js"}}
 
+> ⚠ Note that when using FormControl with the outlined variant of the Select, you need to provide a label in two places: in the InputLabel component and in the `label` prop of the Select component (see the above demo).
+
 ### Auto width
 
 {{"demo": "pages/components/selects/SelectAutoWidth.js"}}


### PR DESCRIPTION
Added a note to include the label twice when using an outlined Select.
Closes #27533
