### PR TITLE
[AvatarGroup] allow cascade direction to be configurable

### DIFF
--- a/docs/pages/api-docs/avatar-group.json
+++ b/docs/pages/api-docs/avatar-group.json
@@ -1,5 +1,9 @@
 {
   "props": {
+    "cascade": {
+      "type": { "name": "enum", "description": "'above'<br>&#124;&nbsp;'below'" },
+      "default": "'below'"
+    },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
     "max": { "type": { "name": "custom", "description": "number" }, "default": "5" },

--- a/docs/src/pages/components/avatars/CascadeAvatars.js
+++ b/docs/src/pages/components/avatars/CascadeAvatars.js
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Avatar from '@mui/material/Avatar';
+import Stack from '@mui/material/Stack';
+import AvatarGroup from '@mui/material/AvatarGroup';
+
+export default function CascadeAvatars() {
+  return (
+    <Stack>
+      <AvatarGroup max={2} cascade="below">
+        <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
+        <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
+        <Avatar alt="Trevor Henderson" src="/static/images/avatar/5.jpg" />
+      </AvatarGroup>
+
+      <AvatarGroup max={2} cascade="above">
+        <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
+        <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
+        <Avatar alt="Trevor Henderson" src="/static/images/avatar/5.jpg" />
+      </AvatarGroup>
+    </Stack>
+  );
+}

--- a/docs/src/pages/components/avatars/CascadeAvatars.tsx
+++ b/docs/src/pages/components/avatars/CascadeAvatars.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Avatar from '@mui/material/Avatar';
+import Stack from '@mui/material/Stack';
+import AvatarGroup from '@mui/material/AvatarGroup';
+
+export default function CascadeAvatars() {
+  return (
+    <Stack>
+      <AvatarGroup max={2} cascade="below">
+        <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
+        <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
+        <Avatar alt="Trevor Henderson" src="/static/images/avatar/5.jpg" />
+      </AvatarGroup>
+
+      <AvatarGroup max={2} cascade="above">
+        <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
+        <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
+        <Avatar alt="Trevor Henderson" src="/static/images/avatar/5.jpg" />
+      </AvatarGroup>
+    </Stack>
+  );
+}

--- a/docs/src/pages/components/avatars/CascadeAvatars.tsx.preview
+++ b/docs/src/pages/components/avatars/CascadeAvatars.tsx.preview
@@ -1,0 +1,11 @@
+<AvatarGroup max={2} cascade="below">
+  <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
+  <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
+  <Avatar alt="Trevor Henderson" src="/static/images/avatar/5.jpg" />
+</AvatarGroup>
+
+<AvatarGroup max={2} cascade="above">
+  <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
+  <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
+  <Avatar alt="Trevor Henderson" src="/static/images/avatar/5.jpg" />
+</AvatarGroup>

--- a/docs/src/pages/components/avatars/avatars.md
+++ b/docs/src/pages/components/avatars/avatars.md
@@ -61,6 +61,12 @@ If there is an error loading the avatar image, the component falls back to an al
 
 {{"demo": "pages/components/avatars/GroupAvatars.js"}}
 
+### Cascade
+
+If you need to control whether the avatars stack above or below each other, use the `cascade` prop.
+
+{{"demo": "pages/components/avatars/CascadeAvatars.js"}}
+
 ### Total avatars
 
 If you need to control the total number of avatars not shown, you can use the `total` prop.

--- a/docs/translations/api-docs/avatar-group/avatar-group.json
+++ b/docs/translations/api-docs/avatar-group/avatar-group.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "cascade": "Defines whether each avatar in the stack, including the total counter, is positioned on top of or under the one that came before.",
     "children": "The avatars to stack.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "max": "Max avatars to show before +x.",

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.d.ts
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.d.ts
@@ -42,6 +42,11 @@ export interface AvatarGroupProps extends StandardProps<React.HTMLAttributes<HTM
     'circular' | 'rounded' | 'square',
     AvatarGroupPropsVariantOverrides
   >;
+  /**
+   * Defines whether each avatar in the stack, including the total counter, is positioned on top of or under the one that came before.
+   * @default 'below'
+   */
+  cascade?: 'above' | 'below';
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I am working with a design that utilizes `AvatarGroup`, but the design requires the groups to cascade above each other, rather than below.  It seems reasonable to me that a prop for this should exist to configure this.

I will write tests as soon as it's agreed that this has enough value to be added.  Here's what it looks like right now:

<img width="50%" src="https://user-images.githubusercontent.com/15232461/149547993-faff9c0e-ddd8-4a17-82bf-17c9402dd661.png" />

1. I read https://mui.com/guides/api/#property-naming and didn't think a prop named `above` or `below` has enough context.  Maybe `cascadeAbove` or `cascadeBelow` or something?
2. There's more I'd like to do here to make the spacing between the avatars more configurable, but at least this is a start to use theme spacing rather than what it was before (hardcoded value).

### Notes
This component is on [react-ui-roundup](https://react-ui-roundup.dimitrimitropoulos.com/#AvatarGroup) if looking at other implementations is helpful:

<a href="https://react-ui-roundup.dimitrimitropoulos.com/#AvatarGroup"><img width="50%" src="https://user-images.githubusercontent.com/15232461/149551251-48125c6b-c581-451e-9d3e-d6b1ae23458a.png" /></a>


