### PR TITLE
[docs] Make the reference to the select clearer

### DIFF
--- a/docs/src/pages/components/radio-buttons/radio-buttons.md
+++ b/docs/src/pages/components/radio-buttons/radio-buttons.md
@@ -11,7 +11,7 @@ waiAria: https://www.w3.org/TR/wai-aria-practices/#radiobutton
 <p class="description">Radio buttons allow the user to select one option from a set.</p>
 
 Use radio buttons when the user needs to see all available options.
-If available options can be collapsed, consider using a dropdown menu because it uses less space.
+If available options can be collapsed, consider using a [Select component](/components/selects/) because it uses less space.
 
 Radio buttons should have the most commonly used option selected by default.
 


### PR DESCRIPTION
we should suggest not a generic 'dropdown menu' to the user but rather a Select component, which is the same thing, but in the MUI world (where the user is and most likely wishes to stay)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
