### PR TITLE
[Fab] added z-index to fab component

### DIFF
--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -52,6 +52,7 @@ const FabRoot = styled(ButtonBase, {
     minWidth: 0,
     width: 56,
     height: 56,
+    zIndex: 1050,
     boxShadow: theme.shadows[6],
     '&:active': {
       boxShadow: theme.shadows[12],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

As discussed in [this issue](https://github.com/mui-org/material-ui/issues/30603) added `z-index` to `Fab` component in order to keep it above other elements with `z-index` like `Badge` which has `z-index: 1`.