### PR TITLE
[docs] Fix `componentsProps` API docs and PropTypes

### DIFF
--- a/docs/pages/api-docs/autocomplete.json
+++ b/docs/pages/api-docs/autocomplete.json
@@ -19,7 +19,10 @@
     "clearOnEscape": { "type": { "name": "bool" } },
     "clearText": { "type": { "name": "string" }, "default": "'Clear'" },
     "closeText": { "type": { "name": "string" }, "default": "'Close'" },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ clearIndicator?: object }" },
+      "default": "{}"
+    },
     "defaultValue": {
       "type": { "name": "custom", "description": "any" },
       "default": "props.multiple ? [] : null"

--- a/docs/pages/api-docs/backdrop-unstyled.json
+++ b/docs/pages/api-docs/backdrop-unstyled.json
@@ -7,7 +7,10 @@
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ root?: object }" },
+      "default": "{}"
+    },
     "invisible": { "type": { "name": "bool" } }
   },
   "name": "BackdropUnstyled",

--- a/docs/pages/api-docs/backdrop.json
+++ b/docs/pages/api-docs/backdrop.json
@@ -8,7 +8,10 @@
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ root?: object }" },
+      "default": "{}"
+    },
     "invisible": { "type": { "name": "bool" } },
     "sx": {
       "type": {

--- a/docs/pages/api-docs/badge-unstyled.json
+++ b/docs/pages/api-docs/badge-unstyled.json
@@ -15,7 +15,10 @@
       "type": { "name": "shape", "description": "{ Badge?: elementType, Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ badge?: object, root?: object }" },
+      "default": "{}"
+    },
     "invisible": { "type": { "name": "bool" } },
     "max": { "type": { "name": "number" }, "default": "99" },
     "showZero": { "type": { "name": "bool" } },

--- a/docs/pages/api-docs/badge.json
+++ b/docs/pages/api-docs/badge.json
@@ -22,7 +22,10 @@
       "type": { "name": "shape", "description": "{ Badge?: elementType, Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ badge?: object, root?: object }" },
+      "default": "{}"
+    },
     "invisible": { "type": { "name": "bool" } },
     "max": { "type": { "name": "number" }, "default": "99" },
     "overlap": {

--- a/docs/pages/api-docs/clock-picker.json
+++ b/docs/pages/api-docs/clock-picker.json
@@ -12,7 +12,12 @@
         "description": "{ LeftArrowButton?: elementType, LeftArrowIcon?: elementType, RightArrowButton?: elementType, RightArrowIcon?: elementType }"
       }
     },
-    "componentsProps": { "type": { "name": "object" } },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object }"
+      }
+    },
     "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
     "getClockLabelText": {
       "type": { "name": "func" },

--- a/docs/pages/api-docs/date-picker.json
+++ b/docs/pages/api-docs/date-picker.json
@@ -18,7 +18,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object, switchViewButton?: object }"
+      },
+      "default": "{}"
+    },
     "defaultCalendarMonth": { "type": { "name": "any" } },
     "desktopModeMediaQuery": {
       "type": { "name": "string" },

--- a/docs/pages/api-docs/date-range-picker.json
+++ b/docs/pages/api-docs/date-range-picker.json
@@ -29,7 +29,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object, switchViewButton?: object }"
+      },
+      "default": "{}"
+    },
     "defaultCalendarMonth": { "type": { "name": "any" } },
     "desktopModeMediaQuery": {
       "type": { "name": "string" },

--- a/docs/pages/api-docs/date-time-picker.json
+++ b/docs/pages/api-docs/date-time-picker.json
@@ -20,7 +20,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object, switchViewButton?: object }"
+      },
+      "default": "{}"
+    },
     "dateRangeIcon": { "type": { "name": "node" } },
     "defaultCalendarMonth": { "type": { "name": "any" } },
     "desktopModeMediaQuery": {

--- a/docs/pages/api-docs/desktop-date-picker.json
+++ b/docs/pages/api-docs/desktop-date-picker.json
@@ -15,7 +15,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object, switchViewButton?: object }"
+      },
+      "default": "{}"
+    },
     "defaultCalendarMonth": { "type": { "name": "any" } },
     "disableCloseOnSelect": {
       "type": { "name": "bool" },

--- a/docs/pages/api-docs/desktop-date-range-picker.json
+++ b/docs/pages/api-docs/desktop-date-range-picker.json
@@ -26,7 +26,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object, switchViewButton?: object }"
+      },
+      "default": "{}"
+    },
     "defaultCalendarMonth": { "type": { "name": "any" } },
     "disableAutoMonthSwitching": { "type": { "name": "bool" } },
     "disableCloseOnSelect": {

--- a/docs/pages/api-docs/desktop-date-time-picker.json
+++ b/docs/pages/api-docs/desktop-date-time-picker.json
@@ -17,7 +17,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object, switchViewButton?: object }"
+      },
+      "default": "{}"
+    },
     "dateRangeIcon": { "type": { "name": "node" } },
     "defaultCalendarMonth": { "type": { "name": "any" } },
     "disableCloseOnSelect": {

--- a/docs/pages/api-docs/filled-input.json
+++ b/docs/pages/api-docs/filled-input.json
@@ -13,7 +13,10 @@
       "type": { "name": "shape", "description": "{ Input?: elementType, Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ input?: object, root?: object }" },
+      "default": "{}"
+    },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "disableUnderline": { "type": { "name": "bool" } },

