### PR TITLE
[docs] Fix 404 links

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -237,7 +237,9 @@ This change affects almost all components where you're using the `component` pro
 
 ### Ref type specificity
 
-For some components, you may get a type error when passing `ref`. In order to avoid the error, you should use a specific element type. For example, `Card` expects the type of `ref` to be `HTMLDivElement`, and `ListItem` expects its `ref` type to be `HTMLLIElement`.
+For some components, you may get a type error when passing `ref`.
+To avoid the error, you should use a specific element type.
+For example, `Card` expects the type of `ref` to be `HTMLDivElement`, and `ListItem` expects its `ref` type to be `HTMLLIElement`.
 
 Here is an example:
 
@@ -265,21 +267,21 @@ The list of components that expect a specific element type is as follows:
 
 ##### `@mui/material`
 
-- [Accordion](/components/accordion) - `HTMLDivElement`
-- [Alert](/components/alert) - `HTMLDivElement`
-- [Avatar](/components/avatar) - `HTMLDivElement`
-- [ButtonGroup](/components/button-group) - `HTMLDivElement`
-- [Card](/components/card) - `HTMLDivElement`
-- [Dialog](/components/dialog) - `HTMLDivElement`
-- [ImageList](/components/image-list) - `HTMLUListElement`
-- [List](/components/list) - `HTMLUListElement`
-- [Tab](/components/tabs) - `HTMLDivElement`
-- [Tabs](/components/tabs) - `HTMLDivElement`
-- [ToggleButton](/components/toggle-button) - `HTMLButtonElement`
+- [Accordion](/api/accordion/) - `HTMLDivElement`
+- [Alert](/api/alert/) - `HTMLDivElement`
+- [Avatar](/api/avatar/) - `HTMLDivElement`
+- [ButtonGroup](/api/button-group/) - `HTMLDivElement`
+- [Card](/api/card/) - `HTMLDivElement`
+- [Dialog](/api/dialog/) - `HTMLDivElement`
+- [ImageList](/api/image-list/) - `HTMLUListElement`
+- [List](/api/list/) - `HTMLUListElement`
+- [Tab](/api/tab/) - `HTMLDivElement`
+- [Tabs](/api/tabs/) - `HTMLDivElement`
+- [ToggleButton](/api/toggle-button/) - `HTMLButtonElement`
 
 ##### `@mui/lab`
 
-- [Timeline](/components/timeline) - `HTMLUListElement`
+- [Timeline](/api/timeline/) - `HTMLUListElement`
 
 ### Style library
 


### PR DESCRIPTION
It's a follow-up to fix #30114. There are 3 problems with something like `[Dialog](/components/dialog)`

1. It's missing a trailing slash
2. The page doesn't exist, it's dialog**s**
3. We talked about the React module, so it should be the API page, AFAIK

I have noticed it on

<img width="514" alt="Screenshot 2021-12-23 at 11 46 37" src="https://user-images.githubusercontent.com/3165635/147229561-f0374f87-f06f-4501-b08e-bcff34de721b.png">
 