### PR TITLE
[utils] Use built-in hook when available for useId

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1409,11 +1409,6 @@ describe('<Autocomplete />', () => {
       }).toWarnDev([
         'returns duplicated headers',
         !strictModeDoubleLoggingSupressed && 'returns duplicated headers',
-        // React 18 Strict Effects run mount effects twice which lead to a cascading update
-        React.version.startsWith('18') && 'returns duplicated headers',
-        React.version.startsWith('18') &&
-          !strictModeDoubleLoggingSupressed &&
-          'returns duplicated headers',
       ]);
       const options = screen.getAllByRole('option').map((el) => el.textContent);
       expect(options).to.have.length(7);

--- a/packages/mui-utils/src/useId.test.js
+++ b/packages/mui-utils/src/useId.test.js
@@ -1,36 +1,97 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { createRenderer } from 'test/utils';
+import { createRenderer, screen } from 'test/utils';
 import useId from './useId';
 
-const TestComponent = ({ id: idProp }) => {
-  const id = useId(idProp);
-  return <span>{id}</span>;
-};
-
-TestComponent.propTypes = {
-  id: PropTypes.string,
-};
-
 describe('useId', () => {
-  const { render } = createRenderer();
+  const { render, renderToString } = createRenderer();
 
   it('returns the provided ID', () => {
-    const { getByText, setProps } = render(<TestComponent id="some-id" />);
+    const TestComponent = ({ id: idProp }) => {
+      const id = useId(idProp);
+      return <span data-testid="target" id={id} />;
+    };
+    const { hydrate } = renderToString(<TestComponent id="some-id" />);
+    const { setProps } = hydrate();
 
-    expect(getByText('some-id')).not.to.equal(null);
+    expect(screen.getByTestId('target')).to.have.property('id', 'some-id');
 
     setProps({ id: 'another-id' });
-    expect(getByText('another-id')).not.to.equal(null);
+
+    expect(screen.getByTestId('target')).to.have.property('id', 'another-id');
   });
 
   it("generates an ID if one isn't provided", () => {
-    const { getByText, setProps } = render(<TestComponent />);
+    const TestComponent = ({ id: idProp }) => {
+      const id = useId(idProp);
+      return <span data-testid="target" id={id} />;
+    };
+    const { hydrate } = renderToString(<TestComponent />);
+    const { setProps } = hydrate();
 
-    expect(getByText(/^mui-[0-9]+$/)).not.to.equal(null);
+    expect(screen.getByTestId('target').id).not.to.equal('');
 
     setProps({ id: 'another-id' });
-    expect(getByText('another-id')).not.to.equal(null);
+    expect(screen.getByTestId('target')).to.have.property('id', 'another-id');
+  });
+
+  it('can be suffixed', () => {
+    function Widget() {
+      const id = useId();
+      const labelId = `${id}-label`;
+
+      return (
+        <React.Fragment>
+          <span data-testid="labelable" aria-labelledby={labelId} />
+          <span data-testid="label" id={labelId}>
+            Label
+          </span>
+        </React.Fragment>
+      );
+    }
+    render(<Widget />);
+
+    expect(screen.getByTestId('labelable')).to.have.attr(
+      'aria-labelledby',
+      screen.getByTestId('label').id,
+    );
+  });
+
+  it('can be used in in IDREF attributes', () => {
+    function Widget() {
+      const labelPartA = useId();
+      const labelPartB = useId();
+
+      return (
+        <React.Fragment>
+          <span data-testid="labelable" aria-labelledby={`${labelPartA} ${labelPartB}`} />
+          <span data-testid="labelA" id={labelPartA}>
+            A
+          </span>
+          <span data-testid="labelB" id={labelPartB}>
+            B
+          </span>
+        </React.Fragment>
+      );
+    }
+    render(<Widget />);
+
+    expect(screen.getByTestId('labelable')).to.have.attr(
+      'aria-labelledby',
+      `${screen.getByTestId('labelA').id} ${screen.getByTestId('labelB').id}`,
+    );
+  });
+
+  it('provides an ID on server in React 18', function test() {
+    if (React.useId === undefined) {
+      this.skip();
+    }
+    const TestComponent = () => {
+      const id = useId();
+      return <span data-testid="target" id={id} />;
+    };
+    renderToString(<TestComponent />);
+
+    expect(screen.getByTestId('target').id).not.to.equal('');
   });
 });

--- a/packages/mui-utils/src/useId.ts
+++ b/packages/mui-utils/src/useId.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 let globalId = 0;
-function useRandomId(idOverride?: string): string | undefined {
+function useGlobalId(idOverride?: string): string | undefined {
   const [defaultId, setDefaultId] = React.useState(idOverride);
   const id = idOverride || defaultId;
   React.useEffect(() => {
@@ -31,5 +31,5 @@ export default function useId(idOverride?: string): string | undefined {
     return idOverride ?? reactId;
   }
   // eslint-disable-next-line react-hooks/rules-of-hooks -- `React.useId` is invariant at runtime.
-  return useRandomId(idOverride);
+  return useGlobalId(idOverride);
 }

--- a/packages/mui-utils/src/useId.ts
+++ b/packages/mui-utils/src/useId.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 let globalId = 0;
-export default function useId(idOverride?: string): string | undefined {
+function useRandomId(idOverride?: string): string | undefined {
   const [defaultId, setDefaultId] = React.useState(idOverride);
   const id = idOverride || defaultId;
   React.useEffect(() => {
@@ -15,4 +15,21 @@ export default function useId(idOverride?: string): string | undefined {
     }
   }, [defaultId]);
   return id;
+}
+
+// eslint-disable-next-line no-useless-concat -- Workaround for https://github.com/webpack/webpack/issues/14814
+const maybeReactUseId: undefined | (() => string) = (React as any)['useId' + ''];
+/**
+ *
+ * @example <div id={useId()} />
+ * @param idOverride
+ * @returns {string}
+ */
+export default function useId(idOverride?: string): string | undefined {
+  if (maybeReactUseId !== undefined) {
+    const reactId = maybeReactUseId();
+    return idOverride ?? reactId;
+  }
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- `React.useId` is invariant at runtime.
+  return useRandomId(idOverride);
 }


### PR DESCRIPTION
Based on https://github.com/mui-org/material-ui/pull/30657

Restores https://github.com/mui-org/material-ui/pull/26489 which was reverted in https://github.com/mui-org/material-ui/pull/29870 by using a workaround described in https://github.com/webpack/webpack/issues/14814#issuecomment-1013856049.

Failed checks are from the React 18 run and just `git diff --exit-code` which is expected.

- [React 17 pipeline](https://app.circleci.com/pipelines/github/mui-org/material-ui/62934/workflows/8a3a2cc0-d707-41eb-8a93-46372d581c72)
- [React 18 pipeline](https://app.circleci.com/pipelines/github/mui-org/material-ui/62935/workflows/93586a6b-c379-4de3-8df1-f4ef316f4149)
- [x] verify locally if a build from this PR works locally in a Create React App but not a build using `@mui/utils@5.2.0` (which is not using the workaround linked above).