### PR TITLE
[docs] Update markdown parser to remove backticks from description

### DIFF
--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -88,7 +88,7 @@ function getDescription(markdown) {
     return undefined;
   }
 
-  return matches[1].trim();
+  return matches[1].trim().replace(/`/g, '');
 }
 
 /**

--- a/docs/packages/markdown/parseMarkdown.test.js
+++ b/docs/packages/markdown/parseMarkdown.test.js
@@ -31,6 +31,16 @@ describe('parseMarkdown', () => {
       ).to.equal('Some description');
     });
 
+    it('remove backticks', () => {
+      expect(
+        getDescription(`
+<p class="description">
+  Some \`description\`
+</p>
+      `),
+      ).to.equal('Some description');
+    });
+
     it('should not be greedy', () => {
       expect(
         getDescription(`

--- a/docs/src/pages/customization/theme-components/theme-components.md
+++ b/docs/src/pages/customization/theme-components/theme-components.md
@@ -1,6 +1,6 @@
 # Components
 
-<p class="description">The theme's `components` key allows you to customize a component without wrapping it in another component. You can change the styles, the default props, and more.</p>
+<p class="description">The theme's components key allows you to customize a component without wrapping it in another component. You can change the styles, the default props, and more.</p>
 
 ## Global style overrides
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

On https://mui.com/customization/theme-components/ the page description element (which is `<p class="description">`) contains backticks which are rendered incorrectly (at least compared to how the backticks work for markdown).

Preview:
![image](https://user-images.githubusercontent.com/8288413/148096360-a034d7cd-be18-4338-a5c7-bf59f5cfa965.png)

Looking into understanding why that happens I found out that the `description` is rendered in the head of the page. Looking more into it I found out that the `title` is rendered the same, but the title already was trimming the backtics. So I added trimming of the backtics for the `description` as well.

While this makes sense to me, obviously I cannot grasp the entire set of implications. Easiest thing to do for now, without introducing this change, would be to remove the backticks from description in the mentioned file.

Deploy preview: https://deploy-preview-30495--material-ui.netlify.app/customization/theme-components/