### PR TITLE
[example] Avoid double rendering in the Remix example

### DIFF
--- a/examples/remix-with-typescript/app/entry.server.tsx
+++ b/examples/remix-with-typescript/app/entry.server.tsx
@@ -44,7 +44,7 @@ export default function handleRequest(
     stylesHTML = `${stylesHTML}${newStyleTag}`;
   });
 
-  // Add the emotion style tags after the insertino point meta tag
+  // Add the emotion style tags after the insertion point meta tag
   const markup = html.replace(
     /<meta(\s)*name="emotion-insertion-point"(\s)*content="emotion-insertion-point"(\s)*\/>/,
     `<meta name="emotion-insertion-point" content="emotion-insertion-point"/>${stylesHTML}`,

--- a/examples/remix-with-typescript/app/entry.server.tsx
+++ b/examples/remix-with-typescript/app/entry.server.tsx
@@ -36,18 +36,18 @@ export default function handleRequest(
   // Grab the CSS from emotion
   const { styles } = extractCriticalToChunks(html);
 
-  let stylesHTML = "";
+  let stylesHTML = '';
 
   styles.forEach(({ key, ids, css }) => {
     const emotionKey = `${key} ${ids.join(' ')}`;
     const newStyleTag = `<style data-emotion="${emotionKey}">${css}</style>`;
     stylesHTML = `${stylesHTML}${newStyleTag}`;
-  })
+  });
 
   // Add the emotion style tags after the insertino point meta tag
   const markup = html.replace(
     /<meta(\s)*name="emotion-insertion-point"(\s)*content="emotion-insertion-point"(\s)*\/>/,
-    `<meta name="emotion-insertion-point" content="emotion-insertion-point"/>${stylesHTML}`
+    `<meta name="emotion-insertion-point" content="emotion-insertion-point"/>${stylesHTML}`,
   );
 
   responseHeaders.set('Content-Type', 'text/html');

--- a/examples/remix-with-typescript/app/entry.server.tsx
+++ b/examples/remix-with-typescript/app/entry.server.tsx
@@ -5,7 +5,6 @@ import type { EntryContext } from 'remix';
 
 import createEmotionCache from './src/createEmotionCache';
 import theme from './src/theme';
-import StylesContext from './src/StylesContext';
 
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
@@ -32,20 +31,23 @@ export default function handleRequest(
   );
 
   // Render the component to a string.
-  const html = renderToString(
-    <StylesContext.Provider value={null}>
-      <MuiRemixServer />
-    </StylesContext.Provider>,
-  );
+  const html = renderToString(<MuiRemixServer />);
 
   // Grab the CSS from emotion
-  const emotionChunks = extractCriticalToChunks(html);
+  const { styles } = extractCriticalToChunks(html);
 
-  // Re-render including the extracted css.
-  const markup = renderToString(
-    <StylesContext.Provider value={emotionChunks.styles}>
-      <MuiRemixServer />
-    </StylesContext.Provider>,
+  let stylesHTML = "";
+
+  styles.forEach(({ key, ids, css }) => {
+    const emotionKey = `${key} ${ids.join(' ')}`;
+    const newStyleTag = `<style data-emotion="${emotionKey}">${css}</style>`;
+    stylesHTML = `${stylesHTML}${newStyleTag}`;
+  })
+
+  // Add the emotion style tags after the insertino point meta tag
+  const markup = html.replace(
+    /<meta(\s)*name="emotion-insertion-point"(\s)*content="emotion-insertion-point"(\s)*\/>/,
+    `<meta name="emotion-insertion-point" content="emotion-insertion-point"/>${stylesHTML}`
   );
 
   responseHeaders.set('Content-Type', 'text/html');

--- a/examples/remix-with-typescript/app/root.tsx
+++ b/examples/remix-with-typescript/app/root.tsx
@@ -1,14 +1,10 @@
 import * as React from 'react';
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useCatch } from 'remix';
-import { useContext } from 'react';
-import StylesContext from './src/StylesContext';
 import theme from './src/theme';
 
 import Layout from './src/Layout';
 
 function Document({ children, title }: { children: React.ReactNode; title?: string }) {
-  const styleData = useContext(StylesContext);
-
   return (
     <html lang="en">
       <head>
@@ -22,14 +18,7 @@ function Document({ children, title }: { children: React.ReactNode; title?: stri
           rel="stylesheet"
           href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
         />
-        {styleData?.map(({ key, ids, css }) => (
-          <style
-            key={key}
-            data-emotion={`${key} ${ids.join(' ')}`}
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: css }}
-          />
-        ))}
+        <meta name="emotion-insertion-point" content="emotion-insertion-point" />
       </head>
       <body>
         {children}

--- a/examples/remix-with-typescript/app/src/StylesContext.tsx
+++ b/examples/remix-with-typescript/app/src/StylesContext.tsx
@@ -1,9 +1,0 @@
-import { createContext } from 'react';
-
-export interface StyleContextData {
-  key: string;
-  ids: Array<string>;
-  css: string;
-}
-
-export default createContext<null | StyleContextData[]>(null);

--- a/examples/remix-with-typescript/remix.config.js
+++ b/examples/remix-with-typescript/remix.config.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   appDirectory: 'app',
-  assetsBuildDirectory: 'public/build',
+  browserBuildDirectory: 'public/build',
   publicPath: '/build/',
   serverBuildDirectory: 'build',
   devServerPort: 8002,


### PR DESCRIPTION
Resolves https://github.com/mui-org/material-ui/pull/29952#discussion_r762576860

The goal is to avoid double rendering on the server. It was solved by injecting the emotion style tag after a specific `meta` tag in the head. It is similar to the new `insertionPoint` option recently added in emotion - https://github.com/emotion-js/emotion/pull/2521

I could use some help testing out, to make sure I didn't miss anything.