### PR TITLE
[docs] Fix anchor tag in table of contents of v4->v5 docs

### DIFF
--- a/docs/src/pages/guides/migration-v0x/migration-v0x.md
+++ b/docs/src/pages/guides/migration-v0x/migration-v0x.md
@@ -32,21 +32,21 @@ With yarn:
 
 ```sh
 yarn add material-ui
-yarn add @mui/material
+yarn add @material-ui/core
 ```
 
 Or with npm:
 
 ```sh
 npm install material-ui
-npm install @mui/material
+npm install @material-ui/core
 ```
 
 then
 
 ```js
 import FlatButton from 'material-ui/FlatButton'; // v0.x
-import Button from '@mui/material/Button'; // v1.x
+import Button from '@material-ui/core/Button'; // v1.x
 ```
 
 2. Run [the migration helper](https://github.com/mui-org/material-ui/tree/master/packages/mui-codemod) on your project.
@@ -54,7 +54,7 @@ import Button from '@mui/material/Button'; // v1.x
 
 ```jsx
 import * as React from 'react';
-import { MuiThemeProvider, createMuiTheme } from '@mui/material/styles'; // v1.x
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'; // v1.x
 import { MuiThemeProvider as V0MuiThemeProvider } from 'material-ui';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
@@ -104,7 +104,7 @@ This will apply a change such as the following:
 
 ```diff
 -import FlatButton from 'material-ui/FlatButton';
-+import Button from '@mui/material/Button';
++import Button from '@material-ui/core/Button';
 
 -<FlatButton />
 +<Button />
@@ -116,7 +116,7 @@ RaisedButton upgrade path:
 
 ```diff
 -import RaisedButton from 'material-ui/RaisedButton';
-+import Button from '@mui/material/Button';
++import Button from '@material-ui/core/Button';
 
 -<RaisedButton />
 +<Button variant="contained" />
@@ -126,7 +126,7 @@ RaisedButton upgrade path:
 
 ```diff
 -import Subheader from 'material-ui/Subheader';
-+import ListSubheader from '@mui/material/ListSubheader';
++import ListSubheader from '@material-ui/core/ListSubheader';
 
 -<Subheader>Sub Heading</Subheader>
 +<ListSubheader>Sub Heading</ListSubheader>
@@ -136,7 +136,7 @@ RaisedButton upgrade path:
 
 ```diff
 -import Toggle from 'material-ui/Toggle';
-+import Switch from '@mui/material/Switch';
++import Switch from '@material-ui/core/Switch';
 
 -<Toggle
 -  toggled={this.state.checkedA}
@@ -152,7 +152,7 @@ RaisedButton upgrade path:
 
 ```diff
 -import MenuItem from 'material-ui/MenuItem';
-+import MenuItem from '@mui/material/MenuItem';
++import MenuItem from '@material-ui/core/MenuItem';
 
 -<MenuItem primaryText="Profile" />
 +<MenuItem>Profile</MenuItem>
@@ -162,7 +162,7 @@ RaisedButton upgrade path:
 
 ```diff
 -import FontIcon from 'material-ui/FontIcon';
-+import Icon from '@mui/material/Icon';
++import Icon from '@material-ui/core/Icon';
 
 -<FontIcon>home</FontIcon>
 +<Icon>home</Icon>
@@ -172,7 +172,7 @@ RaisedButton upgrade path:
 
 ```diff
 -import CircularProgress from 'material-ui/CircularProgress';
-+import CircularProgress from '@mui/material/CircularProgress';
++import CircularProgress from '@material-ui/core/CircularProgress';
 
 -<CircularProgress mode="indeterminate" />
 +<CircularProgress variant="indeterminate" />
@@ -182,7 +182,7 @@ RaisedButton upgrade path:
 
 ```diff
 -import DropDownMenu from 'material-ui/DropDownMenu';
-+import Select from '@mui/material/Select';
++import Select from '@material-ui/core/Select';
 
 -<DropDownMenu></DropDownMenu>
 +<Select value={this.state.value}></Select>

--- a/docs/src/pages/guides/migration-v0x/migration-v0x.md
+++ b/docs/src/pages/guides/migration-v0x/migration-v0x.md
@@ -12,9 +12,9 @@ lower-level components that abstract less complexity.
 
 ### What motivated such a large change?
 
-MUI was started [4 years ago](https://github.com/mui-org/material-ui/commit/28b768913b75752ecf9b6bb32766e27c241dbc46).
+Material-UI was started [4 years ago](https://github.com/mui-org/material-ui/commit/28b768913b75752ecf9b6bb32766e27c241dbc46).
 The ecosystem has evolved a lot since then, we have also learned a lot.
-[@nathanmarks](https://github.com/nathanmarks/) started an ambitious task, rebuilding MUI from the **ground-up**
+[@nathanmarks](https://github.com/nathanmarks/) started an ambitious task, rebuilding Material-UI from the **ground-up**
 taking advantage of this knowledge to address long-standing issues. To name some of the major changes:
 
 - New styling solution using CSS-in-JS (better [customization](/customization/how-to-customize/) power, better performance)
@@ -26,7 +26,7 @@ taking advantage of this knowledge to address long-standing issues. To name some
 
 ### Where should I start in a migration?
 
-1. Start by installing the v1.x version of MUI along side the v0.x version.
+1. Start by installing the v1.x version of Material-UI along side the v0.x version.
 
 With yarn:
 
@@ -82,7 +82,7 @@ export default App;
 
 ### Autocomplete
 
-MUI doesn't provide a high-level API for solving this problem.
+Material-UI doesn't provide a high-level API for solving this problem.
 You're encouraged you to explore [the solutions the React community has built](/components/autocomplete/).
 
 In the future, we will look into providing a simple component to solve the simple use cases: [#9997](https://github.com/mui-org/material-ui/issues/9997).

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -10,7 +10,7 @@ Looking for the v3 docs? You can [find the latest version here](https://mui.com/
 
 ## Introduction
 
-This is a reference for upgrading your site from MUI v3 to v4.
+This is a reference for upgrading your site from Material-UI v3 to v4.
 While there's a lot covered here, you probably won't need to do everything for your site.
 We'll do our best to keep things easy to follow, and as sequential as possible so you can quickly get rocking on v4!
 
@@ -23,9 +23,9 @@ The **why** is covered in the [release blog post on Medium](https://medium.com/m
 
 The very first thing you will need to do is to update your dependencies.
 
-### Update MUI version
+### Update Material-UI version
 
-You need to update your `package.json` to use the latest version of MUI.
+You need to update your `package.json` to use the latest version of Material-UI.
 
 ```json
 "dependencies": {
@@ -48,9 +48,9 @@ yarn add @material-ui/core
 The minimum required version of React was increased from `react@^16.3.0` to `react@^16.8.0`.
 This allows us to rely on [Hooks](https://reactjs.org/docs/hooks-intro.html) (we no longer use the class API).
 
-### Update MUI Styles version
+### Update Material-UI Styles version
 
-If you were previously using `@material-ui/styles` with v3 you need to update your `package.json` to use the latest version of MUI Styles.
+If you were previously using `@material-ui/styles` with v3 you need to update your `package.json` to use the latest version of Material-UI Styles.
 
 ```json
 "dependencies": {
@@ -80,7 +80,7 @@ yarn add @muimaterial-ui
 
 ### Styles
 
-- ⚠️ MUI depends on JSS v10. JSS v10 is not backward compatible with v9.
+- ⚠️ Material-UI depends on JSS v10. JSS v10 is not backward compatible with v9.
   Make sure JSS v9 is not installed in your environment.
   (Removing `react-jss` from your `package.json` can help).
   The StylesProvider component replaces the JssProvider one.
@@ -457,7 +457,7 @@ This change is explained in more detail in the [TypeScript guide](/guides/typesc
 
 ### UMD
 
-- This change eases the use of MUI with a CDN:
+- This change eases the use of Material-UI with a CDN:
 
   ```diff
   const {

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -29,18 +29,18 @@ You need to update your `package.json` to use the latest version of MUI.
 
 ```json
 "dependencies": {
-  "@mui/material": "^4.0.0"
+  "@material-ui/core": "^4.0.0"
 }
 ```
 
 Or run
 
 ```sh
-npm install @mui/material
+npm install @material-ui/core
 
 or
 
-yarn add @mui/material
+yarn add @material-ui/core
 ```
 
 ### Update React version
@@ -50,22 +50,22 @@ This allows us to rely on [Hooks](https://reactjs.org/docs/hooks-intro.html) (we
 
 ### Update MUI Styles version
 
-If you were previously using `@mui/styles` with v3 you need to update your `package.json` to use the latest version of MUI Styles.
+If you were previously using `@material-ui/styles` with v3 you need to update your `package.json` to use the latest version of MUI Styles.
 
 ```json
 "dependencies": {
-  "@mui/styles": "^4.0.0"
+  "@material-ui/styles": "^4.0.0"
 }
 ```
 
 Or run
 
 ```sh
-npm install @mui/styles
+npm install @muimaterial-ui
 
 or
 
-yarn add @mui/styles
+yarn add @muimaterial-ui
 ```
 
 ## Handling breaking changes
@@ -97,8 +97,8 @@ yarn add @mui/styles
 - Rename `convertHexToRGB` to `hexToRgb`.
 
   ```diff
-  -import { convertHexToRgb } from '@mui/material/styles/colorManipulator';
-  +import { hexToRgb } from '@mui/material/styles';
+  -import { convertHexToRgb } from '@material-ui/core/styles/colorManipulator';
+  +import { hexToRgb } from '@material-ui/core/styles';
   ```
 
 - Scope the [keyframes API](https://cssinjs.org/jss-syntax/#keyframes-animation). You should apply the following changes in your codebase.
@@ -171,11 +171,11 @@ yarn add @mui/styles
 
   Going forward, you can use the theme to implement [a custom Grid spacing transformation function](https://mui.com/system/spacing/#transformation).
 
-- [Container] Moved from `@mui/lab` to `@mui/material`.
+- [Container] Moved from `@material-ui/lab` to `@material-ui/core`.
 
   ```diff
-  -import Container from '@mui/lab/Container';
-  +import Container from '@mui/material/Container';
+  -import Container from '@material-ui/lab/Container';
+  +import Container from '@material-ui/core/Container';
   ```
 
 ### TypeScript
@@ -213,16 +213,16 @@ This change is explained in more detail in the [TypeScript guide](/guides/typesc
   ```
 
   ```diff
-  -import Button from '@mui/material/Button';
+  -import Button from '@material-ui/core/Button';
   -<Button variant="fab" />
-  +import Fab from '@mui/material/Fab';
+  +import Fab from '@material-ui/core/Fab';
   +<Fab />
   ```
 
   ```diff
-  -import Button from '@mui/material/Button';
+  -import Button from '@material-ui/core/Button';
   -<Button variant="extendedFab" />
-  +import Fab from '@mui/material/Fab';
+  +import Fab from '@material-ui/core/Fab';
   +<Fab variant="extended" />
   ```
 
@@ -318,11 +318,11 @@ This change is explained in more detail in the [TypeScript guide](/guides/typesc
 
 ### Slider
 
-- [Slider] Move from `@mui/lab` to `@mui/material`.
+- [Slider] Move from `@material-ui/lab` to `@material-ui/core`.
 
   ```diff
-  -import Slider from '@mui/lab/Slider'
-  +import Slider from '@mui/material/Slider'
+  -import Slider from '@material-ui/lab/Slider'
+  +import Slider from '@material-ui/core/Slider'
   ```
 
 ### Switch

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -61,11 +61,11 @@ If you were previously using `@material-ui/styles` with v3 you need to update yo
 Or run
 
 ```sh
-npm install @muimaterial-ui
+npm install @material-ui/styles
 
 or
 
-yarn add @muimaterial-ui
+yarn add @material-ui/styles
 ```
 
 ## Handling breaking changes

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -20,7 +20,7 @@ The **why** is covered in the [release blog post](/blog/mui-core-v5/).
 
 - [Update React & TypeScript](#update-react-amp-typescript-version)
 - [ThemeProvider setup](#themeprovider-setup)
-- [Update MUI](#update-mui-version)
+- [Update MUI Core version](#update-mui-core-version)
 - [Run codemods](#run-codemods)
   - [preset-safe](#preset-safe)
   - [variant-prop (optional)](#variant-prop)
@@ -75,7 +75,7 @@ function App() {
 
 > 📝 Please make sure that your application is still **running** without errors and **commit** the change before continuing the next step.
 
-## Update MUI version
+## Update MUI Core version
 
 To use the `v5` version of MUI Core, you first need to update the package names:
 
@@ -137,7 +137,7 @@ You should be able to remove the dependency following [these steps](#migrate-fro
 
 > 📝 Please make sure that your application is still **running** without errors and **commit** the change before continuing the next step.
 
-Once you application has completely migrated to MUI v5, you can remove the old `@material-ui/*` packages by running `yarn remove` or `npm uninstall`.
+Once you application has completely migrated to MUI Core v5, you can remove the old `@material-ui/*` packages by running `yarn remove` or `npm uninstall`.
 
 ## Run codemods
 
@@ -2959,7 +2959,7 @@ function Parent() {
 **Note:** `tss-react` is **not maintained** by MUI.
 If you have any question about how to setup SSR (Next.js) or if you are wondering
 how to customize the `theme` object please refer to `tss-react`'s documentation,
-the [Mui integration section](https://github.com/garronej/tss-react#mui-integration) in particular.  
+the [Mui integration section](https://github.com/garronej/tss-react#mui-integration) in particular.
 You can also [submit an issue](https://github.com/garronej/tss-react/issues/new) for any bug or
 feature request and [start a discussion](https://github.com/garronej/tss-react/discussions) if you need help.
 

--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -20,7 +20,7 @@ The **why** is covered in the [release blog post](/blog/mui-core-v5/).
 
 - [Update React & TypeScript](#update-react-amp-typescript-version)
 - [ThemeProvider setup](#themeprovider-setup)
-- [Update MUI](#update-material-ui-version)
+- [Update MUI](#update-mui-version)
 - [Run codemods](#run-codemods)
   - [preset-safe](#preset-safe)
   - [variant-prop (optional)](#variant-prop)


### PR DESCRIPTION
fix: migration anchor tag in migration of v4 to v5 documentation.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


https://deploy-preview-30595--material-ui.netlify.app/guides/migration-v4/