### PR TITLE
[docs] Redirect old urls to `/material/*` when search

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -18,6 +18,7 @@ import Link from 'docs/src/modules/components/Link';
 import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
 import useLazyCSS from 'docs/src/modules/utils/useLazyCSS';
 import { useRouter } from 'next/router';
+import FEATURE_TOGGLE from 'docs/src/featureToggle';
 
 const SearchButton = styled('button')(({ theme }) => {
   return {
@@ -298,7 +299,7 @@ export default function AppSearch() {
                 }
 
                 // TODO: remove this logic once the migration to new structure is done.
-                if (router.asPath.startsWith('/material')) {
+                if (FEATURE_TOGGLE.enable_product_scope) {
                   parseUrl.href = parseUrl.href.replace(
                     /(?<!material\/)(getting-started|components|api|customization|guides|discover-more)(\/[^/]+\/)/,
                     `material/$1$2`,

--- a/test/e2e-website/material-docs.spec.ts
+++ b/test/e2e-website/material-docs.spec.ts
@@ -121,10 +121,18 @@ test.describe.parallel('Material docs', () => {
 
       const anchor = await page.locator('.DocSearch-Hits a:has-text("Card")');
 
-      await expect(anchor.first()).toHaveAttribute(
-        'href',
-        `${materialUrlPrefix}/components/cards/#main-content`,
-      );
+      if (FEATURE_TOGGLE.enable_product_scope && !materialUrlPrefix) {
+        // the old url doc should point to the new location
+        await expect(anchor.first()).toHaveAttribute(
+          'href',
+          `/material/components/cards/#main-content`,
+        );
+      } else {
+        await expect(anchor.first()).toHaveAttribute(
+          'href',
+          `${materialUrlPrefix}/components/cards/#main-content`,
+        );
+      }
     });
 
     test('should have correct link when searching API', async ({ page, materialUrlPrefix }) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR cover all scenarios when searching with cmd+K (algolia search):

**Before migration**
The feature toggle is not turned on, so the behavior is still the same.

**Migration phase**
When the contents are duplicated to `docs/pages/material/*` and the feature toggle is turned on, all the search results (related to components, API, etc.) are replaced to point to `/material/*` URL.

**Post migration**
The search config on the doc search is updated and the new `/material/*` have been indexed, the URL will not be replaced because of the regex in the code.

✅ E2E website added.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