--- a/docs/pages/api-docs/form-control-label.json
+++ b/docs/pages/api-docs/form-control-label.json
@@ -10,7 +10,10 @@
     },
     "checked": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" } },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ typography?: object }" },
+      "default": "{}"
+    },
     "disabled": { "type": { "name": "bool" } },
     "disableTypography": { "type": { "name": "bool" } },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },

--- a/docs/pages/api-docs/input-base.json
+++ b/docs/pages/api-docs/input-base.json
@@ -13,7 +13,10 @@
       "type": { "name": "shape", "description": "{ Input?: elementType, Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ input?: object, root?: object }" },
+      "default": "{}"
+    },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "disableInjectingGlobalStyles": { "type": { "name": "bool" } },

--- a/docs/pages/api-docs/input-unstyled.json
+++ b/docs/pages/api-docs/input-unstyled.json
@@ -11,7 +11,10 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ input?: object, root?: object }" },
+      "default": "{}"
+    },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "endAdornment": { "type": { "name": "node" } },

--- a/docs/pages/api-docs/input.json
+++ b/docs/pages/api-docs/input.json
@@ -13,7 +13,10 @@
       "type": { "name": "shape", "description": "{ Input?: elementType, Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ input?: object, root?: object }" },
+      "default": "{}"
+    },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "disableUnderline": { "type": { "name": "bool" } },

--- a/docs/pages/api-docs/list-item.json
+++ b/docs/pages/api-docs/list-item.json
@@ -21,7 +21,10 @@
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ root?: object }" },
+      "default": "{}"
+    },
     "ContainerComponent": {
       "type": { "name": "custom", "description": "element type" },
       "default": "'li'",

--- a/docs/pages/api-docs/mobile-date-picker.json
+++ b/docs/pages/api-docs/mobile-date-picker.json
@@ -18,7 +18,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object, switchViewButton?: object }"
+      },
+      "default": "{}"
+    },
     "defaultCalendarMonth": { "type": { "name": "any" } },
     "DialogProps": { "type": { "name": "object" } },
     "disableCloseOnSelect": {

--- a/docs/pages/api-docs/mobile-date-range-picker.json
+++ b/docs/pages/api-docs/mobile-date-range-picker.json
@@ -29,7 +29,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object, switchViewButton?: object }"
+      },
+      "default": "{}"
+    },
     "defaultCalendarMonth": { "type": { "name": "any" } },
     "DialogProps": { "type": { "name": "object" } },
     "disableAutoMonthSwitching": { "type": { "name": "bool" } },

--- a/docs/pages/api-docs/mobile-date-time-picker.json
+++ b/docs/pages/api-docs/mobile-date-time-picker.json
@@ -20,7 +20,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object, switchViewButton?: object }"
+      },
+      "default": "{}"
+    },
     "dateRangeIcon": { "type": { "name": "node" } },
     "defaultCalendarMonth": { "type": { "name": "any" } },
     "DialogProps": { "type": { "name": "object" } },

--- a/docs/pages/api-docs/modal-unstyled.json
+++ b/docs/pages/api-docs/modal-unstyled.json
@@ -11,7 +11,10 @@
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ root?: object }" },
+      "default": "{}"
+    },
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },
     "disableAutoFocus": { "type": { "name": "bool" } },
     "disableEnforceFocus": { "type": { "name": "bool" } },

