### PR TITLE
[slider] Add `input` slot to components and componentsProps

### DIFF
--- a/docs/pages/api-docs/slider-unstyled.json
+++ b/docs/pages/api-docs/slider-unstyled.json
@@ -8,7 +8,7 @@
     "components": {
       "type": {
         "name": "shape",
-        "description": "{ Mark?: elementType, MarkLabel?: elementType, Rail?: elementType, Root?: elementType, Thumb?: elementType, Track?: elementType, ValueLabel?: elementType }"
+        "description": "{ Input?: elementType, Mark?: elementType, MarkLabel?: elementType, Rail?: elementType, Root?: elementType, Thumb?: elementType, Track?: elementType, ValueLabel?: elementType }"
       },
       "default": "{}"
     },

--- a/docs/pages/api-docs/slider.json
+++ b/docs/pages/api-docs/slider.json
@@ -15,7 +15,7 @@
     "components": {
       "type": {
         "name": "shape",
-        "description": "{ Mark?: elementType, MarkLabel?: elementType, Rail?: elementType, Root?: elementType, Thumb?: elementType, Track?: elementType, ValueLabel?: elementType }"
+        "description": "{ Input?: elementType, Mark?: elementType, MarkLabel?: elementType, Rail?: elementType, Root?: elementType, Thumb?: elementType, Track?: elementType, ValueLabel?: elementType }"
       },
       "default": "{}"
     },

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.d.ts
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.d.ts
@@ -49,6 +49,7 @@ export interface SliderUnstyledTypeMap<P = {}, D extends React.ElementType = 'sp
       Mark?: React.ElementType;
       MarkLabel?: React.ElementType;
       ValueLabel?: React.ElementType;
