### PR TITLE
[docs] Document how to unmount transition child

### DIFF
--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -308,7 +308,7 @@ export default function AppLayoutDocsFooter() {
             </PaginationDiv>
           </React.Fragment>
         )}
-        <Collapse in={commentOpen} onEntered={handleEntered}>
+        <Collapse in={commentOpen} unmountOnExit onEntered={handleEntered}>
           <form
             aria-labelledby="feedback-message"
             onReset={handleCancelComment}

--- a/docs/src/pages/components/accordion/accordion.md
+++ b/docs/src/pages/components/accordion/accordion.md
@@ -45,8 +45,8 @@ accordions it might be a good idea to change this default behavior by enabling t
 <Accordion TransitionProps={{ unmountOnExit: true }} />
 ```
 
-As with any performance optimization this is not a silver bullet. Be sure to identify
-bottlenecks first and then try out these optimization strategies.
+As with any performance optimization this is not a silver bullet.
+Be sure to identify bottlenecks first and then try out these optimization strategies.
 
 ## Accessibility
 

--- a/docs/src/pages/components/transitions/transitions.md
+++ b/docs/src/pages/components/transitions/transitions.md
@@ -117,3 +117,17 @@ You can also visit the dedicated sections of some of the components:
 - [Popper](/components/popper/#transitions)
 - [Snackbar](/components/snackbars/#transitions)
 - [Tooltip](/components/tooltips/#transitions)
+
+## Performance & SEO
+
+The content of transition component is mounted by default even if `in={false}`.
+This default behavior has server-side rendering and SEO in mind.
+If you render expensive component trees inside your transition it might be a good idea to change this default behavior by enabling the
+`unmountOnExit` prop:
+
+```jsx
+<Fade in={false} unmountOnExit />
+```
+
+As with any performance optimization this is not a silver bullet.
+Be sure to identify bottlenecks first and then try out these optimization strategies.


### PR DESCRIPTION
I have noticed this having a quick look at #30378. When you open WAVE, on any page, say https://mui.com/components/alert/, it will let you know that

<img width="728" alt="Screenshot 2021-12-23 at 15 10 28" src="https://user-images.githubusercontent.com/3165635/147251852-001d3bea-4444-4ad3-8d92-3fbc72f62594.png">

the textbox in the rating popup is missing a text label. But why is this rendered in the DOM in the first place?

So, I'm removing it from the DOM with the prop. It should help with performance, only rendering what's needed.

Second, since this is kind of an obscure trick and I saw people asking about it 1-2 years ago on the issue, and that it's still not in the docs, I added it. https://deploy-preview-30382--material-ui.netlify.app/components/transitions/#performance-amp-seo