--- a/docs/pages/api-docs/modal.json
+++ b/docs/pages/api-docs/modal.json
@@ -14,7 +14,10 @@
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ root?: object }" },
+      "default": "{}"
+    },
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },
     "disableAutoFocus": { "type": { "name": "bool" } },
     "disableEnforceFocus": { "type": { "name": "bool" } },

--- a/docs/pages/api-docs/slider-unstyled.json
+++ b/docs/pages/api-docs/slider-unstyled.json
@@ -12,7 +12,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ mark?: object, markLabel?: object, rail?: object, root?: object, thumb?: object, track?: object, valueLabel?: { className?: string, components?: { Root?: elementType }, style?: object, value?: Array&lt;number&gt;<br>&#124;&nbsp;number, valueLabelDisplay?: 'auto'<br>&#124;&nbsp;'off'<br>&#124;&nbsp;'on' } }"
+      },
+      "default": "{}"
+    },
     "defaultValue": {
       "type": { "name": "union", "description": "Array&lt;number&gt;<br>&#124;&nbsp;number" }
     },

--- a/docs/pages/api-docs/slider.json
+++ b/docs/pages/api-docs/slider.json
@@ -19,7 +19,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ mark?: object, markLabel?: object, rail?: object, root?: object, thumb?: object, track?: object, valueLabel?: { className?: string, components?: { Root?: elementType }, style?: object, value?: Array&lt;number&gt;<br>&#124;&nbsp;number, valueLabelDisplay?: 'auto'<br>&#124;&nbsp;'off'<br>&#124;&nbsp;'on' } }"
+      },
+      "default": "{}"
+    },
     "defaultValue": {
       "type": { "name": "union", "description": "Array&lt;number&gt;<br>&#124;&nbsp;number" }
     },

--- a/docs/pages/api-docs/static-date-picker.json
+++ b/docs/pages/api-docs/static-date-picker.json
@@ -15,7 +15,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object, switchViewButton?: object }"
+      },
+      "default": "{}"
+    },
     "defaultCalendarMonth": { "type": { "name": "any" } },
     "disableCloseOnSelect": {
       "type": { "name": "bool" },

--- a/docs/pages/api-docs/static-date-range-picker.json
+++ b/docs/pages/api-docs/static-date-range-picker.json
@@ -26,7 +26,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object, switchViewButton?: object }"
+      },
+      "default": "{}"
+    },
     "defaultCalendarMonth": { "type": { "name": "any" } },
     "disableAutoMonthSwitching": { "type": { "name": "bool" } },
     "disableCloseOnSelect": {

--- a/docs/pages/api-docs/static-date-time-picker.json
+++ b/docs/pages/api-docs/static-date-time-picker.json
@@ -17,7 +17,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ leftArrowButton?: object, rightArrowButton?: object, switchViewButton?: object }"
+      },
+      "default": "{}"
+    },
     "dateRangeIcon": { "type": { "name": "node" } },
     "defaultCalendarMonth": { "type": { "name": "any" } },
     "disableCloseOnSelect": {

--- a/docs/pages/api-docs/step-label.json
+++ b/docs/pages/api-docs/step-label.json
@@ -2,7 +2,10 @@
   "props": {
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ label?: object }" },
+      "default": "{}"
+    },
     "error": { "type": { "name": "bool" } },
     "icon": { "type": { "name": "node" } },
     "optional": { "type": { "name": "node" } },

--- a/docs/pages/api-docs/switch-unstyled.json
+++ b/docs/pages/api-docs/switch-unstyled.json
@@ -10,7 +10,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ input?: object, root?: object, thumb?: object, track?: object }"
+      },
+      "default": "{}"
+    },
     "defaultChecked": { "type": { "name": "bool" } },
     "disabled": { "type": { "name": "bool" } },
     "onChange": { "type": { "name": "func" } },

--- a/docs/pages/api-docs/tab-panel-unstyled.json
+++ b/docs/pages/api-docs/tab-panel-unstyled.json
@@ -10,7 +10,10 @@
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" }
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ root?: object }" },
+      "default": "{}"
+    }
   },
   "name": "TabPanelUnstyled",
   "styles": { "classes": [], "globalClasses": {}, "name": null },

--- a/docs/pages/api-docs/tab-unstyled.json
+++ b/docs/pages/api-docs/tab-unstyled.json
@@ -11,7 +11,10 @@
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ root?: object }" },
+      "default": "{}"
+    },
     "disabled": { "type": { "name": "bool" } },
     "onChange": { "type": { "name": "func" } },
     "value": { "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" } }

