### PR TITLE
[docs] Inform about specific files for DataGrid locales

### DIFF
--- a/docs/src/pages/guides/localization/Locales.js
+++ b/docs/src/pages/guides/localization/Locales.js
@@ -10,7 +10,12 @@ export default function Locales() {
   const [locale, setLocale] = React.useState('zhCN');
 
   const theme = useTheme();
-  const themeWithLocale = createTheme(theme, locales[locale]);
+
+  const themeWithLocale = React.useMemo(
+    () => createTheme(theme, locales[locale]),
+    [locale, theme],
+  );
+
   return (
     <Box sx={{ width: '100%' }}>
       <ThemeProvider theme={themeWithLocale}>

--- a/docs/src/pages/guides/localization/Locales.js
+++ b/docs/src/pages/guides/localization/Locales.js
@@ -3,17 +3,17 @@ import TablePagination from '@mui/material/TablePagination';
 import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { createTheme, ThemeProvider, useTheme } from '@mui/material/styles';
 import * as locales from '@mui/material/locale';
 
 export default function Locales() {
   const [locale, setLocale] = React.useState('zhCN');
 
+  const theme = useTheme();
+  const themeWithLocale = createTheme(theme, locales[locale]);
   return (
     <Box sx={{ width: '100%' }}>
-      <ThemeProvider
-        theme={(outerTheme) => createTheme(outerTheme, locales[locale])}
-      >
+      <ThemeProvider theme={themeWithLocale}>
         <Autocomplete
           options={Object.keys(locales)}
           getOptionLabel={(key) => `${key.substring(0, 2)}-${key.substring(2, 4)}`}

--- a/docs/src/pages/guides/localization/Locales.tsx
+++ b/docs/src/pages/guides/localization/Locales.tsx
@@ -3,7 +3,7 @@ import TablePagination from '@mui/material/TablePagination';
 import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { createTheme, ThemeProvider, useTheme } from '@mui/material/styles';
 import * as locales from '@mui/material/locale';
 
 type SupportedLocales = keyof typeof locales;
@@ -11,10 +11,12 @@ type SupportedLocales = keyof typeof locales;
 export default function Locales() {
   const [locale, setLocale] = React.useState<SupportedLocales>('zhCN');
 
+  const theme = useTheme()
+  const themeWithLocale = createTheme(theme, locales[locale])
   return (
     <Box sx={{ width: '100%' }}>
       <ThemeProvider
-        theme={(outerTheme) => createTheme(outerTheme, locales[locale])}
+        theme={themeWithLocale}
       >
         <Autocomplete
           options={Object.keys(locales)}
@@ -34,7 +36,7 @@ export default function Locales() {
           rowsPerPage={10}
           page={1}
           component="div"
-          onPageChange={() => {}}
+          onPageChange={() => { }}
         />
       </ThemeProvider>
     </Box>

--- a/docs/src/pages/guides/localization/Locales.tsx
+++ b/docs/src/pages/guides/localization/Locales.tsx
@@ -11,13 +11,16 @@ type SupportedLocales = keyof typeof locales;
 export default function Locales() {
   const [locale, setLocale] = React.useState<SupportedLocales>('zhCN');
 
-  const theme = useTheme()
-  const themeWithLocale = createTheme(theme, locales[locale])
+  const theme = useTheme();
+
+  const themeWithLocale = React.useMemo(
+    () => createTheme(theme, locales[locale]),
+    [locale, theme],
+  );
+
   return (
     <Box sx={{ width: '100%' }}>
-      <ThemeProvider
-        theme={themeWithLocale}
-      >
+      <ThemeProvider theme={themeWithLocale}>
         <Autocomplete
           options={Object.keys(locales)}
           getOptionLabel={(key) => `${key.substring(0, 2)}-${key.substring(2, 4)}`}
@@ -36,7 +39,7 @@ export default function Locales() {
           rowsPerPage={10}
           page={1}
           component="div"
-          onPageChange={() => { }}
+          onPageChange={() => {}}
         />
       </ThemeProvider>
     </Box>

--- a/docs/src/pages/guides/localization/localization.md
+++ b/docs/src/pages/guides/localization/localization.md
@@ -28,7 +28,9 @@ const theme = createTheme(
 
 ### Example
 
-{{"demo": "pages/guides/localization/Locales.js", "defaultCodeOpen": false}}
+{{"demo": "pages/guides/localization/Locales.js", "hideToolbar": true}}
+
+> ⚠️ The `DataGrid` and `DataGridPro` components have their own locale files. To use them see the documentation about [localization for DataGrid](/components/data-grid/localization/).
 
 ### Supported locales
 

--- a/docs/src/pages/guides/localization/localization.md
+++ b/docs/src/pages/guides/localization/localization.md
@@ -28,9 +28,9 @@ const theme = createTheme(
 
 ### Example
 
-{{"demo": "pages/guides/localization/Locales.js", "hideToolbar": true}}
+{{"demo": "pages/guides/localization/Locales.js"}}
 
-> ⚠️ The `DataGrid` and `DataGridPro` components have their own locale files. To use them see the documentation about [localization for DataGrid](/components/data-grid/localization/).
+> ⚠️ For [`DataGrid` and `DataGridPro`](/components/data-grid/) components, they have their own [localization](/components/data-grid/localization/).
 
 ### Supported locales
 


### PR DESCRIPTION
Fix https://github.com/mui-org/material-ui-x/issues/3514

It is not clear that when using the DataGrid component locales must be imported from the DataGrid package.

Also the codesandbox did not work because the following line is using `outerTheme` to know if the documentation is in light or dark mode.
```js
theme={(outerTheme) => createTheme(outerTheme, locales[locale])}
```

But the codeSandbox, does not declareanother them, so `outerTheme` is not defined, leading to a bug.

I removed the demo toolbar because there is an example on top of the demo