### PR TITLE
[docs] fix edge case when replacing data-grid url for migration

### DIFF
--- a/docs/src/modules/utils/replaceUrl.test.js
+++ b/docs/src/modules/utils/replaceUrl.test.js
@@ -89,6 +89,9 @@ describe('replaceUrl', () => {
     expect(
       replaceUrl(`/components/data-grid/getting-started/#main-content`, '/x/react-data-grid'),
     ).to.equal(`/x/react-data-grid/getting-started/#main-content`);
+    expect(
+      replaceUrl(`/components/data-grid/components/#main-content`, '/x/react-data-grid'),
+    ).to.equal(`/x/react-data-grid/components/#main-content`);
     expect(replaceUrl(`/api/button-unstyled`, '/base/api/mui-base/button-unstyled')).to.equal(
       `/base/api/mui-base/button-unstyled`,
     );

--- a/docs/src/modules/utils/replaceUrl.ts
+++ b/docs/src/modules/utils/replaceUrl.ts
@@ -3,20 +3,25 @@ function isNewLocation(url: string) {
 }
 
 export const replaceMaterialLinks = (url: string) => {
-  const routes = 'guides|customization|getting-started|discover-more';
   if (isNewLocation(url)) {
     return url;
   }
-  return url.replace(new RegExp(`(${routes})`), 'material/$1');
+  return url.replace(
+    new RegExp(`(guides|customization|getting-started|discover-more)`),
+    'material/$1',
+  );
 };
 
 export const replaceComponentLinks = (url: string) => {
   if (isNewLocation(url)) {
     return url;
   }
-  return url
-    .replace(/\/components\/data-grid/, '/x/react-data-grid')
-    .replace(/\/components\/(.*)/, '/material/react-$1');
+  url = url.replace(/\/components\/data-grid/, '/x/react-data-grid');
+  if (isNewLocation(url)) {
+    return url;
+  }
+  url = url.replace(/\/components\/(.*)/, '/material/react-$1');
+  return url;
 };
 
 export const replaceAPILinks = (url: string) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

🥲 I missed this case (take a look at the test).

**Note**: This is a bug fix when doing the migration. There is no impact on the current version of the docs.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
