### PR TITLE
[docs] Fix link to /size-snapshot

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -4,7 +4,7 @@
 /trash / 301
 /spam / 301
 
-/size-snapshot https://s3.eu-central-1.amazonaws.com/mui-org-material-ui/artifacts/master/latest/size-snapshot.json 200
+/size-snapshot https://s3.eu-central-1.amazonaws.com/mui-org-ci/artifacts/master/latest/size-snapshot.json 200
 
 # To add when we finish work on v6
 # https://next.mui.com/* https://mui.com/:splat 301!


### PR DESCRIPTION
Fix #30356. With Jan, we moved the S3 to the root AWS account of MUI, we had to create a new bucket.