### PR TITLE
Add missing dev dependencies to base/next

### DIFF
--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -60,6 +60,7 @@
     "react-is": "^17.0.2"
   },
   "devDependencies": {
+    "@mui/material": "^5.2.7",
     "@mui/types": "^7.1.0"
   },
   "sideEffects": false,

--- a/packages/mui-material-next/package.json
+++ b/packages/mui-material-next/package.json
@@ -72,6 +72,9 @@
     "react-is": "^17.0.2",
     "react-transition-group": "^4.4.2"
   },
+  "devDependencies": {
+    "@mui/material": "^5.2.7"
+  },
   "sideEffects": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Discovered this while trying a few things with rollup while investigating https://github.com/mui-org/material-ui/pull/30510 and https://github.com/mui-org/material-ui/pull/30200
`@mui/material` is being used in the tests of these packages.