### PR TITLE
[docs] Change ThemeProvider API links

### DIFF
--- a/packages/mui-material/src/styles/ThemeProvider.d.ts
+++ b/packages/mui-material/src/styles/ThemeProvider.d.ts
@@ -10,7 +10,7 @@ export interface ThemeProviderProps<Theme = DefaultTheme> {
  * It should preferably be used at **the root of your component tree**.
  * API:
  *
- * - [ThemeProvider API](https://mui.com/api/theme-provider/)
+ * - [ThemeProvider API](https://mui.com/styles/api/#themeprovider)
  */
 export default function ThemeProvider<T = DefaultTheme>(
   props: ThemeProviderProps<T>,

--- a/packages/mui-material/src/styles/ThemeProvider.d.ts
+++ b/packages/mui-material/src/styles/ThemeProvider.d.ts
@@ -10,7 +10,7 @@ export interface ThemeProviderProps<Theme = DefaultTheme> {
  * It should preferably be used at **the root of your component tree**.
  * API:
  *
- * - [ThemeProvider API](https://mui.com/styles/api/#themeprovider)
+ * - [ThemeProvider API](/customization/theming/#themeprovider)
  */
 export default function ThemeProvider<T = DefaultTheme>(
   props: ThemeProviderProps<T>,

--- a/packages/mui-system/src/ThemeProvider/ThemeProvider.d.ts
+++ b/packages/mui-system/src/ThemeProvider/ThemeProvider.d.ts
@@ -10,7 +10,7 @@ export interface ThemeProviderProps<Theme = DefaultTheme> {
  * It should preferably be used at **the root of your component tree**.
  * API:
  *
- * - [ThemeProvider API](https://mui.com/api/theme-provider/)
+ * - [ThemeProvider API](https://mui.com/styles/api/#themeprovider)
  */
 export default function ThemeProvider<T = DefaultTheme>(
   props: ThemeProviderProps<T>,

--- a/packages/mui-system/src/ThemeProvider/ThemeProvider.d.ts
+++ b/packages/mui-system/src/ThemeProvider/ThemeProvider.d.ts
@@ -10,7 +10,7 @@ export interface ThemeProviderProps<Theme = DefaultTheme> {
  * It should preferably be used at **the root of your component tree**.
  * API:
  *
- * - [ThemeProvider API](https://mui.com/styles/api/#themeprovider)
+ * - [ThemeProvider API](/customization/theming/#themeprovider)
  */
 export default function ThemeProvider<T = DefaultTheme>(
   props: ThemeProviderProps<T>,


### PR DESCRIPTION
Former link was redirecting to a 404 page. I presume this link is the correct one, cheers!

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
