### PR TITLE
[docs] Codemod doc for overriding styles using tss

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -2920,12 +2920,48 @@ and [an explicit name for the stylesheet](https://github.com/garronej/tss-react#
  export default MyCustomButton;
 ```
 
-> **Note:** `tss-react` is **not maintained** by MUI.  
-> If you have any question about how to setup SSR (Next.js) or if you are wondering
-> how to customize the `theme` object please refer to `tss-react`'s documentation,
-> the [Mui integration section](https://github.com/garronej/tss-react#mui-integration) in particular.  
-> You can also [submit an issue](https://github.com/garronej/tss-react/issues/new) for any bug or
-> feature request and [start a discussion](https://github.com/garronej/tss-react/discussions) if you need help.
+#### Overriding styles - `classes` prop
+
+[Documentation of the feature in v4](https://v4.mui.com/styles/advanced/#makestyles) - [Equivalent in `tss-react`](https://v4.mui.com/styles/advanced/#makestyles)
+
+```diff
+-import { makeStyles } from '@material-ui/core/styles';
++import { makeStyles } from 'tss-react/mui';
++import { useMergedClasses } from 'tss-react';
+
+-const useStyles = makeStyles({
++const useStyles = makeStyles()({
+  root: {}, // a style rule
+  label: {}, // a nested style rule
+});
+
+function Nested(props) {
+- const classes = useStyles(props);
++ let { classes } = useStyles();
++ classes = useMergedClasses(classes, props.classes);
+
+  return (
+    <button className={classes.root}>
+      <span className={classes.label}> // 'tss-xxxx-label my-label'
+        nested
+      </span>
+    </button>
+  );
+}
+
+function Parent() {
+  return <Nested classes={{ label: 'my-label' }} />
+}
+```
+
+#### Other questions?
+
+**Note:** `tss-react` is **not maintained** by MUI.  
+If you have any question about how to setup SSR (Next.js) or if you are wondering
+how to customize the `theme` object please refer to `tss-react`'s documentation,
+the [Mui integration section](https://github.com/garronej/tss-react#mui-integration) in particular.  
+You can also [submit an issue](https://github.com/garronej/tss-react/issues/new) for any bug or
+feature request and [start a discussion](https://github.com/garronej/tss-react/discussions) if you need help.
 
 💡 Once you migrate all of the styling, remove unnecessary `@mui/styles` by:
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -2954,7 +2954,7 @@ function Parent() {
 }
 ```
 
-**Note:** `tss-react` is **not maintained** by MUI. 
+**Note:** `tss-react` is **not maintained** by MUI.
 If you have any question about how to setup SSR (Next.js) or if you are wondering
 how to customize the `theme` object please refer to `tss-react`'s documentation,
 the [Mui integration section](https://github.com/garronej/tss-react#mui-integration) in particular.  

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -2954,9 +2954,7 @@ function Parent() {
 }
 ```
 
-#### Other questions?
-
-**Note:** `tss-react` is **not maintained** by MUI.  
+**Note:** `tss-react` is **not maintained** by MUI. 
 If you have any question about how to setup SSR (Next.js) or if you are wondering
 how to customize the `theme` object please refer to `tss-react`'s documentation,
 the [Mui integration section](https://github.com/garronej/tss-react#mui-integration) in particular.  


### PR DESCRIPTION
Hi,  

I got [an issue](https://github.com/garronej/tss-react/issues/49) tonight from a user that was wondering [how to override the `classes` prop](https://v4.mui.com/styles/advanced/#makestyles).  

I wasn't aware of this feature's existence. I implemented [an equivalent for TSS](https://github.com/garronej/tss-react#usemergedclasses).  

This PR is an update of the codemod for migrating from jss to tss.  

Best regard