### PR TITLE
[system][Box, Grid, Typography] `textTransform` prop should work directly on component

### DIFF
--- a/docs/src/pages/system/typography/TextTransform.js
+++ b/docs/src/pages/system/typography/TextTransform.js
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+
+export default function TextTransform() {
+  return (
+    <Typography component="div">
+      <Box sx={{ textTransform: 'capitalize', m: 1 }}>capitalized text.</Box>
+      <Box sx={{ textTransform: 'lowercase', m: 1 }}>Lowercase Text.</Box>
+      <Box sx={{ textTransform: 'uppercase', m: 1 }}>Uppercase Text.</Box>
+    </Typography>
+  );
+}

--- a/docs/src/pages/system/typography/TextTransform.tsx
+++ b/docs/src/pages/system/typography/TextTransform.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+
+export default function TextTransform() {
+  return (
+    <Typography component="div">
+      <Box sx={{ textTransform: 'capitalize', m: 1 }}>capitalized text.</Box>
+      <Box sx={{ textTransform: 'lowercase', m: 1 }}>Lowercase Text.</Box>
+      <Box sx={{ textTransform: 'uppercase', m: 1 }}>Uppercase Text.</Box>
+    </Typography>
+  );
+}

--- a/docs/src/pages/system/typography/TextTransform.tsx.preview
+++ b/docs/src/pages/system/typography/TextTransform.tsx.preview
@@ -1,0 +1,5 @@
+<Typography component="div">
+  <Box sx={{ textTransform: 'capitalize', m: 1 }}>capitalized text.</Box>
+  <Box sx={{ textTransform: 'lowercase', m: 1 }}>Lowercase Text.</Box>
+  <Box sx={{ textTransform: 'uppercase', m: 1 }}>Uppercase Text.</Box>
+</Typography>

--- a/docs/src/pages/system/typography/typography.md
+++ b/docs/src/pages/system/typography/typography.md
@@ -22,6 +22,16 @@
 <Box sx={{ textAlign: 'right' }}>…
 ```
 
+## Text transformation
+
+{{"demo": "pages/system/typography/TextTransform.js", "defaultCodeOpen": false}}
+
+```jsx
+<Box sx={{ textTransform: 'capitalize' }}>…
+<Box sx={{ textTransform: 'lowercase' }}>…
+<Box sx={{ textTransform: 'uppercase' }}>…
+```
+
 ## Font weight
 
 {{"demo": "pages/system/typography/FontWeight.js", "defaultCodeOpen": false}}
@@ -97,3 +107,4 @@ import { typography } from '@mui/system';
 | `letterSpacing` | `letterSpacing` | `letter-spacing`                                                                             | none                                                                   |
 | `lineHeight`    | `lineHeight`    | `line-height`                                                                                | none                                                                   |
 | `textAlign`     | `textAlign`     | `text-align`                                                                                 | none                                                                   |
+| `textTransform` | `textTransform` | `text-transform`                                                                             | none                                                                   |

--- a/packages/mui-system/src/Box/Box.d.ts
+++ b/packages/mui-system/src/Box/Box.d.ts
@@ -123,6 +123,7 @@ export const typography: SimpleStyleFunction<
   | 'letterSpacing'
   | 'lineHeight'
   | 'textAlign'
+  | 'textTransform'
 >;
 
 // compose.js

--- a/packages/mui-system/src/index.d.ts
+++ b/packages/mui-system/src/index.d.ts
@@ -88,6 +88,7 @@ export const fontWeight: SimpleStyleFunction<'fontWeight'>;
 export const letterSpacing: SimpleStyleFunction<'letterSpacing'>;
 export const lineHeight: SimpleStyleFunction<'lineHeight'>;
 export const textAlign: SimpleStyleFunction<'textAlign'>;
+export const textTransform: SimpleStyleFunction<'textTransform'>;
 export type TypographyProps = PropsFor<typeof typography>;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/mui-system/src/typography.js
+++ b/packages/mui-system/src/typography.js
@@ -25,6 +25,10 @@ export const letterSpacing = style({
   prop: 'letterSpacing',
 });
 
+export const textTransform = style({
+  prop: 'textTransform',
+});
+
 export const lineHeight = style({
   prop: 'lineHeight',
 });
@@ -48,6 +52,7 @@ const typography = compose(
   letterSpacing,
   lineHeight,
   textAlign,
+  textTransform,
 );
 
 export default typography;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #30435

Issue:
- `Typography`, `Grid` and `Box` mentions on their docs that they support "all system properties" and that developers can "use them as props directly on the component."
- However, using `textTransform` directly as a prop throws a typescript error and doesn't work in effect as well
- [code sandbox](https://codesandbox.io/s/cocky-mayer-intql?file=/src/Demo.tsx:371-372)

After:
- [code sandbox](https://codesandbox.io/s/kind-poincare-8kwj7?file=/src/Demo.tsx)