### PR TITLE
[Badge] Fix `classes` prop TypeScript type

### DIFF
--- a/packages/mui-material/src/Badge/Badge.d.ts
+++ b/packages/mui-material/src/Badge/Badge.d.ts
@@ -31,25 +31,25 @@ export type BadgeTypeMap<
       /** Styles applied to the badge `span` element if `color="warning"`. */
       colorWarning?: string;
       /** Class name applied to the badge `span` element if `anchorOrigin={{ 'top', 'right' }} overlap="rectangular"`. */
-      anchorOriginTopRightRectangular: string;
+      anchorOriginTopRightRectangular?: string;
       /** Class name applied to the badge `span` element if `anchorOrigin={{ 'bottom', 'right' }} overlap="rectangular"`. */
-      anchorOriginBottomRightRectangular: string;
+      anchorOriginBottomRightRectangular?: string;
       /** Class name applied to the badge `span` element if `anchorOrigin={{ 'top', 'left' }} overlap="rectangular"`. */
-      anchorOriginTopLeftRectangular: string;
+      anchorOriginTopLeftRectangular?: string;
       /** Class name applied to the badge `span` element if `anchorOrigin={{ 'bottom', 'left' }} overlap="rectangular"`. */
-      anchorOriginBottomLeftRectangular: string;
+      anchorOriginBottomLeftRectangular?: string;
       /** Class name applied to the badge `span` element if `anchorOrigin={{ 'top', 'right' }} overlap="circular"`. */
-      anchorOriginTopRightCircular: string;
+      anchorOriginTopRightCircular?: string;
       /** Class name applied to the badge `span` element if `anchorOrigin={{ 'bottom', 'right' }} overlap="circular"`. */
-      anchorOriginBottomRightCircular: string;
+      anchorOriginBottomRightCircular?: string;
       /** Class name applied to the badge `span` element if `anchorOrigin={{ 'top', 'left' }} overlap="circular"`. */
-      anchorOriginTopLeftCircular: string;
+      anchorOriginTopLeftCircular?: string;
       /** Class name applied to the badge `span` element if `anchorOrigin={{ 'bottom', 'left' }} overlap="circular"`. */
-      anchorOriginBottomLeftCircular: string;
+      anchorOriginBottomLeftCircular?: string;
       /** Class name applied to the badge `span` element if `overlap="rectangular"`. */
-      overlapRectangular: string;
+      overlapRectangular?: string;
       /** Class name applied to the badge `span` element if `overlap="circular"`. */
-      overlapCircular: string;
+      overlapCircular?: string;
     };
     /**
      * The color of the component. It supports those theme colors that make sense for this component.

--- a/packages/mui-material/src/Badge/Badge.spec.tsx
+++ b/packages/mui-material/src/Badge/Badge.spec.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { Badge } from '@mui/material';
+
+function classesTest() {
+  return (
+    <Badge badgeContent={4} classes={{ badge: 'testBadgeClassName' }}>
+      <div>Hello World</div>
+    </Badge>
+  );
+}

--- a/packages/mui-material/src/Badge/Badge.spec.tsx
+++ b/packages/mui-material/src/Badge/Badge.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Badge } from '@mui/material';
+import Badge from '@mui/material/Badge';
 
 function classesTest() {
   return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #30419 

Missed in #30246 that old classes should be marked optional when moved from `badgeUnstyledClasses` to `Badge.d.ts`. 