### PR TITLE
[Tabs] Remove `Partial<>` type around TabIndicatorProps type

### DIFF
--- a/packages/mui-material-next/src/Tabs/Tabs.d.ts
+++ b/packages/mui-material-next/src/Tabs/Tabs.d.ts
@@ -88,7 +88,7 @@ export interface TabsTypeMap<P = {}, D extends React.ElementType = typeof Button
      * Props applied to the tab indicator element.
      * @default  {}
      */
-    TabIndicatorProps?: Partial<React.HTMLAttributes<HTMLDivElement>>;
+    TabIndicatorProps?: React.HTMLAttributes<HTMLDivElement>;
     /**
      * Props applied to the [`TabScrollButton`](/api/tab-scroll-button/) element.
      * @default {}

--- a/packages/mui-material/src/Tabs/Tabs.d.ts
+++ b/packages/mui-material/src/Tabs/Tabs.d.ts
@@ -88,7 +88,7 @@ export interface TabsTypeMap<P = {}, D extends React.ElementType = typeof Button
      * Props applied to the tab indicator element.
      * @default  {}
      */
-    TabIndicatorProps?: Partial<React.HTMLAttributes<HTMLDivElement>>;
+    TabIndicatorProps?: React.HTMLAttributes<HTMLDivElement>;
     /**
      * Props applied to the [`TabScrollButton`](/api/tab-scroll-button/) element.
      * @default {}

--- a/packages/mui-material/src/Tabs/Tabs.spec.tsx
+++ b/packages/mui-material/src/Tabs/Tabs.spec.tsx
@@ -11,3 +11,5 @@ function testOnChange() {
     onChange={handleElementChange}
   />;
 }
+
+const TabTest = () => <Tabs TabIndicatorProps={{ style: { backgroundColor: 'green' } }} />;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Since the properties of `React.HTMLAttributes` are all optional, Partial utility type is not needed. 