### PR TITLE
[styled-engine-sc] Add the withConfig API to enable using the babel plugin

### DIFF
--- a/packages/mui-styled-engine-sc/src/index.js
+++ b/packages/mui-styled-engine-sc/src/index.js
@@ -13,7 +13,7 @@ export default function styled(tag, options) {
   }
 
   if (process.env.NODE_ENV !== 'production') {
-    return (...styles) => {
+    const fn = (...styles) => {
       const component = typeof tag === 'string' ? `"${tag}"` : 'component';
       if (styles.length === 0) {
         console.error(
@@ -29,9 +29,11 @@ export default function styled(tag, options) {
       }
       return stylesFactory(...styles);
     };
+    fn.withConfig = stylesFactory.withConfig;
+    return fn;
   }
 
-  return (...styles) => stylesFactory(...styles);
+  return stylesFactory;
 }
 
 export { ThemeContext, keyframes, css } from 'styled-components';

--- a/packages/mui-styled-engine-sc/src/styled.test.js
+++ b/packages/mui-styled-engine-sc/src/styled.test.js
@@ -38,4 +38,9 @@ describe('styled', () => {
   it("should not allow styled-components's APIs: .attrs", () => {
     expect(typeof styled('span').attrs).to.equal('undefined');
   });
+
+  // The babel-plugin-styled-components depends on the withConfig option to be defined
+  it("should allow styled-components's APIs: .withConfig", () => {
+    expect(typeof styled('span').withConfig).to.equal('function');
+  });
 });

--- a/packages/mui-system/src/createStyled.js
+++ b/packages/mui-system/src/createStyled.js
@@ -189,6 +189,11 @@ export default function createStyled(input = {}) {
 
       return Component;
     };
+
+    if (defaultStyledResolver.withConfig) {
+      muiStyledResolver.withConfig = defaultStyledResolver.withConfig;
+    }
+
     return muiStyledResolver;
   };
 }


### PR DESCRIPTION
Part of https://github.com/mui-org/material-ui/pull/29873

The `babel-plugin-styled-components` expects that this option exists on the `styled()` utility.