### PR TITLE
[docs] Update remix example to restore from error pages

### DIFF
--- a/examples/remix-with-typescript/app/entry.client.tsx
+++ b/examples/remix-with-typescript/app/entry.client.tsx
@@ -1,21 +1,37 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { hydrate } from 'react-dom';
 import { RemixBrowser } from 'remix';
 import { CacheProvider, ThemeProvider } from '@emotion/react';
 import CssBaseline from '@mui/material/CssBaseline';
 
+import ClientStyleContext from './src/ClientStyleContext';
 import createEmotionCache from './src/createEmotionCache';
 import theme from './src/theme';
 
-const emotionCache = createEmotionCache();
+interface ClientCacheProviderProps {
+  children: React.ReactNode;
+}
+function ClientCacheProvider({ children }: ClientCacheProviderProps) {
+  const [cache, setCache] = useState(createEmotionCache());
+
+  function reset() {
+    setCache(createEmotionCache());
+  }
+
+  return (
+    <ClientStyleContext.Provider value={{ reset }}>
+      <CacheProvider value={cache}>{children}</CacheProvider>
+    </ClientStyleContext.Provider>
+  );
+}
 
 hydrate(
-  <CacheProvider value={emotionCache}>
+  <ClientCacheProvider>
     <ThemeProvider theme={theme}>
       {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
       <CssBaseline />
       <RemixBrowser />
     </ThemeProvider>
-  </CacheProvider>,
+  </ClientCacheProvider>,
   document,
 );

--- a/examples/remix-with-typescript/app/entry.client.tsx
+++ b/examples/remix-with-typescript/app/entry.client.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useState } from 'react';
 import { hydrate } from 'react-dom';
 import { RemixBrowser } from 'remix';

--- a/examples/remix-with-typescript/app/root.tsx
+++ b/examples/remix-with-typescript/app/root.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useCatch } from 'remix';
 import { withEmotionCache } from '@emotion/react';
+import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/material';
 import theme from './src/theme';
 import ClientStyleContext from './src/ClientStyleContext';
 import Layout from './src/Layout';
@@ -14,17 +15,19 @@ const Document = withEmotionCache(({ children, title }: DocumentProps, emotionCa
   const clientStyleData = React.useContext(ClientStyleContext);
 
   // Only executed on client
-  React.useLayoutEffect(() => {
+  useEnhancedEffect(() => {
     // re-link sheet container
     emotionCache.sheet.container = document.head;
     // re-inject tags
     const tags = emotionCache.sheet.tags;
     emotionCache.sheet.flush();
     tags.forEach((tag) => {
+      // eslint-disable-next-line no-underscore-dangle
       (emotionCache.sheet as any)._insertTag(tag);
     });
     // reset cache to reapply global styles
     clientStyleData.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/examples/remix-with-typescript/app/root.tsx
+++ b/examples/remix-with-typescript/app/root.tsx
@@ -14,7 +14,7 @@ const Document = withEmotionCache(({ children, title }: DocumentProps, emotionCa
   const clientStyleData = React.useContext(ClientStyleContext);
 
   // Only executed on client
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     // re-link sheet container
     emotionCache.sheet.container = document.head;
     // re-inject tags

--- a/examples/remix-with-typescript/app/root.tsx
+++ b/examples/remix-with-typescript/app/root.tsx
@@ -1,10 +1,32 @@
 import * as React from 'react';
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useCatch } from 'remix';
+import { withEmotionCache } from '@emotion/react';
 import theme from './src/theme';
-
+import ClientStyleContext from './src/ClientStyleContext';
 import Layout from './src/Layout';
 
-function Document({ children, title }: { children: React.ReactNode; title?: string }) {
+interface DocumentProps {
+  children: React.ReactNode;
+  title?: string;
+}
+
+const Document = withEmotionCache(({ children, title }: DocumentProps, emotionCache) => {
+  const clientStyleData = React.useContext(ClientStyleContext);
+
+  // Only executed on client
+  React.useEffect(() => {
+    // re-link sheet container
+    emotionCache.sheet.container = document.head;
+    // re-inject tags
+    const tags = emotionCache.sheet.tags;
+    emotionCache.sheet.flush();
+    tags.forEach((tag) => {
+      (emotionCache.sheet as any)._insertTag(tag);
+    });
+    // reset cache to reapply global styles
+    clientStyleData.reset();
+  }, []);
+
   return (
     <html lang="en">
       <head>
@@ -28,7 +50,7 @@ function Document({ children, title }: { children: React.ReactNode; title?: stri
       </body>
     </html>
   );
-}
+});
 
 // https://remix.run/api/conventions#default-export
 // https://remix.run/api/conventions#route-filenames

--- a/examples/remix-with-typescript/app/routes/index.tsx
+++ b/examples/remix-with-typescript/app/routes/index.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import type { MetaFunction } from 'remix';
 import { Link } from 'remix';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
-import Stack from '@mui/material/Stack';
 
 // https://remix.run/api/conventions#meta
 export const meta: MetaFunction = () => {
@@ -16,16 +14,13 @@ export const meta: MetaFunction = () => {
 // https://remix.run/guides/routing#index-routes
 export default function Index() {
   return (
-    <Stack>
+    <React.Fragment>
       <Typography variant="h4" component="h1" gutterBottom>
         Remix with TypeScript example
       </Typography>
       <Link to="/about" color="secondary">
         Go to the about page
       </Link>
-      <Button variant="contained" component={Link} to="/404">
-        Go to the 404 page (bug reproduce)
-      </Button>
-    </Stack>
+    </React.Fragment>
   );
 }

--- a/examples/remix-with-typescript/app/routes/index.tsx
+++ b/examples/remix-with-typescript/app/routes/index.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import type { MetaFunction } from 'remix';
 import { Link } from 'remix';
 import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
 
 // https://remix.run/api/conventions#meta
 export const meta: MetaFunction = () => {
@@ -14,13 +16,16 @@ export const meta: MetaFunction = () => {
 // https://remix.run/guides/routing#index-routes
 export default function Index() {
   return (
-    <React.Fragment>
+    <Stack>
       <Typography variant="h4" component="h1" gutterBottom>
         Remix with TypeScript example
       </Typography>
       <Link to="/about" color="secondary">
         Go to the about page
       </Link>
-    </React.Fragment>
+      <Button variant="contained" component={Link} to="/404">
+        Go to the 404 page (bug reproduce)
+      </Button>
+    </Stack>
   );
 }

--- a/examples/remix-with-typescript/app/src/ClientStyleContext.tsx
+++ b/examples/remix-with-typescript/app/src/ClientStyleContext.tsx
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+export interface ClientStyleContextData {
+  reset: () => void;
+}
+
+export default createContext<ClientStyleContextData>({
+  reset: () => {},
+});


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/30436

Based on https://github.com/mui-org/material-ui/issues/30436#issuecomment-1003339715 with small adjustments to avoid double rendering.

Credits go to @lvauvillier for the initial implementation.