+      Input?: React.ElementType;
     };
     /**
      * The props used for each slot inside the Slider.
@@ -63,6 +64,7 @@ export interface SliderUnstyledTypeMap<P = {}, D extends React.ElementType = 'sp
       markLabel?: React.HTMLAttributes<HTMLSpanElement> & SliderUnstyledComponentsPropsOverrides;
       valueLabel?: React.ComponentPropsWithRef<typeof SliderValueLabelUnstyled> &
         SliderUnstyledComponentsPropsOverrides;
+      input?: React.HTMLAttributes<HTMLInputElement> & SliderUnstyledComponentsPropsOverrides;
     };
     /**
      * The default value. Use when the component is not controlled.

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
@@ -787,6 +787,9 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                     height: '100%',
                     ...inputProps.style,
                   }}
+                  {...(!isHostComponent(Input) && {
+                    ownerState: { ...ownerState, ...inputProps.ownerState },
+                  })}
                   {...inputProps}
                 />
               </Thumb>

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
@@ -607,6 +607,9 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
   const MarkLabel = components.MarkLabel || 'span';
   const markLabelProps = componentsProps.markLabel || {};
 
+  const Input = components.Input || 'input';
+  const inputProps = componentsProps.input || {};
+
   // all props with defaults
   // consider extracting to hook an reusing the lint rule for the varints
   const ownerState = {
@@ -754,7 +757,9 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                   ...thumbProps.style,
                 }}
               >
-                <input
+                <Input
+                  tabIndex={tabIndex}
+                  data-index={index}
                   aria-label={getAriaLabel ? getAriaLabel(index) : ariaLabel}
                   aria-labelledby={ariaLabelledby}
                   aria-orientation={orientation}
@@ -764,25 +769,25 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                   aria-valuetext={
                     getAriaValueText ? getAriaValueText(scale(value), index) : ariaValuetext
                   }
-                  data-index={index}
-                  disabled={disabled}
-                  max={props.max}
-                  min={props.min}
-                  name={name}
-                  onBlur={handleBlur}
-                  onChange={handleHiddenInputChange}
                   onFocus={handleFocus}
+                  onBlur={handleBlur}
+                  name={name}
+                  type="range"
+                  min={props.min}
+                  max={props.max}
                   step={props.step}
+                  disabled={disabled}
+                  value={values[index]}
+                  onChange={handleHiddenInputChange}
                   style={{
                     ...visuallyHidden,
                     direction: isRtl ? 'rtl' : 'ltr',
                     // So that VoiceOver's focus indicator matches the thumb's dimensions
                     width: '100%',
                     height: '100%',
+                    ...inputProps.style,
                   }}
-                  tabIndex={tabIndex}
-                  type="range"
-                  value={values[index]}
+                  {...inputProps}
                 />
               </Thumb>
             </ValueLabelComponent>
@@ -853,6 +858,7 @@ SliderUnstyled.propTypes /* remove-proptypes */ = {
    * @default {}
    */
   components: PropTypes.shape({
+    Input: PropTypes.elementType,
     Mark: PropTypes.elementType,
     MarkLabel: PropTypes.elementType,
     Rail: PropTypes.elementType,

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
@@ -755,8 +755,6 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                 }}
               >
                 <input
-                  tabIndex={tabIndex}
-                  data-index={index}
                   aria-label={getAriaLabel ? getAriaLabel(index) : ariaLabel}
                   aria-labelledby={ariaLabelledby}
                   aria-orientation={orientation}
@@ -766,16 +764,15 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                   aria-valuetext={
                     getAriaValueText ? getAriaValueText(scale(value), index) : ariaValuetext
                   }
-                  onFocus={handleFocus}
-                  onBlur={handleBlur}
-                  name={name}
-                  type="range"
-                  min={props.min}
-                  max={props.max}
-                  step={props.step}
+                  data-index={index}
                   disabled={disabled}
-                  value={values[index]}
+                  max={props.max}
+                  min={props.min}
+                  name={name}
+                  onBlur={handleBlur}
                   onChange={handleHiddenInputChange}
+                  onFocus={handleFocus}
+                  step={props.step}
                   style={{
                     ...visuallyHidden,
                     direction: isRtl ? 'rtl' : 'ltr',
@@ -783,6 +780,9 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                     width: '100%',
                     height: '100%',
                   }}
+                  tabIndex={tabIndex}
+                  type="range"
+                  value={values[index]}
                 />
               </Thumb>
             </ValueLabelComponent>

--- a/packages/mui-material/src/Slider/Slider.d.ts
+++ b/packages/mui-material/src/Slider/Slider.d.ts
@@ -60,6 +60,7 @@ type SliderRailProps = NonNullable<SliderTypeMap['props']['componentsProps']>['r
 type SliderTrackProps = NonNullable<SliderTypeMap['props']['componentsProps']>['track'];
 type SliderThumbProps = NonNullable<SliderTypeMap['props']['componentsProps']>['thumb'];
 type SliderValueLabelProps = NonNullable<SliderTypeMap['props']['componentsProps']>['valueLabel'];
+type SliderInputProps = NonNullable<SliderTypeMap['props']['componentsProps']>['input'];
 
 export const SliderRoot: React.FC<SliderRootProps>;
 export const SliderMark: React.FC<SliderMarkProps>;
@@ -68,6 +69,7 @@ export const SliderRail: React.FC<SliderRailProps>;
 export const SliderTrack: React.FC<SliderTrackProps>;
 export const SliderThumb: React.FC<SliderThumbProps>;
 export const SliderValueLabel: React.FC<SliderValueLabelProps>;
+export const SliderInput: React.FC<SliderInputProps>;
 
 /**
  *

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -421,8 +421,8 @@ const shouldSpreadOwnerState = (Component) => {
   return !Component || !isHostComponent(Component);
 };
 
-const Slider = React.forwardRef(function Slider(inputProps, ref) {
-  const props = useThemeProps({ props: inputProps, name: 'MuiSlider' });
+const Slider = React.forwardRef(function Slider(sliderProps, ref) {
+  const props = useThemeProps({ props: sliderProps, name: 'MuiSlider' });
 
   const theme = useTheme();
   const isRtl = theme.direction === 'rtl';
@@ -545,6 +545,7 @@ Slider.propTypes /* remove-proptypes */ = {
    * @default {}
    */
   components: PropTypes.shape({
+    Input: PropTypes.elementType,
     Mark: PropTypes.elementType,
     MarkLabel: PropTypes.elementType,
     Rail: PropTypes.elementType,

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1189,7 +1189,9 @@ describe('<Slider />', () => {
       // ARRANGE
       const dataTestId = 'slider-input-testid';
       const name = 'custom-input';
-      const CustomInput = (props) => <input {...props} data-testid={dataTestId} name={name} />;
+      const CustomInput = ({ ownerState, ...props }) => (
+        <input {...props} data-testid={dataTestId} name={name} />
+      );
 
       // ACT
       const { getByTestId } = render(<Slider components={{ Input: CustomInput }} />);

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1183,4 +1183,35 @@ describe('<Slider />', () => {
       expect(thumb).to.have.class(classes.thumbSizeSmall);
     });
   });
+
+  describe('prop: components', () => {
+    it('should render custom components if specified', () => {
+      // ARRANGE
+      const dataTestId = 'slider-input-testid';
+      const name = 'custom-input';
+      const CustomInput = (props) => <input {...props} data-testid={dataTestId} name={name} />;
+
+      // ACT
+      const { getByTestId } = render(<Slider components={{ Input: CustomInput }} />);
+
+      // ASSERT
+      expect(getByTestId(dataTestId).name).to.equal(name);
+    });
+  });
+
+  describe('prop: componentsProps', () => {
+    it('should forward the props to their respective components', () => {
+      // ARRANGE
+      const dataTestId = 'slider-input-testid';
+      const id = 'slider-input-id';
+
+      // ACT
+      const { getByTestId } = render(
+        <Slider defaultValue={10} componentsProps={{ input: { 'data-testid': dataTestId, id } }} />,
+      );
+
+      // ASSERT
+      expect(getByTestId(dataTestId).id).to.equal(id);
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui-org/material-ui/issues/30346 