### PR TITLE
[@mui/material, createPalette] `getContrastText` does not take into consideration your custom palette

### DIFF
--- a/packages/mui-material/src/styles/createPalette.js
+++ b/packages/mui-material/src/styles/createPalette.js
@@ -192,8 +192,6 @@ export default function createPalette(palette) {
     info = getDefaultInfo(mode),
     success = getDefaultSuccess(mode),
     warning = getDefaultWarning(mode),
-    text,
-    type,
     ...customPalettes
   } = other;
 
@@ -275,12 +273,25 @@ export default function createPalette(palette) {
     }
   }
 
-  // Augment Colors of customPalettes
+  // Augment Colors of custom Palettes only. Ignore other elements in object like background
+  const ignoreKeys = [
+    'common',
+    'grey',
+    'getContrastText',
+    'augmentColor',
+    'text',
+    'type',
+    'divider',
+    'background',
+    'action',
+  ];
   Object.keys(customPalettes).forEach((customPalette) => {
-    customPalettes[customPalette] = augmentColor({
-      color: customPalettes[customPalette],
-      name: customPalette,
-    });
+    if (ignoreKeys.findIndex((key) => key === customPalette) < 0) {
+      customPalettes[customPalette] = augmentColor({
+        color: customPalettes[customPalette],
+        name: customPalette,
+      });
+    }
   });
 
   const paletteOutput = deepmerge(

--- a/packages/mui-material/src/styles/createPalette.js
+++ b/packages/mui-material/src/styles/createPalette.js
@@ -185,8 +185,7 @@ export default function createPalette(palette) {
   const { mode = 'light', contrastThreshold = 3, tonalOffset = 0.2, ...other } = palette;
 
   // seperate custom palettes from the rest
-  const { primary, secondary, error, info, success, warning, text, type, ...customPalettes } =
-    other;
+  var { primary, secondary, error, info, success, warning, text, type, ...customPalettes } = other;
 
   primary = primary || getDefaultPrimary(mode);
   secondary = secondary || getDefaultSecondary(mode);

--- a/packages/mui-material/src/styles/createPalette.js
+++ b/packages/mui-material/src/styles/createPalette.js
@@ -184,6 +184,13 @@ function getDefaultWarning(mode = 'light') {
 export default function createPalette(palette) {
   const { mode = 'light', contrastThreshold = 3, tonalOffset = 0.2, ...other } = palette;
 
+  // seperate custom palettes from the rest
+  const defaultPalettes = ['primary', 'secondary', 'error', 'info', 'success', 'warning'];
+  const customPalettes = _objectWithoutPropertiesLoose(
+    other,
+    defaultPalettes.concat(['text', 'type']),
+  );
+
   const primary = palette.primary || getDefaultPrimary(mode);
   const secondary = palette.secondary || getDefaultSecondary(mode);
   const error = palette.error || getDefaultError(mode);
@@ -269,6 +276,14 @@ export default function createPalette(palette) {
     }
   }
 
+  // Augment Colors of customPalettes
+  Object.keys(customPalettes).forEach((palette) => {
+    customPalettes[palette] = augmentColor({
+      color: customPalettes[palette],
+      name: palette,
+    });
+  });
+
   const paletteOutput = deepmerge(
     {
       // A collection of common colors.
@@ -309,6 +324,7 @@ export default function createPalette(palette) {
       // The light and dark mode object.
       ...modes[mode],
     },
+    customPalettes,
     other,
   );
 

--- a/packages/mui-material/src/styles/createPalette.js
+++ b/packages/mui-material/src/styles/createPalette.js
@@ -1,3 +1,4 @@
+import _objectWithoutPropertiesLoose from '@babel/runtime/helpers/esm/objectWithoutPropertiesLoose';
 import { deepmerge } from '@mui/utils';
 import MuiError from '@mui/utils/macros/MuiError.macro';
 import { darken, getContrastRatio, lighten } from '@mui/system';
@@ -185,14 +186,18 @@ export default function createPalette(palette) {
   const { mode = 'light', contrastThreshold = 3, tonalOffset = 0.2, ...other } = palette;
 
   // seperate custom palettes from the rest
-  var { primary, secondary, error, info, success, warning, text, type, ...customPalettes } = other;
+  const defaultPalettes = ['primary', 'secondary', 'error', 'info', 'success', 'warning'];
+  const customPalettes = _objectWithoutPropertiesLoose(
+    other,
+    defaultPalettes.concat(['text', 'type']),
+  );
 
-  primary = primary || getDefaultPrimary(mode);
-  secondary = secondary || getDefaultSecondary(mode);
-  error = error || getDefaultError(mode);
-  info = info || getDefaultInfo(mode);
-  success = success || getDefaultSuccess(mode);
-  warning = warning || getDefaultWarning(mode);
+  const primary = palette.primary || getDefaultPrimary(mode);
+  const secondary = palette.secondary || getDefaultSecondary(mode);
+  const error = palette.error || getDefaultError(mode);
+  const info = palette.info || getDefaultInfo(mode);
+  const success = palette.success || getDefaultSuccess(mode);
+  const warning = palette.warning || getDefaultWarning(mode);
 
   // Use the same logic as
   // Bootstrap: https://github.com/twbs/bootstrap/blob/1d6e3710dd447de1a200f29e8fa521f8a0908f70/scss/_functions.scss#L59
@@ -273,10 +278,10 @@ export default function createPalette(palette) {
   }
 
   // Augment Colors of customPalettes
-  Object.keys(customPalettes).forEach((palette) => {
-    customPalettes[palette] = augmentColor({
-      color: customPalettes[palette],
-      name: palette,
+  Object.keys(customPalettes).forEach((customPalette) => {
+    customPalettes[customPalette] = augmentColor({
+      color: customPalettes[customPalette],
+      name: customPalette,
     });
   });
 

--- a/packages/mui-material/src/styles/createPalette.js
+++ b/packages/mui-material/src/styles/createPalette.js
@@ -1,4 +1,4 @@
-import _objectWithoutPropertiesLoose from '@babel/runtime/helpers/esm/objectWithoutPropertiesLoose';
+import { _objectWithoutPropertiesLoose } from '@babel/runtime/helpers/esm/objectWithoutPropertiesLoose';
 import { deepmerge } from '@mui/utils';
 import MuiError from '@mui/utils/macros/MuiError.macro';
 import { darken, getContrastRatio, lighten } from '@mui/system';

--- a/packages/mui-material/src/styles/createPalette.js
+++ b/packages/mui-material/src/styles/createPalette.js
@@ -185,8 +185,9 @@ export default function createPalette(palette) {
   const { mode = 'light', contrastThreshold = 3, tonalOffset = 0.2, ...other } = palette;
 
   // seperate custom palettes from the rest
-  const { primary, secondary, error, info, success, warning, text, type, ...customPalettes } = other
- 
+  const { primary, secondary, error, info, success, warning, text, type, ...customPalettes } =
+    other;
+
   primary = primary || getDefaultPrimary(mode);
   secondary = secondary || getDefaultSecondary(mode);
   error = error || getDefaultError(mode);

--- a/packages/mui-material/src/styles/createPalette.js
+++ b/packages/mui-material/src/styles/createPalette.js
@@ -185,18 +185,14 @@ export default function createPalette(palette) {
   const { mode = 'light', contrastThreshold = 3, tonalOffset = 0.2, ...other } = palette;
 
   // seperate custom palettes from the rest
-  const defaultPalettes = ['primary', 'secondary', 'error', 'info', 'success', 'warning'];
-  const customPalettes = _objectWithoutPropertiesLoose(
-    other,
-    defaultPalettes.concat(['text', 'type']),
-  );
-
-  const primary = palette.primary || getDefaultPrimary(mode);
-  const secondary = palette.secondary || getDefaultSecondary(mode);
-  const error = palette.error || getDefaultError(mode);
-  const info = palette.info || getDefaultInfo(mode);
-  const success = palette.success || getDefaultSuccess(mode);
-  const warning = palette.warning || getDefaultWarning(mode);
+  const { primary, secondary, error, info, success, warning, text, type, ...customPalettes } = other
+ 
+  primary = primary || getDefaultPrimary(mode);
+  secondary = secondary || getDefaultSecondary(mode);
+  error = error || getDefaultError(mode);
+  info = info || getDefaultInfo(mode);
+  success = success || getDefaultSuccess(mode);
+  warning = warning || getDefaultWarning(mode);
 
   // Use the same logic as
   // Bootstrap: https://github.com/twbs/bootstrap/blob/1d6e3710dd447de1a200f29e8fa521f8a0908f70/scss/_functions.scss#L59

--- a/packages/mui-material/src/styles/createPalette.js
+++ b/packages/mui-material/src/styles/createPalette.js
@@ -1,4 +1,3 @@
-import { _objectWithoutPropertiesLoose } from '@babel/runtime/helpers/esm/objectWithoutPropertiesLoose';
 import { deepmerge } from '@mui/utils';
 import MuiError from '@mui/utils/macros/MuiError.macro';
 import { darken, getContrastRatio, lighten } from '@mui/system';
@@ -185,19 +184,18 @@ function getDefaultWarning(mode = 'light') {
 export default function createPalette(palette) {
   const { mode = 'light', contrastThreshold = 3, tonalOffset = 0.2, ...other } = palette;
 
-  // seperate custom palettes from the rest
-  const defaultPalettes = ['primary', 'secondary', 'error', 'info', 'success', 'warning'];
-  const customPalettes = _objectWithoutPropertiesLoose(
-    other,
-    defaultPalettes.concat(['text', 'type']),
-  );
-
-  const primary = palette.primary || getDefaultPrimary(mode);
-  const secondary = palette.secondary || getDefaultSecondary(mode);
-  const error = palette.error || getDefaultError(mode);
-  const info = palette.info || getDefaultInfo(mode);
-  const success = palette.success || getDefaultSuccess(mode);
-  const warning = palette.warning || getDefaultWarning(mode);
+  // get default and custom palettes
+  const {
+    primary = getDefaultPrimary(mode),
+    secondary = getDefaultSecondary(mode),
+    error = getDefaultError(mode),
+    info = getDefaultInfo(mode),
+    success = getDefaultSuccess(mode),
+    warning = getDefaultWarning(mode),
+    text,
+    type,
+    ...customPalettes
+  } = other;
 
   // Use the same logic as
   // Bootstrap: https://github.com/twbs/bootstrap/blob/1d6e3710dd447de1a200f29e8fa521f8a0908f70/scss/_functions.scss#L59


### PR DESCRIPTION
When creating a custom palette without specifying the contrastText and then using it for example with the MuiChip Component
a error `color is not defined` will be thrown by the `<MuiChipRoot>` Component.

That is because only the default palettes will be handled by the `getContrastText()` function inside `createPalette.js`
So I made the custom palettes go through the same procedure as the default ones.
Therefore `contrastText` will be determined and defined automatically.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #29730