### PR TITLE
[core] Rename missed `Material-UI` text to `MUI` in warning logs

### DIFF
--- a/packages/mui-base/src/InputUnstyled/InputUnstyled.tsx
+++ b/packages/mui-base/src/InputUnstyled/InputUnstyled.tsx
@@ -145,7 +145,7 @@ const InputUnstyled = React.forwardRef(function InputUnstyled(
       if (process.env.NODE_ENV !== 'production') {
         if (minRows || maxRows) {
           console.warn(
-            'Material-UI: You can not use the `minRows` or `maxRows` props when the input `rows` prop is set.',
+            'MUI: You can not use the `minRows` or `maxRows` props when the input `rows` prop is set.',
           );
         }
       }

--- a/packages/mui-material-next/src/Button/Button.js
+++ b/packages/mui-material-next/src/Button/Button.js
@@ -404,7 +404,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
       if (enableTouchRipple && !rippleRef.current) {
         console.error(
           [
-            'Material-UI: The `component` prop provided to Button is invalid.',
+            'MUI: The `component` prop provided to Button is invalid.',
             'Please make sure the children prop is rendered in this custom component.',
           ].join('\n'),
         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
