### PR TITLE
[docs] add additional explanation to `CSS injection order` section

### DIFF
--- a/docs/src/pages/styles/advanced/advanced.md
+++ b/docs/src/pages/styles/advanced/advanced.md
@@ -227,7 +227,7 @@ Note that this doesn't support selectors, or nested rules.
 > as it's one of the key elements to know when overriding styles.
 > You are encouraged to read this MDN paragraph: [How is specificity calculated?](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#How_is_specificity_calculated)
 
-By default, the style tags are injected **last** in the `<head>` element of the page.
+By default, the style tags are injected **last** in the `<head>` element of the page. (If there is style tags in the page `<head>` element, it is injected after the last style tags.)
 They gain more specificity than any other style tags on your page e.g. CSS modules, styled components.
 
 ### injectFirst


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

When injecting a style in the emotion-sheet, if a style already exists in the head element, the style is injected after the style.
https://github.com/emotion-js/emotion/blob/516fe458058c9ec8218740472b301e935801ebbc/packages/sheet/src/index.js#L101-L105

(related issues) In Nextjs development mode, the mui style is added to the top of the head element due to the already inserted fouc-related style elements.
![스크린샷 2022-01-16 오후 5 02 53](https://user-images.githubusercontent.com/11916476/149652125-bdc96fd9-7763-4041-abaf-3dcf31465f7e.png)

![스크린샷 2022-01-16 오후 4 48 37](https://user-images.githubusercontent.com/11916476/149651963-1aa96057-8db4-443b-b1b0-99466dd3b314.png)

When injecting styles, the before variable points to the script element.
![스크린샷 2022-01-16 오후 4 49 24](https://user-images.githubusercontent.com/11916476/149652011-b0caae5d-6ec7-4734-9a4f-824fdde8a066.png)