### PR TITLE
[CI] use --frozen-lockfile for reproducible builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ commands:
                   - v5-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
       - run:
           name: Install js dependencies
-          command: yarn install --verbose
+          command: yarn install --frozen-lockfile --verbose
           environment:
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: <<# parameters.browsers >>0<</ parameters.browsers >><<^ parameters.browsers >>1<</ parameters.browsers >>
       - save_cache:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: 14
           cache: 'yarn' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
         env:
           # Don't need playwright in this job
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1


### PR DESCRIPTION
This makes sure the lock file is the source of truth for ci (https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-frozen-lockfile)
It will fail the build when the lockfile is out of sync