### PR TITLE
[docs] Make Autocomplete docs gender neutral

### DIFF
--- a/docs/translations/api-docs/autocomplete/autocomplete.json
+++ b/docs/translations/api-docs/autocomplete/autocomplete.json
@@ -8,7 +8,7 @@
     "ChipProps": "Props applied to the <a href=\"/api/chip/\"><code>Chip</code></a> element.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "clearIcon": "The icon to display in place of the default clear icon.",
-    "clearOnBlur": "If <code>true</code>, the input&#39;s text is cleared on blur if no value is selected.<br>Set to <code>true</code> if you want to help the user enter a new value. Set to <code>false</code> if you want to help the user resume his search.",
+    "clearOnBlur": "If <code>true</code>, the input&#39;s text is cleared on blur if no value is selected.<br>Set to <code>true</code> if you want to help the user enter a new value. Set to <code>false</code> if you want to help the user resume their search.",
     "clearOnEscape": "If <code>true</code>, clear all values when the user presses escape and the popup is closed.",
     "clearText": "Override the default text for the <em>clear</em> icon button.<br>For localization purposes, you can use the provided <a href=\"/guides/localization/\">translations</a>.",
     "closeText": "Override the default text for the <em>close popup</em> icon button.<br>For localization purposes, you can use the provided <a href=\"/guides/localization/\">translations</a>.",

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.d.ts
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.d.ts
@@ -74,7 +74,7 @@ export interface UseAutocompleteProps<
    * If `true`, the input's text is cleared on blur if no value is selected.
    *
    * Set to `true` if you want to help the user enter a new value.
-   * Set to `false` if you want to help the user resume his search.
+   * Set to `false` if you want to help the user resume their search.
    * @default !props.freeSolo
    */
   clearOnBlur?: boolean;

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -698,7 +698,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * If `true`, the input's text is cleared on blur if no value is selected.
    *
    * Set to `true` if you want to help the user enter a new value.
-   * Set to `false` if you want to help the user resume his search.
+   * Set to `false` if you want to help the user resume their search.
    * @default !props.freeSolo
    */
   clearOnBlur: PropTypes.bool,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

# Summary

Changed the AutoComplete `clearOnBlur` API documentation from 

> If true, the input's text is cleared on blur if no value is selected.Set to true if you want to help the user enter a new value. Set to false if you want to help the user resume **his** search.

to

> If true, the input's text is cleared on blur if no value is selected.Set to true if you want to help the user enter a new value. Set to false if you want to help the user resume **their** search.

# Motivation

The AutoComplete `clearOnBlur` API documentation fails to recognise that about half the planet/potential users do not identify with he/his pronouns. I figured that this was a small enough change that it would be reasonably simple to fix.

EDIT: I'd like to say thanks for all the work that has gone into the `material-ui` package and acknowledge that this might well have been a result of unconscious bias. But here is the opportunity to fix that 😄 

![image](https://user-images.githubusercontent.com/12929395/149855294-d41cb167-55bb-4f94-bbf1-456bee0ffacd.png)