--- a/docs/pages/api-docs/table-pagination-unstyled.json
+++ b/docs/pages/api-docs/table-pagination-unstyled.json
@@ -12,7 +12,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ actions?: object, displayedRows?: object, menuItem?: object, root?: object, select?: object, selectLabel?: object, spacer?: object, toolbar?: object }"
+      },
+      "default": "{}"
+    },
     "getItemAriaLabel": {
       "type": { "name": "func" },
       "default": "function defaultGetAriaLabel(type: ItemAriaLabelType) {\n  return `Go to ${type} page`;\n}"

--- a/docs/pages/api-docs/tabs-list-unstyled.json
+++ b/docs/pages/api-docs/tabs-list-unstyled.json
@@ -6,7 +6,10 @@
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" }
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ root?: object }" },
+      "default": "{}"
+    }
   },
   "name": "TabsListUnstyled",
   "styles": { "classes": [], "globalClasses": {}, "name": null },

--- a/docs/pages/api-docs/tabs-unstyled.json
+++ b/docs/pages/api-docs/tabs-unstyled.json
@@ -6,7 +6,10 @@
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": { "name": "shape", "description": "{ root?: object }" },
+      "default": "{}"
+    },
     "defaultValue": {
       "type": {
         "name": "union",

--- a/docs/pages/api-docs/tooltip.json
+++ b/docs/pages/api-docs/tooltip.json
@@ -11,7 +11,13 @@
       },
       "default": "{}"
     },
-    "componentsProps": { "type": { "name": "object" }, "default": "{}" },
+    "componentsProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ arrow?: object, popper?: object, tooltip?: object, transition?: object }"
+      },
+      "default": "{}"
+    },
     "describeChild": { "type": { "name": "bool" } },
     "disableFocusListener": { "type": { "name": "bool" } },
     "disableHoverListener": { "type": { "name": "bool" } },

--- a/packages/mui-base/src/BackdropUnstyled/BackdropUnstyled.js
+++ b/packages/mui-base/src/BackdropUnstyled/BackdropUnstyled.js
@@ -89,7 +89,9 @@ BackdropUnstyled.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Backdrop.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    root: PropTypes.object,
+  }),
   /**
    * If `true`, the backdrop is invisible.
    * It can be used when rendering a popover or a custom select component.

--- a/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.js
+++ b/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.js
@@ -134,7 +134,10 @@ BadgeUnstyled.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Badge.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    badge: PropTypes.object,
+    root: PropTypes.object,
+  }),
   /**
    * If `true`, the badge is invisible.
    */

--- a/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.tsx
+++ b/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.tsx
@@ -144,7 +144,9 @@ ButtonUnstyled.propTypes /* remove-proptypes */ = {
   /**
    * @ignore
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    root: PropTypes.object,
+  }),
   /**
    * If `true`, the component is disabled.
    * @default false

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
@@ -195,7 +195,9 @@ FormControlUnstyled.propTypes /* remove-proptypes */ = {
   /**
    * @ignore
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    root: PropTypes.object,
+  }),
   /**
    * @ignore
    */

--- a/packages/mui-base/src/InputUnstyled/InputUnstyled.tsx
+++ b/packages/mui-base/src/InputUnstyled/InputUnstyled.tsx
@@ -230,7 +230,10 @@ InputUnstyled.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Input.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    input: PropTypes.object,
+    root: PropTypes.object,
+  }),
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.js
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.js
@@ -330,7 +330,9 @@ ModalUnstyled.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Modal.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    root: PropTypes.object,
+  }),
   /**
    * An HTML element or function that returns one.
    * The `container` will have the portal children appended to it.

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
@@ -865,7 +865,23 @@ SliderUnstyled.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Slider.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    mark: PropTypes.object,
+    markLabel: PropTypes.object,
+    rail: PropTypes.object,
+    root: PropTypes.object,
+    thumb: PropTypes.object,
+    track: PropTypes.object,
+    valueLabel: PropTypes.shape({
+      className: PropTypes.string,
+      components: PropTypes.shape({
+        Root: PropTypes.elementType,
+      }),
+      style: PropTypes.object,
+      value: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.number), PropTypes.number]),
+      valueLabelDisplay: PropTypes.oneOf(['auto', 'off', 'on']),
+    }),
+  }),
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
@@ -165,7 +165,12 @@ SwitchUnstyled.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Switch.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    input: PropTypes.object,
+    root: PropTypes.object,
+    thumb: PropTypes.object,
+    track: PropTypes.object,
+  }),
   /**
    * The default checked state. Use when the component is not controlled.
    */

