### PR TITLE
Reduce bundle size comparison memory consumption

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "mocha": "^9.1.3",
     "node-fetch": "^2.6.6",
     "nyc": "^15.1.0",
+    "piscina": "^3.2.0",
     "playwright": "^1.17.1",
     "prettier": "^2.5.1",
     "process": "^0.11.10",

--- a/scripts/sizeSnapshot/create.js
+++ b/scripts/sizeSnapshot/create.js
@@ -1,16 +1,9 @@
 const fse = require('fs-extra');
 const lodash = require('lodash');
 const path = require('path');
-const { promisify } = require('util');
-const webpackCallbackBased = require('webpack');
 const yargs = require('yargs');
-const createWebpackConfig = require('./webpack.config');
-
-const webpack = promisify(webpackCallbackBased);
-// Creating the size snapshot requires collecting webpack stats for each entrypoint,
-// This requires a lot of memory.
-// Concurrency is therefore bound by the amount of available memory.
-const webpackCompilationConcurrency = 10;
+const Piscina = require('piscina');
+const { getWebpackEntries } = require('./webpack.config');
 
 const workspaceRoot = path.join(__dirname, '../../');
 const snapshotDestPath = path.join(workspaceRoot, 'size-snapshot.json');
@@ -40,69 +33,21 @@ async function getRollupSize(snapshotPath) {
  * creates size snapshot for every bundle that built with webpack
  */
 async function getWebpackSizes(webpackEnvironment) {
+  const worker = new Piscina({
+    filename: require.resolve('./worker'),
+    maxThreads: 10,
+  });
   await fse.mkdirp(path.join(__dirname, 'build'));
 
-  const configurations = await createWebpackConfig(webpack, webpackEnvironment);
-  const sizes = [];
-  for (let index = 0; index < configurations.length; index += webpackCompilationConcurrency) {
-    const configurationsChunk = configurations.slice(index, index + webpackCompilationConcurrency);
-    // eslint-disable-next-line no-console -- process monitoring
-    console.log(
-      `Compiling ${index}-${index + configurationsChunk.length}: ${configurationsChunk
-        .map((configuration) => {
-          return `"${Object.keys(configuration.entry)}"`;
-        })
-        .join(', ')}`,
-    );
-    // eslint-disable-next-line no-await-in-loop -- Can't run all entrypoints concurrently with limited memory.
-    const webpackMultiStats = await webpack(configurationsChunk);
-
-    webpackMultiStats.stats.forEach((webpackStats) => {
-      if (webpackStats.hasErrors()) {
-        const { entrypoints, errors } = webpackStats.toJson({
-          all: false,
-          entrypoints: true,
-          errors: true,
-        });
-        throw new Error(
-          `The following errors occured during bundling of ${Object.keys(
-            entrypoints,
-          )} with webpack: \n${errors
-            .map((error) => {
-              return `${JSON.stringify(error, null, 2)}`;
-            })
-            .join('\n')}`,
-        );
-      }
-
-      const stats = webpackStats.toJson({
-        all: false,
-        assets: true,
-        entrypoints: true,
-        relatedAssets: true,
-      });
-      const assets = new Map(stats.assets.map((asset) => [asset.name, asset]));
-
-      Object.values(stats.entrypoints).forEach((entrypoint) => {
-        let parsedSize = 0;
-        let gzipSize = 0;
-
-        entrypoint.assets.forEach(({ name, size }) => {
-          const asset = assets.get(name);
-          const gzippedAsset = asset.related.find((relatedAsset) => {
-            return relatedAsset.type === 'gzipped';
-          });
-
-          parsedSize += size;
-          gzipSize += gzippedAsset.size;
-        });
-
-        sizes.push([entrypoint.name, { parsed: parsedSize, gzip: gzipSize }]);
-      });
-    });
+  const entries = await getWebpackEntries();
+  const sizePromises = [];
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    sizePromises.push(worker.run({ entry, webpackEnvironment, index }));
   }
 
-  return sizes;
+  const sizeArrays = await Promise.all(sizePromises);
+  return sizeArrays.flat();
 }
 
 async function run(argv) {

--- a/scripts/sizeSnapshot/create.js
+++ b/scripts/sizeSnapshot/create.js
@@ -29,14 +29,15 @@ async function getRollupSize(snapshotPath) {
     normalizeRollupSnapshot(snapshot),
   ]);
 }
