### PR TITLE
[docs] Fix incorrect number of breakpoint helpers

### DIFF
--- a/docs/src/pages/customization/breakpoints/breakpoints.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints.md
@@ -26,7 +26,7 @@ These values can be [customized](#custom-breakpoints).
 ## CSS Media Queries
 
 CSS media queries are the idiomatic approach to make your UI responsive.
-The theme provides four styles helpers to do so:
+The theme provides five styles helpers to do so:
 
 - [theme.breakpoints.up(key)](#theme-breakpoints-up-key-media-query)
 - [theme.breakpoints.down(key)](#theme-breakpoints-down-key-media-query)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The #29311 PR forgot to update the number of breakpoint helpers in the docs. The text says four, but they are now five.