### PR TITLE
[docs] Fix `useMediaQuery` SSR example to v5 theme API

### DIFF
--- a/docs/src/pages/components/use-media-query/use-media-query.md
+++ b/docs/src/pages/components/use-media-query/use-media-query.md
@@ -144,7 +144,7 @@ For instance on the server-side:
 import ReactDOMServer from 'react-dom/server';
 import parser from 'ua-parser-js';
 import mediaQuery from 'css-mediaquery';
-import { ThemeProvider } from '@mui/material/styles';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 function handleRender(req, res) {
   const deviceType = parser(req.headers['user-agent']).device.type || 'desktop';
@@ -154,18 +154,20 @@ function handleRender(req, res) {
       width: deviceType === 'mobile' ? '0px' : '1024px',
     }),
   });
+  
+  const theme = createTheme({
+    components: {
+      // Change the default options of useMediaQuery
+      MuiUseMediaQuery: {
+        defaultProps: {
+          ssrMatchMedia,
+        },
+      },
+    },
+  });
 
   const html = ReactDOMServer.renderToString(
-    <ThemeProvider
-      theme={{
-        props: {
-          // Change the default options of useMediaQuery
-          MuiUseMediaQuery: {
-            ssrMatchMedia,
-          },
-        },
-      }}
-    >
+    <ThemeProvider theme={theme}>
       <App />
     </ThemeProvider>,
   );

--- a/docs/src/pages/components/use-media-query/use-media-query.md
+++ b/docs/src/pages/components/use-media-query/use-media-query.md
@@ -154,7 +154,7 @@ function handleRender(req, res) {
       width: deviceType === 'mobile' ? '0px' : '1024px',
     }),
   });
-  
+
   const theme = createTheme({
     components: {
       // Change the default options of useMediaQuery


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I tried following the example and the `ssrMatchMedia` was never used. I think the current example is still using v4 implementation. I updated it to the new Theme structure of v5.

https://deploy-preview-30454--material-ui.netlify.app/components/use-media-query/#server-side-rendering