### PR TITLE
[useMediaQuery] Ensure no tearing in React 18

### DIFF
--- a/packages/mui-material/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/mui-material/src/useMediaQuery/useMediaQuery.ts
@@ -26,42 +26,24 @@ export type MuiMediaQueryListListener = (event: MuiMediaQueryListEvent) => void;
 export interface Options {
   defaultMatches?: boolean;
   matchMedia?: typeof window.matchMedia;
+  /**
+   * This option is kept for backwards compatibility and has no longer any effect.
+   * It's previous behavior is now handled automatically.
+   */
+  // TODO: Deprecate for v6
   noSsr?: boolean;
   ssrMatchMedia?: (query: string) => { matches: boolean };
 }
 
-export default function useMediaQuery<Theme = unknown>(
-  queryInput: string | ((theme: Theme) => string),
-  options: Options = {},
+function useMediaQueryOld(
+  query: string,
+  defaultMatches: boolean,
+  matchMedia: typeof window.matchMedia | null,
+  ssrMatchMedia: ((query: string) => { matches: boolean }) | null,
+  noSsr: boolean | undefined,
 ): boolean {
-  const theme = useTheme<Theme>();
-  // Wait for jsdom to support the match media feature.
-  // All the browsers MUI support have this built-in.
-  // This defensive check is here for simplicity.
-  // Most of the time, the match media logic isn't central to people tests.
   const supportMatchMedia =
     typeof window !== 'undefined' && typeof window.matchMedia !== 'undefined';
-  const {
-    defaultMatches = false,
-    matchMedia = supportMatchMedia ? window.matchMedia : null,
-    noSsr = false,
-    ssrMatchMedia = null,
-  } = getThemeProps({ name: 'MuiUseMediaQuery', props: options, theme });
-
-  if (process.env.NODE_ENV !== 'production') {
-    if (typeof queryInput === 'function' && theme === null) {
-      console.error(
-        [
-          'MUI: The `query` argument provided is invalid.',
-          'You are providing a function without a theme in the context.',
-          'One of the parent elements needs to use a ThemeProvider.',
-        ].join('\n'),
-      );
-    }
-  }
-
-  let query = typeof queryInput === 'function' ? queryInput(theme) : queryInput;
-  query = query.replace(/^@media( ?)/m, '');
 
   const [match, setMatch] = React.useState(() => {
     if (noSsr && supportMatchMedia) {
@@ -93,12 +75,100 @@ export default function useMediaQuery<Theme = unknown>(
       }
     };
     updateMatch();
+    // TODO: Use `addEventListener` once support for Safari < 14 is dropped
     queryList.addListener(updateMatch);
     return () => {
       active = false;
       queryList.removeListener(updateMatch);
     };
   }, [query, matchMedia, supportMatchMedia]);
+
+  return match;
+}
+
+// eslint-disable-next-line no-useless-concat -- Workaround for https://github.com/webpack/webpack/issues/14814
+const maybeReactUseSyncExternalStore: undefined | any = (React as any)['useSyncExternalStore' + ''];
+
+function useMediaQueryNew(
+  query: string,
+  defaultMatches: boolean,
+  matchMedia: typeof window.matchMedia | null,
+  ssrMatchMedia: ((query: string) => { matches: boolean }) | null,
+): boolean {
+  const getDefaultSnapshot = React.useCallback(() => defaultMatches, [defaultMatches]);
+  const getServerSnapshot = React.useMemo(() => {
+    if (ssrMatchMedia !== null) {
+      const { matches } = ssrMatchMedia(query);
+      return () => matches;
+    }
+    return getDefaultSnapshot;
+  }, [getDefaultSnapshot, query, ssrMatchMedia]);
+  const [getSnapshot, subscribe] = React.useMemo(() => {
+    if (matchMedia === null) {
+      return [getDefaultSnapshot, () => () => {}];
+    }
+
+    const mediaQueryList = matchMedia(query);
+
+    return [
+      () => mediaQueryList.matches,
+      (notify: () => void) => {
+        // TODO: Use `addEventListener` once support for Safari < 14 is dropped
+        mediaQueryList.addListener(notify);
+        return () => {
+          mediaQueryList.removeListener(notify);
+        };
+      },
+    ];
+  }, [getDefaultSnapshot, matchMedia, query]);
+  const match = maybeReactUseSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  return match;
+}
+
+export default function useMediaQuery<Theme = unknown>(
+  queryInput: string | ((theme: Theme) => string),
+  options: Options = {},
+): boolean {
+  const theme = useTheme<Theme>();
+  // Wait for jsdom to support the match media feature.
+  // All the browsers MUI support have this built-in.
+  // This defensive check is here for simplicity.
+  // Most of the time, the match media logic isn't central to people tests.
+  const supportMatchMedia =
+    typeof window !== 'undefined' && typeof window.matchMedia !== 'undefined';
+  const {
+    defaultMatches = false,
+    matchMedia = supportMatchMedia ? window.matchMedia : null,
+    ssrMatchMedia = null,
+    noSsr,
+  } = getThemeProps({ name: 'MuiUseMediaQuery', props: options, theme });
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (typeof queryInput === 'function' && theme === null) {
+      console.error(
+        [
+          'MUI: The `query` argument provided is invalid.',
+          'You are providing a function without a theme in the context.',
+          'One of the parent elements needs to use a ThemeProvider.',
+        ].join('\n'),
+      );
+    }
+  }
+
+  let query = typeof queryInput === 'function' ? queryInput(theme) : queryInput;
+  query = query.replace(/^@media( ?)/m, '');
+
+  // TODO: Drop `useMediaQueryOld` and use  `use-sync-external-store` shim in `useMediaQueryNew` once the package is stable
+  const useMediaQueryImplementation =
+    maybeReactUseSyncExternalStore !== undefined ? useMediaQueryNew : useMediaQueryOld;
+  const match = useMediaQueryImplementation(
+    query,
+    defaultMatches,
+    matchMedia,
+    ssrMatchMedia,
+    noSsr,
+  );
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks


### PR DESCRIPTION
Restores https://github.com/mui-org/material-ui/pull/28491 which was reverted in https://github.com/mui-org/material-ui/pull/29870 by using a workaround described in https://github.com/webpack/webpack/issues/14814#issuecomment-1013856049.

Failed checks are from the React 18 run and just `git diff --exit-code` which is expected.

- [React 17 pipeline](https://app.circleci.com/pipelines/github/mui-org/material-ui/62094/workflows/4346c0f9-58e8-4d22-aadc-ce2264f09864)
- [React 18 pipeline](https://app.circleci.com/pipelines/github/mui-org/material-ui/62103/workflows/ae5894d9-0f1e-4021-8f50-fd8079480564)
- [x] verify locally if a build from this PR works locally in a Create React App but not a build using `@mui/material@5.2.0` (which is not using the workaround linked above).