-
+// eslint-disable-next-line no-console
+console.log('cpus:', os.cpus().length);
 /**
  * creates size snapshot for every bundle that built with webpack
  */
 async function getWebpackSizes(webpackEnvironment) {
   const worker = new Piscina({
     filename: require.resolve('./worker'),
-    maxThreads: os.cpus().length,
+    maxThreads: 10,
   });
   await fse.mkdirp(path.join(__dirname, 'build'));
 

--- a/scripts/sizeSnapshot/create.js
+++ b/scripts/sizeSnapshot/create.js
@@ -3,6 +3,7 @@ const lodash = require('lodash');
 const path = require('path');
 const yargs = require('yargs');
 const Piscina = require('piscina');
+const os = require('os');
 const { getWebpackEntries } = require('./webpack.config');
 
 const workspaceRoot = path.join(__dirname, '../../');
@@ -35,7 +36,7 @@ async function getRollupSize(snapshotPath) {
 async function getWebpackSizes(webpackEnvironment) {
   const worker = new Piscina({
     filename: require.resolve('./worker'),
-    maxThreads: 10,
+    maxThreads: os.cpus().length,
   });
   await fse.mkdirp(path.join(__dirname, 'build'));
 

--- a/scripts/sizeSnapshot/create.js
+++ b/scripts/sizeSnapshot/create.js
@@ -6,7 +6,7 @@ const Piscina = require('piscina');
 const os = require('os');
 const { getWebpackEntries } = require('./webpack.config');
 
-const MAX_CONCURRENCY = Math.min(4, os.cpus().length);
+const MAX_CONCURRENCY = Math.min(8, os.cpus().length);
 
 const workspaceRoot = path.join(__dirname, '../../');
 const snapshotDestPath = path.join(workspaceRoot, 'size-snapshot.json');

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -165,73 +165,71 @@ async function getWebpackEntries() {
   ];
 }
 
-module.exports = async function webpackConfig(webpack, environment) {
+function createWebpackConfig(entry, environment) {
   const analyzerMode = environment.analyze ? 'static' : 'disabled';
   const concatenateModules = !environment.accurateBundles;
 
-  const entries = await getWebpackEntries();
-  const configurations = entries.map((entry) => {
-    /**
-     * @type {import('webpack').Configuration}
-     */
-    const configuration = {
-      // ideally this would be computed from the bundles peer dependencies
-      // Ensure that `react` as well as `react/*` are considered externals but not `react*`
-      externals: /^(date-fns|dayjs|luxon|moment|react|react-dom)(\/.*)?$/,
-      mode: 'production',
-      optimization: {
-        concatenateModules,
-        minimizer: [
-          new TerserPlugin({
-            test: /\.js(\?.*)?$/i,
-          }),
-        ],
-      },
-      output: {
-        filename: '[name].js',
-        library: {
-          // TODO: Use `type: 'module'` once it is supported (currently incompatible with `externals`)
-          name: 'M',
-          type: 'var',
-          // type: 'module',
-        },
-        path: path.join(__dirname, 'build'),
-      },
-      plugins: [
-        new CompressionPlugin(),
-        new BundleAnalyzerPlugin({
-          analyzerMode,
-          // We create a report for each bundle so around 120 reports.
-          // Opening them all is spam.
-          // If opened with `webpack --config . --analyze` it'll still open one new tab though.
-          openAnalyzer: false,
-          // '[name].html' not supported: https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/12
-          reportFilename: `${entry.id}.html`,
+  /**
+   * @type {import('webpack').Configuration}
+   */
+  const configuration = {
+    // ideally this would be computed from the bundles peer dependencies
+    // Ensure that `react` as well as `react/*` are considered externals but not `react*`
+    externals: /^(date-fns|dayjs|luxon|moment|react|react-dom)(\/.*)?$/,
+    mode: 'production',
+    optimization: {
+      concatenateModules,
+      minimizer: [
+        new TerserPlugin({
+          test: /\.js(\?.*)?$/i,
         }),
       ],
-      resolve: {
-        alias: {
-          '@mui/material': path.join(workspaceRoot, 'packages/mui-material/build'),
-          '@mui/lab': path.join(workspaceRoot, 'packages/mui-lab/build'),
-          '@mui/styled-engine': path.join(workspaceRoot, 'packages/mui-styled-engine/build'),
-          '@mui/styled-engine-sc': path.join(workspaceRoot, 'packages/mui-styles-sc/build'),
-          '@mui/styles': path.join(workspaceRoot, 'packages/mui-styles/build'),
-          '@mui/system': path.join(workspaceRoot, 'packages/mui-system/build'),
-          '@mui/private-theming': path.join(workspaceRoot, 'packages/mui-private-theming/build'),
-          '@mui/utils': path.join(workspaceRoot, 'packages/mui-utils/build'),
-          '@mui/base': path.join(workspaceRoot, 'packages/mui-base/build'),
-          '@mui/material-next': path.join(workspaceRoot, 'packages/mui-material-next/build'),
-          '@mui/joy': path.join(workspaceRoot, 'packages/mui-joy/build'),
-        },
+    },
+    output: {
+      filename: '[name].js',
+      library: {
+        // TODO: Use `type: 'module'` once it is supported (currently incompatible with `externals`)
+        name: 'M',
+        type: 'var',
+        // type: 'module',
       },
-      entry: { [entry.id]: path.join(workspaceRoot, entry.path) },
-      // TODO: 'browserslist:modern'
-      // See https://github.com/webpack/webpack/issues/14203
-      target: 'web',
-    };
+      path: path.join(__dirname, 'build'),
+    },
+    plugins: [
+      new CompressionPlugin(),
+      new BundleAnalyzerPlugin({
+        analyzerMode,
+        // We create a report for each bundle so around 120 reports.
+        // Opening them all is spam.
+        // If opened with `webpack --config . --analyze` it'll still open one new tab though.
+        openAnalyzer: false,
+        // '[name].html' not supported: https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/12
+        reportFilename: `${entry.id}.html`,
+      }),
+    ],
+    resolve: {
+      alias: {
+        '@mui/material': path.join(workspaceRoot, 'packages/mui-material/build'),
+        '@mui/lab': path.join(workspaceRoot, 'packages/mui-lab/build'),
+        '@mui/styled-engine': path.join(workspaceRoot, 'packages/mui-styled-engine/build'),
+        '@mui/styled-engine-sc': path.join(workspaceRoot, 'packages/mui-styles-sc/build'),
+        '@mui/styles': path.join(workspaceRoot, 'packages/mui-styles/build'),
+        '@mui/system': path.join(workspaceRoot, 'packages/mui-system/build'),
+        '@mui/private-theming': path.join(workspaceRoot, 'packages/mui-private-theming/build'),
+        '@mui/utils': path.join(workspaceRoot, 'packages/mui-utils/build'),
+        '@mui/base': path.join(workspaceRoot, 'packages/mui-base/build'),
+        '@mui/material-next': path.join(workspaceRoot, 'packages/mui-material-next/build'),
+        '@mui/joy': path.join(workspaceRoot, 'packages/mui-joy/build'),
+      },
+    },
+    entry: { [entry.id]: path.join(workspaceRoot, entry.path) },
+    // TODO: 'browserslist:modern'
+    // See https://github.com/webpack/webpack/issues/14203
+    target: 'web',
+  };
 
-    return configuration;
-  });
+  return configuration;
+}
 
-  return configurations;
-};
+exports.getWebpackEntries = getWebpackEntries;
+exports.createWebpackConfig = createWebpackConfig;

--- a/scripts/sizeSnapshot/worker.js
+++ b/scripts/sizeSnapshot/worker.js
@@ -1,0 +1,62 @@
+const { promisify } = require('util');
+const webpackCallbackBased = require('webpack');
+const { createWebpackConfig } = require('./webpack.config');
+
+const webpack = promisify(webpackCallbackBased);
+
+async function getSizes({ entry, webpackEnvironment, index }) {
+  const sizes = [];
+
+  const configuration = createWebpackConfig(entry, webpackEnvironment);
+
+  // eslint-disable-next-line no-console -- process monitoring
+  console.log(`Compiling ${index}: "${Object.keys(configuration.entry)}"`);
+
+  const webpackStats = await webpack(configuration);
+
+  if (webpackStats.hasErrors()) {
+    const { entrypoints, errors } = webpackStats.toJson({
+      all: false,
+      entrypoints: true,
+      errors: true,
+    });
+    throw new Error(
+      `The following errors occured during bundling of ${Object.keys(
+        entrypoints,
+      )} with webpack: \n${errors
+        .map((error) => {
+          return `${JSON.stringify(error, null, 2)}`;
+        })
+        .join('\n')}`,
+    );
+  }
+
+  const stats = webpackStats.toJson({
+    all: false,
+    assets: true,
+    entrypoints: true,
+    relatedAssets: true,
+  });
+  const assets = new Map(stats.assets.map((asset) => [asset.name, asset]));
+
+  Object.values(stats.entrypoints).forEach((entrypoint) => {
+    let parsedSize = 0;
+    let gzipSize = 0;
+
+    entrypoint.assets.forEach(({ name, size }) => {
+      const asset = assets.get(name);
+      const gzippedAsset = asset.related.find((relatedAsset) => {
+        return relatedAsset.type === 'gzipped';
+      });
+
+      parsedSize += size;
+      gzipSize += gzippedAsset.size;
+    });
+
+    sizes.push([entrypoint.name, { parsed: parsedSize, gzip: gzipSize }]);
+  });
+
+  return sizes;
+}
+
+module.exports = getSizes;

--- a/scripts/sizeSnapshot/worker.js
+++ b/scripts/sizeSnapshot/worker.js
@@ -4,13 +4,13 @@ const { createWebpackConfig } = require('./webpack.config');
 
 const webpack = promisify(webpackCallbackBased);
 
-async function getSizes({ entry, webpackEnvironment, index }) {
+async function getSizes({ entry, webpackEnvironment, index, total }) {
   const sizes = [];
 
   const configuration = createWebpackConfig(entry, webpackEnvironment);
 
   // eslint-disable-next-line no-console -- process monitoring
-  console.log(`Compiling ${index}: "${Object.keys(configuration.entry)}"`);
+  console.log(`Compiling ${index}/${total}: "${Object.keys(configuration.entry)}"`);
 
   const webpackStats = await webpack(configuration);
 

--- a/scripts/sizeSnapshot/worker.js
+++ b/scripts/sizeSnapshot/worker.js
@@ -10,7 +10,7 @@ async function getSizes({ entry, webpackEnvironment, index, total }) {
   const configuration = createWebpackConfig(entry, webpackEnvironment);
 
   // eslint-disable-next-line no-console -- process monitoring
-  console.log(`Compiling ${index}/${total}: "${Object.keys(configuration.entry)}"`);
+  console.log(`Compiling ${index + 1}/${total}: "${Object.keys(configuration.entry)}"`);
 
   const webpackStats = await webpack(configuration);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12554,7 +12554,7 @@ pacote@^11.2.6:
     ssri "^8.0.1"
     tar "^6.1.0"
 
-pako@^1.0.3:
+pako@^1.0.3, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -12563,11 +12563,6 @@ pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
   integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
-
-pako@~1.0.5:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
-  integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
 
 param-case@^3.0.4:
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -125,6 +125,11 @@
     "@algolia/logger-common" "4.10.5"
     "@algolia/requester-common" "4.10.5"
 
+"@assemblyscript/loader@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.10.1.tgz#70e45678f06c72fa2e350e8553ec4a4d72b92e06"
+  integrity sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==
+
 "@babel/cli@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.16.0.tgz#a729b7a48eb80b49f48a339529fc4129fd7bcef3"
@@ -2308,26 +2313,12 @@
     glob-to-regexp "^0.3.0"
 
 "@mui/core@^5.0.0-alpha.54":
-  version "5.0.0-alpha.59"
-  dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@emotion/is-prop-valid" "^1.1.1"
-    "@mui/utils" "^5.2.3"
-    "@popperjs/core" "^2.4.4"
-    clsx "^1.1.1"
-    prop-types "^15.7.2"
-    react-is "^17.0.2"
+  version "0.0.0"
+  uid ""
 
 "@mui/core@link:./packages/mui-base":
-  version "5.0.0-alpha.59"
-  dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@emotion/is-prop-valid" "^1.1.1"
-    "@mui/utils" "^5.2.3"
-    "@popperjs/core" "^2.4.4"
-    clsx "^1.1.1"
-    prop-types "^15.7.2"
-    react-is "^17.0.2"
+  version "0.0.0"
+  uid ""
 
 "@mui/x-data-grid-generator@^5.0.1":
   version "5.0.1"
@@ -4736,7 +4727,7 @@ base64-arraybuffer@~1.0.1:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz#87bd13525626db4a9838e00a508c2b73efcf348c"
   integrity sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA==
 
-base64-js@^1.0.2, base64-js@^1.3.1:
+base64-js@^1.0.2, base64-js@^1.2.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -7700,6 +7691,11 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
+eventemitter-asyncresource@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eventemitter-asyncresource/-/eventemitter-asyncresource-1.0.0.tgz#734ff2e44bf448e627f7748f905d6bdd57bdb65b"
+  integrity sha512-39F7TBIV0G7gTelxwbEqnwhp90eqCPON1k0NwNfwhgKn4Co4ybUbj2pECcXT0B3ztRKZ7Pw1JujUUgmQJHcVAQ==
+
 eventemitter3@^4.0.0, eventemitter3@^4.0.1, eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
@@ -8883,6 +8879,20 @@ hasurl@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hasurl/-/hasurl-1.0.0.tgz#e4c619097ae1e8fc906bee904ce47e94f5e1ea37"
   integrity sha512-43ypUd3DbwyCT01UYpA99AEZxZ4aKtRxWGBHEIbjcOsUghd9YUON0C+JF6isNjaiwC/UF5neaUudy6JS9jZPZQ==
+
+hdr-histogram-js@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/hdr-histogram-js/-/hdr-histogram-js-2.0.1.tgz#ecb1ff2bcb6181c3e93ff4af9472c28c7e97284e"
+  integrity sha512-uPZxl1dAFnjUFHWLZmt93vUUvtHeaBay9nVNHu38SdOjMSF/4KqJUqa1Seuj08ptU1rEb6AHvB41X8n/zFZ74Q==
+  dependencies:
+    "@assemblyscript/loader" "^0.10.1"
+    base64-js "^1.2.0"
+    pako "^1.0.3"
+
+hdr-histogram-percentiles-obj@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz#9409f4de0c2dda78e61de2d9d78b1e9f3cba283c"
+  integrity sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==
 
 he@1.2.0, he@^1.2.0:
   version "1.2.0"
@@ -11732,6 +11742,14 @@ next@^12.0.4:
     "@next/swc-win32-ia32-msvc" "12.0.5"
     "@next/swc-win32-x64-msvc" "12.0.5"
 
+nice-napi@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nice-napi/-/nice-napi-1.0.2.tgz#dc0ab5a1eac20ce548802fc5686eaa6bc654927b"
+  integrity sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==
+  dependencies:
+    node-addon-api "^3.0.0"
+    node-gyp-build "^4.2.2"
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -11755,6 +11773,11 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
+
+node-addon-api@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
 node-cleanup@^2.1.2:
   version "2.1.2"
@@ -11787,6 +11810,11 @@ node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.6:
   integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-gyp-build@^4.2.2:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
+  integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
 
 node-gyp@^5.0.2:
   version "5.0.3"
@@ -12526,6 +12554,11 @@ pacote@^11.2.6:
     ssri "^8.0.1"
     tar "^6.1.0"
 
+pako@^1.0.3:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
@@ -12867,6 +12900,17 @@ pirates@^4.0.0:
   integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
   dependencies:
     node-modules-regexp "^1.0.0"
+
+piscina@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/piscina/-/piscina-3.2.0.tgz#f5a1dde0c05567775690cccefe59d9223924d154"
+  integrity sha512-yn/jMdHRw+q2ZJhFhyqsmANcbF6V2QwmD84c6xRau+QpQOmtrBCoRGdvTfeuFDYXB5W2m6MfLkjkvQa9lUSmIA==
+  dependencies:
+    eventemitter-asyncresource "^1.0.0"
+    hdr-histogram-js "^2.0.1"
+    hdr-histogram-percentiles-obj "^3.0.0"
+  optionalDependencies:
+    nice-napi "^1.0.2"
 
 pkg-dir@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Noticed that the size snapshot script regularly gets OOM killed by the circle ci docker host (e.g. https://app.circleci.com/pipelines/github/mui-org/material-ui/59188/workflows/3a20643a-72d7-4111-b7ad-265ef5b7bf94/jobs/326618). Been testing locally and it's indeed flirting with the 4GB memory limit set for the cci medium instances. I've been investigating and noticed a memory leak with `webpack-bundle-analyzer`. Memory grows with each batch of compilations and doesn't get reclaimed. Removing `webpack-bundle-analyzer` from the webpack configuration keeps the memory stable.
I propose a different way of parallelizing the size calculations by using node.js worker threads. This makes sure memory gets cleaned up for every webpack run so that the script becomes scalable again.  First observations suggest it runs about 25% faster as well.