### PR TITLE
[core] Fix outdated TypeScript template

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -41,7 +41,7 @@ https://mui.com/store/* https://material-ui.com/store/:splat 302!
 /r/issue-template https://codesandbox.io/s/material-ui-issue-latest-s2dsx
 /r/issue-template-next https://codesandbox.io/s/material-ui-issue-next-o7xkt
 /r/issue-template-latest https://codesandbox.io/s/material-ui-issue-latest-s2dsx
-/r/ts-issue-template https://www.typescriptlang.org/play/#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nXHAPSdwwAWWOLhKQAdllEx0ATwgBXOHNRYAJnQC+cIiXIABEMhhYowZABsAtHOCdhlMnToE5o-MAii4AESwgIACgBKVnYuHgBNeSghCBUsDSA 302
+/r/ts-issue-template https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nXHAPSdwwAWWOLhKQAdllEx0ATwgBXOHNRYAJnQC+cIiXIABEHOCcQyGFijBkAGzJ06BOaPzAIouABEsICAAoAlKzsXDwAmvJQQhAqWBpAA 302
 /r/custom-component-variants /customization/components/#adding-new-component-variants
 /r/x-license https://material-ui.com/store/items/material-ui-pro/
 /r/migration-v4 /guides/migration-v4/


### PR DESCRIPTION
I noticed this in https://github.com/mui-org/material-ui-x/pull/3530/files#r777226554 which we link in:

https://github.com/mui-org/material-ui/blob/b9117f2ff7fa99d85dd66b5c240dcb32e833a1c9/.github/ISSUE_TEMPLATE/1.bug.yml#L42

**Before**

<img width="410" alt="Screenshot 2022-01-12 at 23 01 52" src="https://user-images.githubusercontent.com/3165635/149230134-28de45d0-aaff-4634-b42c-bacb92df2bb6.png">

**After**

<img width="350" alt="Screenshot 2022-01-12 at 23 01 46" src="https://user-images.githubusercontent.com/3165635/149230130-9efa1745-2cd9-4748-8223-afd73cc77382.png">
