### PR TITLE
[ButtonGroup] Fix typo in `ButtonGroupContext`'s interface

### DIFF
--- a/packages/mui-material/src/ButtonGroup/ButtonGroupContext.ts
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroupContext.ts
@@ -5,7 +5,7 @@ interface IButtonGroupContext {
   className?: string;
   color?: ButtonGroupProps['color'];
   disabled?: boolean;
-  disabledElevation?: boolean;
+  disableElevation?: boolean;
   disableFocusRipple?: boolean;
   disableRipple?: boolean;
   fullWidth?: boolean;


### PR DESCRIPTION
Change `disabledElevation` to `disableElevation`

The ButtonGroup and Button components both use `disableElevation` not `disabledElevation`. This fixes that typo.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