--- a/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.tsx
+++ b/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.tsx
@@ -100,7 +100,9 @@ TabPanelUnstyled.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the TabPanel.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    root: PropTypes.object,
+  }),
   /**
    * The value of the TabPanel. It will be shown when the Tab with the corresponding value is selected.
    */

--- a/packages/mui-base/src/TabUnstyled/TabUnstyled.tsx
+++ b/packages/mui-base/src/TabUnstyled/TabUnstyled.tsx
@@ -129,7 +129,9 @@ TabUnstyled.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Tab.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    root: PropTypes.object,
+  }),
   /**
    * If `true`, the component is disabled.
    * @default false

--- a/packages/mui-base/src/TablePaginationUnstyled/TablePaginationUnstyled.tsx
+++ b/packages/mui-base/src/TablePaginationUnstyled/TablePaginationUnstyled.tsx
@@ -245,7 +245,16 @@ TablePaginationUnstyled.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the TablePagination.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    actions: PropTypes.object,
+    displayedRows: PropTypes.object,
+    menuItem: PropTypes.object,
+    root: PropTypes.object,
+    select: PropTypes.object,
+    selectLabel: PropTypes.object,
+    spacer: PropTypes.object,
+    toolbar: PropTypes.object,
+  }),
   /**
    * The total number of rows.
    *

--- a/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.tsx
+++ b/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.tsx
@@ -91,7 +91,9 @@ TabsListUnstyled.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the TabsList.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    root: PropTypes.object,
+  }),
 } as any;
 
 export default TabsListUnstyled;

--- a/packages/mui-base/src/TabsUnstyled/TabsUnstyled.tsx
+++ b/packages/mui-base/src/TabsUnstyled/TabsUnstyled.tsx
@@ -104,7 +104,9 @@ TabsUnstyled.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Tabs.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    root: PropTypes.object,
+  }),
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/mui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/mui-lab/src/ClockPicker/ClockPicker.tsx
@@ -441,7 +441,10 @@ ClockPicker.propTypes /* remove-proptypes */ = {
   /**
    * The props used for each slot inside.
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+  }),
   /**
    * Selected date @DateIOType.
    */

--- a/packages/mui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/mui-lab/src/DatePicker/DatePicker.tsx
@@ -134,7 +134,11 @@ DatePicker.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
   /**
    * Default calendar month displayed when `value={null}`.
    */

--- a/packages/mui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/mui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -234,7 +234,11 @@ DateRangePicker.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
   /**
    * Default calendar month displayed when `value={null}`.
    */

--- a/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -144,7 +144,11 @@ DateTimePicker.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
   /**
    * Date tab icon.
    */

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -124,7 +124,11 @@ DesktopDatePicker.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
   /**
    * Default calendar month displayed when `value={null}`.
    */

--- a/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -227,7 +227,11 @@ DesktopDateRangePicker.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
   /**
    * Default calendar month displayed when `value={null}`.
    */

--- a/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -135,7 +135,11 @@ DesktopDateTimePicker.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
   /**
    * Date tab icon.
    */

--- a/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -131,7 +131,11 @@ MobileDatePicker.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
   /**
    * Default calendar month displayed when `value={null}`.
    */

--- a/packages/mui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/mui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -238,7 +238,11 @@ MobileDateRangePicker.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
   /**
    * Default calendar month displayed when `value={null}`.
    */

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -144,7 +144,11 @@ MobileDateTimePicker.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
   /**
    * Date tab icon.
    */

--- a/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -117,7 +117,11 @@ StaticDatePicker.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
   /**
    * Default calendar month displayed when `value={null}`.
    */

--- a/packages/mui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/mui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -215,7 +215,11 @@ StaticDateRangePicker.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
   /**
    * Default calendar month displayed when `value={null}`.
    */

--- a/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -130,7 +130,11 @@ StaticDateTimePicker.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
   /**
    * Date tab icon.
    */

--- a/packages/mui-material-next/src/Input/Input.js
+++ b/packages/mui-material-next/src/Input/Input.js
@@ -377,7 +377,10 @@ Input.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Input.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    input: PropTypes.object,
+    root: PropTypes.object,
+  }),
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -720,7 +720,9 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    clearIndicator: PropTypes.object,
+  }),
   /**
    * The default value. Use when the component is not controlled.
    * @default props.multiple ? [] : null

--- a/packages/mui-material/src/Backdrop/Backdrop.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.js
@@ -114,7 +114,9 @@ Backdrop.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Backdrop.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    root: PropTypes.object,
+  }),
   /**
    * If `true`, the backdrop is invisible.
    * It can be used when rendering a popover or a custom select component.

--- a/packages/mui-material/src/Badge/Badge.js
+++ b/packages/mui-material/src/Badge/Badge.js
@@ -348,7 +348,10 @@ Badge.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Badge.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    badge: PropTypes.object,
+    root: PropTypes.object,
+  }),
   /**
    * If `true`, the badge is invisible.
    */

