### PR TITLE
[docs] Fix incorrect aria label in SpeedDial demo

### DIFF
--- a/docs/src/pages/components/speed-dial/ControlledOpenSpeedDial.js
+++ b/docs/src/pages/components/speed-dial/ControlledOpenSpeedDial.js
@@ -23,7 +23,7 @@ export default function ControlledOpenSpeedDial() {
   return (
     <Box sx={{ height: 320, transform: 'translateZ(0px)', flexGrow: 1 }}>
       <SpeedDial
-        ariaLabel="SpeedDial uncontrolled open example"
+        ariaLabel="SpeedDial controlled open example"
         sx={{ position: 'absolute', bottom: 16, right: 16 }}
         icon={<SpeedDialIcon />}
         onClose={handleClose}

--- a/docs/src/pages/components/speed-dial/ControlledOpenSpeedDial.tsx
+++ b/docs/src/pages/components/speed-dial/ControlledOpenSpeedDial.tsx
@@ -23,7 +23,7 @@ export default function ControlledOpenSpeedDial() {
   return (
     <Box sx={{ height: 320, transform: 'translateZ(0px)', flexGrow: 1 }}>
       <SpeedDial
-        ariaLabel="SpeedDial uncontrolled open example"
+        ariaLabel="SpeedDial controlled open example"
         sx={{ position: 'absolute', bottom: 16, right: 16 }}
         icon={<SpeedDialIcon />}
         onClose={handleClose}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The controlled SpeedDial demo has the aria label "uncontrolled" where it should be "controlled".