### PR TITLE
[docs] Add Checkbox color prop change

### DIFF
--- a/docs/src/pages/guides/migration-v4/migration-v4.md
+++ b/docs/src/pages/guides/migration-v4/migration-v4.md
@@ -1129,6 +1129,15 @@ As the core components use emotion as their style engine, the props used by emot
 
 ### Checkbox
 
+- The checkbox color prop is now "primary" by default.
+  To continue using the "secondary" color, you must explicitly indicate `secondary`.
+  This brings the checkbox closer to the Material Design guidelines.
+
+  ```diff
+  -<Checkbox />
+  +<Checkbox color="secondary" />
+  ```
+
 - The component doesn't have `.MuiIconButton-root` and `.MuiIconButton-label` class names anymore, target `.MuiButtonBase-root` instead.
 
   ```diff


### PR DESCRIPTION
Same as other components (`Radio`, `Switch` etc), the default value for the `color` prop has changed, it was "secondary" in [v4](https://github.com/mui-org/material-ui/blob/77a8daeed0e8efa67c6d86f3cc40239dc6eb3d94/packages/material-ui/src/Checkbox/Checkbox.js#L66), when it is now "primary" in [v5](https://github.com/mui-org/material-ui/blob/681632be73fa2d6dc090cf72d01ef59f8b98f822/packages/mui-material/src/Checkbox/Checkbox.js#L77).

Copied the text from `Radio` component description.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

https://deploy-preview-30697--material-ui.netlify.app/guides/migration-v4/#checkbox
