### PR TITLE
[docs] Fix Icon Search UI crash

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -203,7 +203,7 @@ const Root = styled('div')(({ theme }) => ({
     backgroundColor:
       theme.palette.mode === 'dark'
         ? // Support Material design theme
-          alpha(theme.palette.warning[900], 0.2) ?? alpha(theme.palette.warning.dark, 0.09)
+          alpha(theme.palette.warning[900] ?? theme.palette.warning.dark, 0.2)
         : theme.palette.warning[50] ?? theme.palette.warning.light,
     padding: '10px 20px',
     margin: '20px 0',


### PR DESCRIPTION
Make sure to coalesce the colors before feeding them into `alpha` for the dark theme.

Fixes https://github.com/mui-org/material-ui/issues/30304

Preview: https://deploy-preview-30319--material-ui.netlify.app/components/material-icons/
