### PR TITLE
[FormControlLabel][FormGroup] add Mui-error class

### DIFF
--- a/docs/pages/api-docs/form-control-label.json
+++ b/docs/pages/api-docs/form-control-label.json
@@ -41,9 +41,10 @@
       "labelPlacementTop",
       "labelPlacementBottom",
       "disabled",
-      "label"
+      "label",
+      "error"
     ],
-    "globalClasses": { "disabled": "Mui-disabled" },
+    "globalClasses": { "disabled": "Mui-disabled", "error": "Mui-error" },
     "name": "MuiFormControlLabel"
   },
   "spread": true,

--- a/docs/pages/api-docs/form-group.json
+++ b/docs/pages/api-docs/form-group.json
@@ -11,7 +11,11 @@
     }
   },
   "name": "FormGroup",
-  "styles": { "classes": ["root", "row"], "globalClasses": {}, "name": "MuiFormGroup" },
+  "styles": {
+    "classes": ["root", "row", "error"],
+    "globalClasses": { "error": "Mui-error" },
+    "name": "MuiFormGroup"
+  },
   "spread": true,
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/FormGroup/FormGroup.js",

--- a/docs/translations/api-docs/form-control-label/form-control-label.json
+++ b/docs/translations/api-docs/form-control-label/form-control-label.json
@@ -39,6 +39,11 @@
     "label": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the label's Typography component"
+    },
+    "error": {
+      "description": "State class applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>error={true}</code>"
     }
   }
 }

--- a/docs/translations/api-docs/form-group/form-group.json
+++ b/docs/translations/api-docs/form-group/form-group.json
@@ -12,6 +12,11 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>row={true}</code>"
+    },
+    "error": {
+      "description": "State class applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>error={true}</code>"
     }
   }
 }

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.js
@@ -11,11 +11,17 @@ import useThemeProps from '../styles/useThemeProps';
 import formControlLabelClasses, {
   getFormControlLabelUtilityClasses,
 } from './formControlLabelClasses';
+import formControlState from '../FormControl/formControlState';
 
 const useUtilityClasses = (ownerState) => {
-  const { classes, disabled, labelPlacement } = ownerState;
+  const { classes, disabled, labelPlacement, error } = ownerState;
   const slots = {
-    root: ['root', disabled && 'disabled', `labelPlacement${capitalize(labelPlacement)}`],
+    root: [
+      'root',
+      disabled && 'disabled',
+      `labelPlacement${capitalize(labelPlacement)}`,
+      error && 'error',
+    ],
     label: ['label', disabled && 'disabled'],
   };
 
@@ -108,11 +114,18 @@ const FormControlLabel = React.forwardRef(function FormControlLabel(inProps, ref
     }
   });
 