--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -257,7 +257,10 @@ FilledInput.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Input.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    input: PropTypes.object,
+    root: PropTypes.object,
+  }),
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.js
@@ -157,7 +157,9 @@ FormControlLabel.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    typography: PropTypes.object,
+  }),
   /**
    * A control element. For instance, it can be a `Radio`, a `Switch` or a `Checkbox`.
    */

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -184,7 +184,10 @@ Input.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Input.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    input: PropTypes.object,
+    root: PropTypes.object,
+  }),
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -596,7 +596,10 @@ InputBase.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Input.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    input: PropTypes.object,
+    root: PropTypes.object,
+  }),
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/mui-material/src/ListItem/ListItem.js
+++ b/packages/mui-material/src/ListItem/ListItem.js
@@ -385,7 +385,9 @@ ListItem.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Input.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    root: PropTypes.object,
+  }),
   /**
    * The container component used when a `ListItemSecondaryAction` is the last child.
    * @default 'li'

--- a/packages/mui-material/src/Modal/Modal.js
+++ b/packages/mui-material/src/Modal/Modal.js
@@ -172,7 +172,9 @@ Modal.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Modal.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    root: PropTypes.object,
+  }),
   /**
    * An HTML element or function that returns one.
    * The `container` will have the portal children appended to it.

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -557,7 +557,23 @@ Slider.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the Slider.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    mark: PropTypes.object,
+    markLabel: PropTypes.object,
+    rail: PropTypes.object,
+    root: PropTypes.object,
+    thumb: PropTypes.object,
+    track: PropTypes.object,
+    valueLabel: PropTypes.shape({
+      className: PropTypes.string,
+      components: PropTypes.shape({
+        Root: PropTypes.elementType,
+      }),
+      style: PropTypes.object,
+      value: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.number), PropTypes.number]),
+      valueLabelDisplay: PropTypes.oneOf(['auto', 'off', 'on']),
+    }),
+  }),
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/mui-material/src/StepLabel/StepLabel.js
+++ b/packages/mui-material/src/StepLabel/StepLabel.js
@@ -198,7 +198,9 @@ StepLabel.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    label: PropTypes.object,
+  }),
   /**
    * If `true`, the step is marked as failed.
    * @default false

--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -747,7 +747,12 @@ Tooltip.propTypes /* remove-proptypes */ = {
    * and `componentsProps.transition` prop values win over `TransitionProps` if both are applied.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  componentsProps: PropTypes.shape({
+    arrow: PropTypes.object,
+    popper: PropTypes.object,
+    tooltip: PropTypes.object,
+    transition: PropTypes.object,
+  }),
   /**
    * Set to `true` if the `title` acts as an accessible description.
    * By default the `title` acts as an accessible label for the child.

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -179,7 +179,11 @@ async function generateProptypes(
 ): Promise<void> {
   const proptypes = ttp.parseFromProgram(tsFile, program, {
     shouldResolveObject: ({ name }) => {
-      if (name.toLowerCase().endsWith('classes') || name === 'theme' || name.endsWith('Props')) {
+      if (
+        name.toLowerCase().endsWith('classes') ||
+        name === 'theme' ||
+        (name.endsWith('Props') && name !== 'componentsProps')
+      ) {
         return false;
       }
       return undefined;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

For `componentsProps` in docs we say that `The props used for each slot inside the Component`, but the users don't know the slots available. Also now these props are validated with PropTypes. 

Below is an example (Tooltip.componentsProps):
Before: https://mui.com/api/tooltip/ 
After: https://deploy-preview-30502--material-ui.netlify.app/api/tooltip/#main-content