### PR TITLE
[l10n] Improve fiFI locale

### DIFF
--- a/packages/mui-material/src/locale/index.ts
+++ b/packages/mui-material/src/locale/index.ts
@@ -1131,8 +1131,8 @@ export const fiFI: Localization = {
           return 'Mene edelliselle sivulle';
         },
         labelRowsPerPage: 'Rivejä per sivu:',
-        // labelDisplayedRows: ({ from, to, count }) =>
-        //   `${from}–${to} / ${count !== -1 ? count : `more than ${to}`}`,
+        labelDisplayedRows: ({ from, to, count }) =>
+          `${from}–${to} / ${count !== -1 ? count : `enemmän kuin ${to}`}`,
       },
     },
     MuiRating: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Originally, I was planning to only include one option but upon seeing how the change would look in an actual table I came up with two possible solutions since the Finnish language does not have a similar word as "of" in English:

* First (currently in the PR and more line with rest of the languages' style):
<img width="446" alt="image" src="https://user-images.githubusercontent.com/16798635/147675653-5ab67413-f17f-405b-8770-2782cc90dc99.png">

* Second (aesthetically more pleasing since at no other positions of the string are words used):
<img width="360" alt="image" src="https://user-images.githubusercontent.com/16798635/147675749-97315471-0c49-4fb5-a081-c19005dc27e0.png">

Any comments and/or discussion regarding the topic is welcome.
