### PR TITLE
Fix typo in remix-with-typescript example README

### DIFF
--- a/examples/remix-with-typescript/README.md
+++ b/examples/remix-with-typescript/README.md
@@ -8,7 +8,7 @@ Download the example [or clone the repo](https://github.com/mui-org/material-ui)
 
 ```sh
 curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/remix-with-typescript
-cd nextjs
+cd remix-with-typescript
 ```
 
 Install it and run:


### PR DESCRIPTION
After cloning the example project, the project folder is `remix-with-typescript` but the README was mentioning `cd nextjs` for getting to the working folder.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
