### PR TITLE
[docs] Rename remaining 'unstyled' references to 'base'

### DIFF
--- a/docs/src/pages/components/backdrop/backdrop.md
+++ b/docs/src/pages/components/backdrop/backdrop.md
@@ -19,7 +19,7 @@ In its simplest form, the backdrop component will add a dimmed layer over your a
 
 ## Unstyled
 
-The backdrop also comes with the unstyled package.
+The backdrop also comes with the Base package.
 It's ideal for doing heavy customizations and minimizing bundle size.
 
 ```js

--- a/docs/src/pages/components/click-away-listener/click-away-listener.md
+++ b/docs/src/pages/components/click-away-listener/click-away-listener.md
@@ -41,7 +41,7 @@ However, you can configure it to respond to the leading events (mouse down + tou
 
 - 📦 [784 B gzipped](https://bundlephobia.com/package/@mui/base@latest)
 
-As the component does not have any styles, it also comes with the unstyled package.
+As the component does not have any styles, it also comes with the Base package.
 
 ```js
 import ClickAwayListener from '@mui/base/ClickAwayListener';

--- a/docs/src/pages/components/no-ssr/no-ssr.md
+++ b/docs/src/pages/components/no-ssr/no-ssr.md
@@ -36,7 +36,7 @@ React does [2 commits](https://reactjs.org/docs/strict-mode.html#detecting-unexp
 
 - 📦 [784 B gzipped](https://bundlephobia.com/package/@mui/base@latest)
 
-As the component does not have any styles, it also comes with the unstyled package.
+As the component does not have any styles, it also comes with the Base package.
 
 ```js
 import NoSsr from '@mui/base/NoSsr';

--- a/docs/src/pages/components/portal/portal.md
+++ b/docs/src/pages/components/portal/portal.md
@@ -26,7 +26,7 @@ You have to wait for the client-side hydration to see the children.
 
 - 📦 [970 B gzipped](https://bundlephobia.com/package/@mui/base@latest)
 
-As the component does not have any styles, it also comes with the unstyled package.
+As the component does not have any styles, it also comes with the Base package.
 
 ```js
 import Portal from '@mui/base/Portal';

--- a/docs/src/pages/components/textarea-autosize/textarea-autosize.md
+++ b/docs/src/pages/components/textarea-autosize/textarea-autosize.md
@@ -30,7 +30,7 @@ The `TextareaAutosize` component automatically adjust the textarea height on key
 
 - 📦 [784 B gzipped](https://bundlephobia.com/package/@mui/base@latest)
 
-As the component does not have any styles, it also comes with the unstyled package.
+As the component does not have any styles, it also comes with the Base package.
 
 ```js
 import TextareaAutosize from '@mui/base/TextareaAutosize';

--- a/docs/src/pages/components/trap-focus/trap-focus.md
+++ b/docs/src/pages/components/trap-focus/trap-focus.md
@@ -25,7 +25,7 @@ When `open={true}` the trap is enabled, and pressing <kbd class="key">Tab</kbd> 
 
 - 📦 [2.0 kB gzipped](https://bundlephobia.com/package/@mui/base@latest)
 
-As the component does not have any styles, it also comes with the unstyled package.
+As the component does not have any styles, it also comes with the Base package.
 
 ```js
 import TrapFocus from '@mui/base/Unstable_TrapFocus';

--- a/docs/src/pages/customization/unstyled-components/unstyled-components.md
+++ b/docs/src/pages/customization/unstyled-components/unstyled-components.md
@@ -6,7 +6,7 @@ MUI Base provides a set of components without any styles.
 These can be used to implement a custom design system that is not based on Material Design.
 
 So far, just a few components have been created,
-but we intend to focus on the @mui/base package extensively in the upcoming months.
+but we intend to focus on the `@mui/base` package extensively in the upcoming months.
 
 ## Use cases
 

--- a/docs/src/pages/customization/unstyled-components/unstyled-components.md
+++ b/docs/src/pages/customization/unstyled-components/unstyled-components.md
@@ -2,15 +2,15 @@
 
 <p class="description">Implementing a custom design system using MUI.</p>
 
-MUI unstyled provides a set of components without any styles.
+MUI Base provides a set of components without any styles.
 These can be used to implement a custom design system that is not based on Material Design.
 
 So far, just a few components have been created,
-but we intend to focus on the unstyled package extensively in the upcoming months.
+but we intend to focus on the @mui/base package extensively in the upcoming months.
 
 ## Use cases
 
-Is the unstyled package good for you?
+Is the Base package good for you?
 
 If you:
 
@@ -30,7 +30,7 @@ then you may be better off using the `@mui/material` package and [customizing it
 
 ## Components vs. hooks
 
-The unstyled package has two kinds of building blocks:
+The Base package has two kinds of building blocks:
 
 - unstyled components
 - hooks

--- a/packages/mui-base/README.md
+++ b/packages/mui-base/README.md
@@ -1,6 +1,6 @@
 # @mui/base
 
-This package hosts unstyled React components that can be used for creating custom design systems.
+This package hosts unstyled React components and hooks that can be used for creating custom design systems.
 
 ## Installation
 


### PR DESCRIPTION
Found few remaining references to 'unstyled' and replaced them with Base.
