### PR TITLE
[docs] fix replace url on data-grid

### DIFF
--- a/docs/src/modules/utils/replaceUrl.test.js
+++ b/docs/src/modules/utils/replaceUrl.test.js
@@ -86,11 +86,20 @@ describe('replaceUrl', () => {
     expect(replaceUrl(`/guides/minimizing-bundle-size/`, '/material/react-buttons')).to.equal(
       `/material/guides/minimizing-bundle-size/`,
     );
+    expect(
+      replaceUrl(`/components/data-grid/getting-started/#main-content`, '/x/react-data-grid'),
+    ).to.equal(`/x/react-data-grid/getting-started/#main-content`);
+    expect(replaceUrl(`/api/button-unstyled`, '/base/api/mui-base/button-unstyled')).to.equal(
+      `/base/api/mui-base/button-unstyled`,
+    );
   });
 
   it('does not replace for old routes', () => {
     expect(replaceUrl(`/guides/minimizing-bundle-size/`, '/components/buttons')).to.equal(
       `/guides/minimizing-bundle-size/`,
     );
+    expect(
+      replaceUrl(`/components/data-grid/getting-started/#main-content`, '/components/buttons'),
+    ).to.equal(`/components/data-grid/getting-started/#main-content`);
   });
 });

--- a/docs/src/modules/utils/replaceUrl.ts
+++ b/docs/src/modules/utils/replaceUrl.ts
@@ -1,13 +1,17 @@
+function isNewLocation(url: string) {
+  return url.startsWith('/x') || url.startsWith('/material') || url.startsWith('/base');
+}
+
 export const replaceMaterialLinks = (url: string) => {
   const routes = 'guides|customization|getting-started|discover-more';
-  if (url.startsWith('/material')) {
+  if (isNewLocation(url)) {
     return url;
   }
   return url.replace(new RegExp(`(${routes})`), 'material/$1');
 };
 
 export const replaceComponentLinks = (url: string) => {
-  if (url.startsWith('/x') || url.startsWith('/material')) {
+  if (isNewLocation(url)) {
     return url;
   }
   return url
@@ -16,12 +20,7 @@ export const replaceComponentLinks = (url: string) => {
 };
 
 export const replaceAPILinks = (url: string) => {
-  if (
-    url.startsWith('/x') ||
-    url.startsWith('/material') ||
-    url.startsWith('/base/') ||
-    !url.startsWith('/api')
-  ) {
+  if (isNewLocation(url) || !url.startsWith('/api')) {
     return url;
   }
   url = url
@@ -32,14 +31,14 @@ export const replaceAPILinks = (url: string) => {
     )
     .replace(/\/api\/([^/]+-unstyled)(.*)/, '/base/api/mui-base/$1$2');
 
-  if (url.startsWith('/x') || url.startsWith('/material') || url.startsWith('/base/')) {
+  if (isNewLocation(url)) {
     return url;
   }
   return url.replace(/\/api\/(.*)/, '/material/api/mui-material/$1');
 };
 
 export default function replaceUrl(url: string, asPath: string) {
-  if (asPath.startsWith('/material/') || asPath.startsWith('/x/') || asPath.startsWith('/base/')) {
+  if (isNewLocation(asPath)) {
     return replaceMaterialLinks(replaceAPILinks(replaceComponentLinks(url)));
   }
   return url;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Found this bug while integrating the migration in https://github.com/mui-org/material-ui-x/pull/3515.

- tests added to cover data-grid url

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
