### PR TITLE
[docs] Fix text from `material-ui` to `@mui` to reflect v5 name changes

### DIFF
--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -12,7 +12,7 @@ Combined with [dangerJS](https://danger.systems/js/) we can inspect
 ## When and how to use tree-shaking?
 
 Tree-shaking of MUI works out of the box in modern frameworks.
-MUI exposes its full API on the top-level `material-ui` import.
+MUI exposes its full API on the top-level `@mui` imports.
 If you're using ES6 modules and a bundler that supports tree-shaking ([`webpack` >= 2.x](https://webpack.js.org/guides/tree-shaking/), [`parcel` with a flag](https://en.parceljs.org/cli.html#enable-experimental-scope-hoisting/tree-shaking-support)) you can safely use named imports and still get an optimized bundle size automatically:
 
 ```js


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