+  const fcs = formControlState({
+    props,
+    muiFormControl,
+    states: ['error'],
+  });
+
   const ownerState = {
     ...props,
     disabled,
     label,
     labelPlacement,
+    error: fcs.error,
   };
 
   const classes = useUtilityClasses(ownerState);

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.test.js
@@ -136,6 +136,17 @@ describe('<FormControlLabel />', () => {
   });
 
   describe('with FormControl', () => {
+    describe('error', () => {
+      it('should have the error class', () => {
+        const { getByTestId } = render(
+          <FormControl error>
+            <FormControlLabel data-testid="FormControlLabel" control={<div />} label="Pizza" />
+          </FormControl>,
+        );
+
+        expect(getByTestId('FormControlLabel')).to.have.class(classes.error);
+      });
+    });
     describe('enabled', () => {
       it('should not have the disabled class', () => {
         const { getByTestId } = render(

--- a/packages/mui-material/src/FormControlLabel/formControlLabelClasses.ts
+++ b/packages/mui-material/src/FormControlLabel/formControlLabelClasses.ts
@@ -13,6 +13,8 @@ export interface FormControlLabelClasses {
   disabled: string;
   /** Styles applied to the label's Typography component. */
   label: string;
+  /** State class applied to the root element if `error={true}`. */
+  error: string;
 }
 
 export type FormControlLabelClassKey = keyof FormControlLabelClasses;
@@ -23,7 +25,15 @@ export function getFormControlLabelUtilityClasses(slot: string): string {
 
 const formControlLabelClasses: FormControlLabelClasses = generateUtilityClasses(
   'MuiFormControlLabel',
-  ['root', 'labelPlacementStart', 'labelPlacementTop', 'labelPlacementBottom', 'disabled', 'label'],
+  [
+    'root',
+    'labelPlacementStart',
+    'labelPlacementTop',
+    'labelPlacementBottom',
+    'disabled',
+    'label',
+    'error',
+  ],
 );
 
 export default formControlLabelClasses;

--- a/packages/mui-material/src/FormGroup/FormGroup.js
+++ b/packages/mui-material/src/FormGroup/FormGroup.js
@@ -5,12 +5,14 @@ import { unstable_composeClasses as composeClasses } from '@mui/base';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
 import { getFormGroupUtilityClass } from './formGroupClasses';
+import useFormControl from '../FormControl/useFormControl';
+import formControlState from '../FormControl/formControlState';
 
 const useUtilityClasses = (ownerState) => {
-  const { classes, row } = ownerState;
+  const { classes, row, error } = ownerState;
 
   const slots = {
-    root: ['root', row && 'row'],
+    root: ['root', row && 'row', error && 'error'],
   };
 
   return composeClasses(slots, getFormGroupUtilityClass, classes);
@@ -45,7 +47,14 @@ const FormGroup = React.forwardRef(function FormGroup(inProps, ref) {
   });
 
   const { className, row = false, ...other } = props;
-  const ownerState = { ...props, row };
+  const muiFormControl = useFormControl();
+  const fcs = formControlState({
+    props,
+    muiFormControl,
+    states: ['error'],
+  });
+
+  const ownerState = { ...props, row, error: fcs.error };
   const classes = useUtilityClasses(ownerState);
 
   return (

--- a/packages/mui-material/src/FormGroup/FormGroup.test.js
+++ b/packages/mui-material/src/FormGroup/FormGroup.test.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, describeConformance } from 'test/utils';
 import FormGroup, { formGroupClasses as classes } from '@mui/material/FormGroup';
+import FormControl from '@mui/material/FormControl';
 
 describe('<FormGroup />', () => {
   const { render } = createRenderer();
@@ -24,5 +25,20 @@ describe('<FormGroup />', () => {
     );
 
     expect(queryByTestId('test-children')).not.to.equal(null);
+  });
+  describe('with FormControl', () => {
+    describe('error', () => {
+      it(`should have the error class`, () => {
+        const { getByTestId } = render(
+          <FormControl error>
+            <FormGroup data-testid="FormGroup">
+              <div />
+            </FormGroup>
+          </FormControl>,
+        );
+
+        expect(getByTestId('FormGroup')).to.have.class(classes.error);
+      });
+    });
   });
 });

--- a/packages/mui-material/src/FormGroup/formGroupClasses.ts
+++ b/packages/mui-material/src/FormGroup/formGroupClasses.ts
@@ -5,6 +5,8 @@ export interface FormGroupClasses {
   root: string;
   /** Styles applied to the root element if `row={true}`. */
   row: string;
+  /** State class applied to the root element if `error={true}`. */
+  error: string;
 }
 
 export type FormGroupClassKey = keyof FormGroupClasses;
@@ -13,6 +15,10 @@ export function getFormGroupUtilityClass(slot: string): string {
   return generateUtilityClass('MuiFormGroup', slot);
 }
 
-const formGroupClasses: FormGroupClasses = generateUtilityClasses('MuiFormGroup', ['root', 'row']);
+const formGroupClasses: FormGroupClasses = generateUtilityClasses('MuiFormGroup', [
+  'root',
+  'row',
+  'error',
+]);
 
 export default formGroupClasses;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes: #30576

[demo](https://codesandbox.io/s/basictimepicker-material-demo-forked-dyl5g?file=/demo.js)

**Problem:**

- `FormControlLabel` and `FormGroup` components did not inherit the `Mui-error` class


**Solution:**

- Adding Mui-error className option based on the `FormControl` to these two components


