### PR TITLE
[MobileDatePicker] Fix calling onOpen when readOnly is true

### DIFF
--- a/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.test.tsx
+++ b/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import TextField from '@mui/material/TextField';
-import { fireEvent, screen } from 'test/utils';
+import { fireEvent, screen, userEvent } from 'test/utils';
 import PickersDay from '@mui/lab/PickersDay';
 import CalendarPickerSkeleton from '@mui/lab/CalendarPickerSkeleton';
 import MobileDatePicker from '@mui/lab/MobileDatePicker';
@@ -290,5 +290,24 @@ describe('<MobileDatePicker />', () => {
     expect(onCloseMock.callCount).to.equal(1);
     expect(handleChange.callCount).to.equal(1);
     expect(adapterToUse.getDiff(handleChange.args[0][0], start)).to.equal(10);
+  });
+  ['readOnly', 'disabled'].forEach((prop) => {
+    it(`should not be opened when "Choose date" is clicked when ${prop}={true}`, () => {
+      const handleOpen = spy();
+      render(
+        <MobileDatePicker
+          value={adapterToUse.date('2019-01-01T00:00:00.000')}
+          {...{ [prop]: true }}
+          onChange={() => {}}
+          onOpen={handleOpen}
+          open={false}
+          renderInput={(params) => <TextField {...params} />}
+        />,
+      );
+
+      userEvent.mousePress(screen.getByLabelText(/Choose date/));
+
+      expect(handleOpen.callCount).to.equal(0);
+    });
   });
 });

--- a/packages/mui-lab/src/internal/pickers/PureDateInput.tsx
+++ b/packages/mui-lab/src/internal/pickers/PureDateInput.tsx
@@ -145,7 +145,7 @@ export const PureDateInput = React.forwardRef(function PureDateInput(
       'aria-readonly': true,
       'aria-label': getOpenDialogAriaText(rawValue, utils),
       value: inputValue,
-      onClick: !props.readOnly ? onOpen : () => {},
+      ...(!props.readOnly && { onClick: onOpen }),
       onKeyDown: onSpaceOrEnter(onOpen),
     },
     ...TextFieldProps,

--- a/packages/mui-lab/src/internal/pickers/PureDateInput.tsx
+++ b/packages/mui-lab/src/internal/pickers/PureDateInput.tsx
@@ -145,7 +145,7 @@ export const PureDateInput = React.forwardRef(function PureDateInput(
       'aria-readonly': true,
       'aria-label': getOpenDialogAriaText(rawValue, utils),
       value: inputValue,
-      onClick: onOpen,
+      onClick: !props.readOnly ? onOpen : () => {},
       onKeyDown: onSpaceOrEnter(onOpen),
     },
     ...TextFieldProps,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
Fixes #29310

**Problem**:

- When the `readOnly` prop is true, clicking on the `MobileDatePicker` component opens the date selector

**Solution**

- adding a condition to check whether the `readOnly` is true before calling onOpen function

[demo](https://codesandbox.io/s/responsivedatepickers-material-demo-forked-uxf4m?file=/demo.js)