### PR TITLE
[TextField][InputLabel] Remove `pointer-events: none` property

### DIFF
--- a/docs/src/pages/premium-themes/onepirate/modules/components/TextField.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/components/TextField.js
@@ -124,6 +124,7 @@ TextField.propTypes = {
   classes: PropTypes.object.isRequired,
   /**
    * Props applied to the [`InputLabel`](/api/input-label/) element.
+   * Pointer events like `onClick` are enabled if and only if `shrink` is `true`.
    */
   InputLabelProps: PropTypes.object,
   /**

--- a/docs/translations/api-docs/text-field/text-field.json
+++ b/docs/translations/api-docs/text-field/text-field.json
@@ -12,7 +12,7 @@
     "fullWidth": "If <code>true</code>, the input will take up the full width of its container.",
     "helperText": "The helper text content.",
     "id": "The id of the <code>input</code> element. Use this prop to make <code>label</code> and <code>helperText</code> accessible for screen readers.",
-    "InputLabelProps": "Props applied to the <a href=\"/api/input-label/\"><code>InputLabel</code></a> element.",
+    "InputLabelProps": "Props applied to the <a href=\"/api/input-label/\"><code>InputLabel</code></a> element. Pointer events like <code>onClick</code> are enabled if and only if <code>shrink</code> is <code>true</code>.",
     "inputProps": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>input</code> element.",
     "InputProps": "Props applied to the Input element. It will be a <a href=\"/api/filled-input/\"><code>FilledInput</code></a>, <a href=\"/api/outlined-input/\"><code>OutlinedInput</code></a> or <a href=\"/api/input/\"><code>Input</code></a> component depending on the <code>variant</code> prop value.",
     "inputRef": "Pass a ref to the <code>input</code> element.",

--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -81,12 +81,15 @@ const InputLabelRoot = styled(FormLabel, {
     // the input field is drawn last and hides the label with an opaque background color.
     // zIndex: 1 will raise the label above opaque background-colors of input.
     zIndex: 1,
+    pointerEvents: 'none',
     transform: 'translate(12px, 16px) scale(1)',
     maxWidth: 'calc(100% - 24px)',
     ...(ownerState.size === 'small' && {
       transform: 'translate(12px, 13px) scale(1)',
     }),
     ...(ownerState.shrink && {
+      userSelect: 'none',
+      pointerEvents: 'auto',
       transform: 'translate(12px, 7px) scale(0.75)',
       maxWidth: 'calc(133% - 24px)',
       ...(ownerState.size === 'small' && {
@@ -97,12 +100,15 @@ const InputLabelRoot = styled(FormLabel, {
   ...(ownerState.variant === 'outlined' && {
     // see comment above on filled.zIndex
     zIndex: 1,
+    pointerEvents: 'none',
     transform: 'translate(14px, 16px) scale(1)',
     maxWidth: 'calc(100% - 24px)',
     ...(ownerState.size === 'small' && {
       transform: 'translate(14px, 9px) scale(1)',
     }),
     ...(ownerState.shrink && {
+      userSelect: 'none',
+      pointerEvents: 'auto',
       maxWidth: 'calc(133% - 24px)',
       transform: 'translate(14px, -9px) scale(0.75)',
     }),

--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -81,7 +81,6 @@ const InputLabelRoot = styled(FormLabel, {
     // the input field is drawn last and hides the label with an opaque background color.
     // zIndex: 1 will raise the label above opaque background-colors of input.
     zIndex: 1,
-    pointerEvents: 'none',
     transform: 'translate(12px, 16px) scale(1)',
     maxWidth: 'calc(100% - 24px)',
     ...(ownerState.size === 'small' && {
@@ -98,7 +97,6 @@ const InputLabelRoot = styled(FormLabel, {
   ...(ownerState.variant === 'outlined' && {
     // see comment above on filled.zIndex
     zIndex: 1,
-    pointerEvents: 'none',
     transform: 'translate(14px, 16px) scale(1)',
     maxWidth: 'calc(100% - 24px)',
     ...(ownerState.size === 'small' && {

--- a/packages/mui-material/src/TextField/TextField.d.ts
+++ b/packages/mui-material/src/TextField/TextField.d.ts
@@ -83,6 +83,7 @@ export interface BaseTextFieldProps
   id?: string;
   /**
    * Props applied to the [`InputLabel`](/api/input-label/) element.
+   * Pointer events like `onClick` are enabled if and only if `shrink` is `true`.
    */
   InputLabelProps?: Partial<InputLabelProps>;
   /**

--- a/packages/mui-material/src/TextField/TextField.js
+++ b/packages/mui-material/src/TextField/TextField.js
@@ -288,6 +288,7 @@ TextField.propTypes /* remove-proptypes */ = {
   id: PropTypes.string,
   /**
    * Props applied to the [`InputLabel`](/api/input-label/) element.
+   * Pointer events like `onClick` are enabled if and only if `shrink` is `true`.
    */
   InputLabelProps: PropTypes.object,
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #30488

Issue:
- When using `TextField` and its `InputLabelProps` prop, which is passed to `InputLabel` component, event handlers (e.g., `onClick`, `onFocus`) passed to `InputLabelProps` don't work.
- [Code sandbox](https://codesandbox.io/s/formpropstextfields-material-demo-forked-nfoke)

Soluition:
- This is a regression from #13040 that was created to fix [an old issue](https://github.com/mui-org/material-ui/issues/12997).
- Simply removing `pointer-events: none` will fix the current issue.
- With our current implementation, even with the removal of `pointer-events: none`, [the old issue](https://github.com/mui-org/material-ui/issues/12997) no longer appears. [Proof](https://codesandbox.io/s/formpropstextfields-material-demo-forked-4b9vr?file=/demo.tsx)
- [Code sandbox](https://codesandbox.io/s/formpropstextfields-material-demo-forked-d85y4?file=/demo.tsx)
