### PR TITLE
[docs] Improve the translation experience

### DIFF
--- a/docs/src/modules/components/EditPage.js
+++ b/docs/src/modules/components/EditPage.js
@@ -21,7 +21,7 @@ export default function EditPage(props) {
       href={
         userLanguage === 'en'
           ? `${process.env.SOURCE_CODE_ROOT_URL}${markdownLocation}`
-          : `${CROWDIN_ROOT_URL}${crowdInLocale}#/staging${crowdInPath}`
+          : `${CROWDIN_ROOT_URL}${crowdInLocale}#/master${crowdInPath}`
       }
       target="_blank"
       rel="noopener nofollow"


### PR DESCRIPTION
I fix a regression that happens, I have no idea when. Before when you would click on the "translate docs button":

<img width="451" alt="Screenshot 2021-12-23 at 00 20 42" src="https://user-images.githubusercontent.com/3165635/147165781-fef31cfc-77e3-4164-a656-9da8be7c80a2.png">

https://mui.com/zh/components/alert/

it would filter the tree and only display the page you can translate:

<img width="1211" alt="Screenshot 2021-12-23 at 00 19 01" src="https://user-images.githubusercontent.com/3165635/147165697-9ce02863-b8b5-4f7a-bbaf-62c587c78373.png">

Today, as a developer that want to fix a bug in the translation, you have to find the page yourself, it's painful:

<img width="1206" alt="Screenshot 2021-12-23 at 00 19 05" src="https://user-images.githubusercontent.com/3165635/147165712-e67e4772-1b5b-40d3-8cba-fdcc2c3facab.png">
