### PR TITLE
Fix faulty property `checked` as `value`

### DIFF
--- a/docs/src/pages/components/checkboxes/checkboxes.md
+++ b/docs/src/pages/components/checkboxes/checkboxes.md
@@ -44,7 +44,7 @@ Use the `size` prop or customize the font size of the svg icons to change the si
 
 ## Controlled
 
-You can control the checkbox with the `checked` and `onChange` props:
+You can control the checkbox with the `value` and `onChange` props:
 
 {{"demo": "pages/components/checkboxes/ControlledCheckbox.js"}}
 


### PR DESCRIPTION
Controlled component should indicate `value` instead of `checked`. An uncontrolled checkbox component uses `checked ` property as a value.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
