### PR TITLE
[website] Improve potentially confusing website component demos

### DIFF
--- a/docs/src/components/showcase/PlayerCard.tsx
+++ b/docs/src/components/showcase/PlayerCard.tsx
@@ -3,12 +3,13 @@ import { ThemeProvider, createTheme, useTheme, Theme } from '@mui/material/style
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import Fade from '@mui/material/Fade';
+import Popover from '@mui/material/Popover';
+import Link from '@mui/material/Link';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import FastForwardRounded from '@mui/icons-material/FastForwardRounded';
 import FastRewindRounded from '@mui/icons-material/FastRewindRounded';
 import PlayArrowRounded from '@mui/icons-material/PlayArrowRounded';
-import PauseRounded from '@mui/icons-material/PauseRounded';
 
 const primaryDark = {
   50: '#E2EDF8',
@@ -24,19 +25,30 @@ const primaryDark = {
 };
 const grey = {
   50: '#F3F6F9',
-  100: '#EAEEF3',
-  200: '#E5E8EC',
-  300: '#D7DCE1',
-  400: '#BFC7CF',
-  500: '#AAB4BE',
-  600: '#96A3B0',
-  700: '#8796A5',
-  800: '#5A6978',
-  900: '#3D4752',
+  100: '#E7EBF0',
+  200: '#E0E3E7',
+  300: '#CDD2D7', // vs blueDark 900: WCAG 11.6 AAA, APCA 78 Best for text
+  400: '#B2BAC2', // vs blueDark 900: WCAG 9 AAA, APCA 63.3 Ok for text
+  500: '#A0AAB4', // vs blueDark 900: WCAG 7.5 AAA, APCA 54.3 Only for large text
+  600: '#6F7E8C', // vs white bg: WCAG 4.1 AA, APCA 68.7 Ok for text
+  700: '#3E5060', // vs white bg: WCAG 8.3 AAA, APCA 88.7 Best for text
+  800: '#2D3843', // vs white bg: WCAG 11.9 AAA, APCA 97.3 Best for text
+  900: '#1A2027',
 };
 
 export default function PlayerCard({ theme: externalTheme }: { theme?: Theme }) {
-  const [paused, setPaused] = React.useState(true);
+  const [anchorEl, setAnchorEl] = React.useState(null);
+
+  const handleClick = (event: any) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : undefined;
   /*
    * Note: this demo use `theme.palette.mode` from `useTheme` to make dark mode works in the documentation only.
    *
@@ -99,6 +111,22 @@ export default function PlayerCard({ theme: externalTheme }: { theme?: Theme }) 
               fontSize: 'small',
             },
           },
+          MuiPopover: {
+            styleOverrides: {
+              paper: {
+                mt: 0.5,
+                minWidth: 160,
+                elevation: 0,
+                color: mode === 'dark' ? grey[100] : grey[900],
+                backgroundImage: 'none',
+                backgroundColor: mode === 'dark' ? grey[900] : '#fff',
+                border: `1px solid ${mode === 'dark' ? grey[800] : grey[200]}`,
+                boxShadow: `0px 4px 20px ${
+                  mode === 'dark' ? 'rgba(0, 0, 0, 0.5)' : 'rgba(170, 180, 190, 0.3)'
+                }`,
+              },
+            },
+          },
         },
       }),
     [mode],
@@ -145,13 +173,36 @@ export default function PlayerCard({ theme: externalTheme }: { theme?: Theme }) 
               <IconButton aria-label="fast rewind" disabled>
                 <FastRewindRounded />
               </IconButton>
-              <IconButton
-                aria-label={paused ? 'play' : 'pause'}
-                sx={{ mx: 2 }}
-                onClick={() => setPaused((val) => !val)}
-              >
-                {paused ? <PlayArrowRounded /> : <PauseRounded />}
+              <IconButton aria-describedby={id} onClick={handleClick} size="small" sx={{ mx: 2 }}>
+                <PlayArrowRounded />
               </IconButton>
+              <Popover
+                id={id}
+                sx={{
+                  mt: 0.5,
+                }}
+                open={open}
+                anchorEl={anchorEl}
+                onClose={handleClose}
+                anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'center',
+                }}
+                transformOrigin={{
+                  vertical: 'top',
+                  horizontal: 'center',
+                }}
+              >
+                <Box sx={{ p: 1, maxWidth: 320 }}>
+                  <Typography variant="body2" fontWeight={500}>
+                    Card component
+                  </Typography>
+                  <Typography sx={{ mt: 0.5, fontSize: 12 }}>
+                    Visit the <Link href="/">Card customization section</Link> to learn how to
+                    customize it so it look lke this.
+                  </Typography>
+                </Box>
+              </Popover>
               <IconButton aria-label="fast forward" disabled>
                 <FastForwardRounded />
               </IconButton>

--- a/docs/src/components/showcase/TaskCard.tsx
+++ b/docs/src/components/showcase/TaskCard.tsx
@@ -1,13 +1,16 @@
 import * as React from 'react';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider, createTheme, useTheme, Theme } from '@mui/material/styles';
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
+import Popover from '@mui/material/Popover';
+import Link from '@mui/material/Link';
+import IconButton from '@mui/material/IconButton';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import Fade from '@mui/material/Fade';
 import LinearProgress from '@mui/material/LinearProgress';
 import Typography from '@mui/material/Typography';
 import CodeRounded from '@mui/icons-material/CodeRounded';
-import ScheduleRounded from '@mui/icons-material/ScheduleRounded';
 
 declare module '@mui/material/Paper' {
   interface PaperPropsVariantOverrides {
@@ -28,57 +31,104 @@ const primary = {
   800: '#004C99',
   900: '#003A75',
 };
+const grey = {
+  50: '#F3F6F9',
+  100: '#E7EBF0',
+  200: '#E0E3E7',
+  300: '#CDD2D7', // vs blueDark 900: WCAG 11.6 AAA, APCA 78 Best for text
+  400: '#B2BAC2', // vs blueDark 900: WCAG 9 AAA, APCA 63.3 Ok for text
+  500: '#A0AAB4', // vs blueDark 900: WCAG 7.5 AAA, APCA 54.3 Only for large text
+  600: '#6F7E8C', // vs white bg: WCAG 4.1 AA, APCA 68.7 Ok for text
+  700: '#3E5060', // vs white bg: WCAG 8.3 AAA, APCA 88.7 Best for text
+  800: '#2D3843', // vs white bg: WCAG 11.9 AAA, APCA 97.3 Best for text
+  900: '#1A2027',
+};
 
-const theme = createTheme({
-  palette: { mode: 'dark', primary },
-  shape: {
-    borderRadius: 10,
-  },
-  spacing: 10,
-  typography: {
-    fontFamily: ['-apple-system', 'BlinkMacSystemFont', 'sans-serif'].join(','),
-    h6: {
-      lineHeight: 1.2,
-      fontWeight: 700,
-    },
-  },
-  components: {
-    MuiPaper: {
-      variants: [
-        {
-          props: { variant: 'gradient' },
-          style: {
-            background: `linear-gradient(to right bottom, ${primary.main}, ${primary[700]} 120%)`,
-            boxShadow: '0px 20px 25px rgba(0, 0, 0, 0.1), 0px 10px 10px rgba(0, 0, 0, 0.04)',
+export default function TaskCard({ theme: externalTheme }: { theme?: Theme }) {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+
+  const handleClick = (event: any) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : undefined;
+
+  const globalTheme = useTheme();
+  const mode = globalTheme.palette.mode;
+  const theme = React.useMemo(
+    () =>
+      createTheme({
+        palette: { mode: 'dark', primary },
+        shape: {
+          borderRadius: 10,
+        },
+        spacing: 10,
+        typography: {
+          fontFamily: ['IBM Plex Sans', '-apple-system', 'BlinkMacSystemFont', 'sans-serif'].join(
+            ',',
+          ),
+          h6: {
+            lineHeight: 1.2,
           },
         },
-      ],
-    },
-    MuiAvatar: {
-      styleOverrides: {
-        root: {
-          border: '1px solid #fff',
+        components: {
+          MuiPaper: {
+            variants: [
+              {
+                props: { variant: 'gradient' },
+                style: {
+                  background: `linear-gradient(to right bottom, ${primary.main}, ${primary[700]} 120%)`,
+                  boxShadow: '0px 20px 25px rgba(0, 0, 0, 0.1), 0px 10px 10px rgba(0, 0, 0, 0.04)',
+                },
+              },
+            ],
+          },
+          MuiAvatar: {
+            styleOverrides: {
+              root: {
+                border: '2px solid #fff',
+              },
+            },
+          },
+          MuiLinearProgress: {
+            styleOverrides: {
+              root: {
+                borderRadius: 10,
+                backgroundColor: primary[500],
+              },
+              bar: {
+                borderRadius: 10,
+                backgroundColor: '#fff',
+              },
+            },
+          },
+          MuiPopover: {
+            styleOverrides: {
+              paper: {
+                mt: 0.5,
+                minWidth: 160,
+                elevation: 0,
+                color: mode === 'dark' ? grey[100] : grey[900],
+                backgroundImage: 'none',
+                backgroundColor: mode === 'dark' ? grey[900] : '#fff',
+                border: `1px solid ${mode === 'dark' ? grey[800] : grey[200]}`,
+                boxShadow: `0px 4px 20px ${
+                  mode === 'dark' ? 'rgba(0, 0, 0, 0.5)' : 'rgba(170, 180, 190, 0.3)'
+                }`,
+              },
+            },
+          },
         },
-      },
-    },
-    MuiLinearProgress: {
-      styleOverrides: {
-        root: {
-          borderRadius: 10,
-          backgroundColor: 'rgba(255,255,255,0.12)',
-        },
-        bar: {
-          borderRadius: 10,
-          backgroundColor: '#fff',
-        },
-      },
-    },
-  },
-});
-
-export default function TaskCard() {
+      }),
+    [mode],
+  );
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={externalTheme || theme}>
       <Fade in timeout={700}>
         <Card
           variant="gradient"
@@ -88,59 +138,89 @@ export default function TaskCard() {
             minHeight: 280,
             display: 'flex',
             flexDirection: 'column',
-            p: 2.5,
+            p: 2,
           }}
         >
-          <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <ScheduleRounded fontSize="inherit" />
-            <Typography
-              color="text.secondary"
-              variant="caption"
-              fontWeight={500}
-              sx={{ ml: 0.5, mt: '1px' }}
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Typography color="primary.100" variant="caption" fontWeight={500} sx={{ mt: 0.3 }}>
+                March 25th
+              </Typography>
+            </Box>
+            <IconButton aria-describedby={id} onClick={handleClick} size="small">
+              <MoreVertIcon fontSize="small" />
+            </IconButton>
+            <Popover
+              id={id}
+              sx={{
+                mt: 0.5,
+              }}
+              open={open}
+              anchorEl={anchorEl}
+              onClose={handleClose}
+              anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'right',
+              }}
+              transformOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
             >
-              March 25th
-            </Typography>
+              <Box sx={{ p: 1, maxWidth: 320 }}>
+                <Typography variant="body2" fontWeight={500}>
+                  Card component
+                </Typography>
+                <Typography sx={{ mt: 0.5, fontSize: 12 }}>
+                  Visit the <Link href="/">Card customization section</Link> to learn how to
+                  customize it so it look lke this.
+                </Typography>
+              </Box>
+            </Popover>
           </Box>
           <Box sx={{ my: 'auto' }}>
             <Box
               sx={{
-                width: 28,
-                height: 28,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 25,
+                height: 25,
                 bgcolor: '#fff',
-                borderRadius: 0.75,
+                borderRadius: 0.5,
                 p: '2px',
               }}
             >
-              <CodeRounded color="primary" />
+              <CodeRounded color="primary" fontSize="small" />
             </Box>
             <Typography variant="h6" component="div" sx={{ mt: 1.5, fontWeight: 500 }}>
               Check the docs for getting every component API
             </Typography>
           </Box>
-          <Box sx={{ display: 'flex' }}>
+          <Box sx={{ display: 'flex', mb: 1 }}>
             <Avatar
               imgProps={{ 'aria-labelledby': 'demo-task-card-assigne-name' }}
               src="/static/images/avatar/1-sm.jpeg"
               variant="rounded"
+              sx={{ mt: 0.4 }}
             />
             <Box sx={{ ml: 1 }}>
-              <Typography variant="body2" color="primary.200" fontWeight={500}>
+              <Typography variant="caption" color="primary.100" fontWeight={400}>
                 Assigned to
               </Typography>
-              <Typography id="demo-task-card-assigne-name" fontWeight={500}>
+              <Typography variant="body2" id="demo-task-card-assigne-name" fontWeight={500}>
                 Michael Scott
               </Typography>
             </Box>
           </Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', mb: -0.5, mt: 0.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: -0.5, mt: 0 }}>
             <LinearProgress
               aria-label="Progress"
               variant="determinate"
               value={60}
-              sx={{ flexGrow: 1 }}
+              sx={{ flexGrow: 1, mt: 0.3 }}
             />
-            <Typography color="#00C8FF" variant="body2" sx={{ ml: 2 }}>
+            <Typography color="primary.200" variant="body2" sx={{ ml: 2 }}>
               <b>60%</b>
             </Typography>
           </Box>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
<!-- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request). -->

A customer - and it seems that others too - sent an email asking how to import the components looking like exactly how the customized demos are available in the homepage's Hero. It hints that it can be confusing that the look and feel of the component demos aren't what comes out of the box.

This pull request is a proposal to ease this confusion. Every component on the homepage's Hero has an interactive item. The idea is that when clicking at them, a popover is shown stating that the version they're looking at is a customized one. It also links to that component section with the customized example. I have noticed that some components already have a _Customization_ example on their doc page but others don't. I figure that if we have a customized version of the component available on the website, on the docs, the example should be the same, for consistency.

For now, I have only made this on the card and player-card component to start, as an example for overall discussion about the idea. 