### PR TITLE
[docs] Post migration preparation fix

### DIFF
--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -131,6 +131,11 @@ const pages = [
       {
         pathname: '/x/data-grid/',
         subheader: 'data-grid',
+        children: [
+          { pathname: '/x/react-data-grid/', title: 'Overview' },
+          { pathname: '/x/react-data-grid/demo/', title: 'Demo' },
+          { pathname: '/x/react-data-grid/getting-started/', title: 'Getting Started' },
+        ],
       },
       {
         pathname: '/material',
@@ -164,13 +169,7 @@ const pages = [
     title: 'Component API',
     pathname: '/material/api',
     icon: 'CodeIcon',
-    children: [
-      ...pagesApi,
-      {
-        pathname: '/x/api/mui-data-grid',
-        title: 'Data Grid',
-      },
-    ],
+    children: pagesApi,
   },
   {
     pathname: '/material/customization',

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -223,6 +223,7 @@ module.exports = {
   },
   reactStrictMode,
   trailingSlash: true,
+  // rewrites has no effect when run `next export` for production
   async rewrites() {
     return [
       { source: `/:lang(${LANGUAGES.join('|')})?/:rest*`, destination: '/:rest*' },
@@ -230,6 +231,8 @@ module.exports = {
       { source: '/api/:rest*/', destination: '/api-docs/:rest*/' },
     ];
   },
+  // For developement, adjust the redirects here (no effect on production because of `next export`)
+  // For production, configure at `docs/public/_redirects` (netlify)
   async redirects() {
     if (FEATURE_TOGGLE.enable_redirects) {
       return [

--- a/docs/scripts/postMigration.ts
+++ b/docs/scripts/postMigration.ts
@@ -80,19 +80,29 @@ function run() {
   redirects = redirects.replace(
     `# 2022`,
     `# 2022
+## MUI X
+/components/data-grid/* https://material-ui-x.netlify.app/x/react-data-grid/:splat 301
+/api/data-grid/* https://material-ui-x.netlify.app/x/api/data-grid/:splat 301
+/x/* https://material-ui-x.netlify.app/x/:splat 301
+
+## MUI Core
 /styles/* /system/styles/:splat 301
 /getting-started/* /material/getting-started/:splat 301
 /customization/* /material/customization/:splat 301
 /guides/* /material/guides/:splat 301
 /discover-more/* /material/discover-more/:splat 301
-/components/data-grid/* /x/react-data-grid/:splat 301
+
+### Exceptions
 /components/icons/ /material/icons/ 301
 /components/material-icons/ /material/material-icons/ 301
 /components/about-the-lab/ /material/about-the-lab/ 301
 /components/transitions/ /material/transitions/ 301
 /components/pickers/ /material/pickers/ 301
+
+### React plural
 /components/tabs/ /material/react-tabs/ 301
 /components/breadcrumbs/ /material/react-breadcrumbs/ 301
+
 /components/checkboxes/ /material/react-checkbox/ 301
 /components/switches/ /material/react-switch/ 301
 /components/buttons/ /material/react-button/ 301
@@ -114,9 +124,13 @@ function run() {
 /components/menus/ /material/react-menu/ 301
 /components/steppers/ /material/react-stepper/ 301
 /components/* /material/react-:splat 301
-/api/data-grid/* /x/api/data-grid/:splat 301
 /api/* /material/api/:splat 301`,
   );
+
+  // remove X redirects because of the above redirects
+  redirects
+    .replace('/api/*/ https://docs-v5--material-ui-x.netlify.app/api/:splat/ 200', '')
+    .replace('/components/* https://docs-v5--material-ui-x.netlify.app/components/:splat 200', '');
 
   fs.writeFileSync(redirectsPath, redirects);
 }

--- a/docs/scripts/postMigration.ts
+++ b/docs/scripts/postMigration.ts
@@ -81,9 +81,9 @@ function run() {
     `# 2022`,
     `# 2022
 ## MUI X
-/components/data-grid/* https://material-ui-x.netlify.app/x/react-data-grid/:splat 301
-/api/data-grid/* https://material-ui-x.netlify.app/x/api/data-grid/:splat 301
-/x/* https://material-ui-x.netlify.app/x/:splat 301
+/components/data-grid/* https://material-ui-x.netlify.app/x/react-data-grid/:splat 200
+/api/data-grid/* https://material-ui-x.netlify.app/x/api/data-grid/:splat 200
+/x/* https://material-ui-x.netlify.app/x/:splat 200
 
 ## MUI Core
 /styles/* /system/styles/:splat 301

--- a/docs/scripts/postMigration.ts
+++ b/docs/scripts/postMigration.ts
@@ -74,7 +74,7 @@ function run() {
   fs.writeFileSync(featureTogglePath, featureToggle);
 
   // Add redirects to _redirects (netlify)
-  const redirectsPath = path.join(process.cwd(), 'docs/src/featureToggle.js');
+  const redirectsPath = path.join(process.cwd(), 'docs/public/_redirects');
   let redirects = fs.readFileSync(redirectsPath, { encoding: 'utf8' });
 
   redirects = redirects.replace(

--- a/docs/scripts/postMigration.ts
+++ b/docs/scripts/postMigration.ts
@@ -72,6 +72,53 @@ function run() {
     .replace(`enable_system_scope: false`, `enable_system_scope: true`);
 
   fs.writeFileSync(featureTogglePath, featureToggle);
+
+  // Add redirects to _redirects (netlify)
+  const redirectsPath = path.join(process.cwd(), 'docs/src/featureToggle.js');
+  let redirects = fs.readFileSync(redirectsPath, { encoding: 'utf8' });
+
+  redirects = redirects.replace(
+    `# 2022`,
+    `# 2022
+/styles/* /system/styles/:splat 301
+/getting-started/* /material/getting-started/:splat 301
+/customization/* /material/customization/:splat 301
+/guides/* /material/guides/:splat 301
+/discover-more/* /material/discover-more/:splat 301
+/components/data-grid/* /x/react-data-grid/:splat 301
+/components/icons/ /material/icons/ 301
+/components/material-icons/ /material/material-icons/ 301
+/components/about-the-lab/ /material/about-the-lab/ 301
+/components/transitions/ /material/transitions/ 301
+/components/pickers/ /material/pickers/ 301
+/components/tabs/ /material/react-tabs/ 301
+/components/breadcrumbs/ /material/react-breadcrumbs/ 301
+/components/checkboxes/ /material/react-checkbox/ 301
+/components/switches/ /material/react-switch/ 301
+/components/buttons/ /material/react-button/ 301
+/components/radio-buttons/ /material/react-radio-button/ 301
+/components/selects/ /material/react-select/ 301
+/components/text-fields/ /material/react-text-field/ 301
+/components/avatars/ /material/react-avatar/ 301
+/components/badges/ /material/react-badge/ 301
+/components/chips/ /material/react-chip/ 301
+/components/dividers/ /material/react-divider/ 301
+/components/lists/ /material/react-list/ 301
+/components/tables/ /material/react-table/ 301
+/components/tooltips/ /material/react-tooltip/ 301
+/components/dialogs/ /material/react-dialog/ 301
+/components/snackbars/ /material/react-snackbar/ 301
+/components/cards/ /material/react-card/ 301
+/components/drawers/ /material/react-drawer/ 301
+/components/links/ /material/react-link/ 301
+/components/menus/ /material/react-menu/ 301
+/components/steppers/ /material/react-stepper/ 301
+/components/* /material/react-:splat 301
+/api/data-grid/* /x/api/data-grid/:splat 301
+/api/* /material/api/:splat 301`,
+  );
+
+  fs.writeFileSync(redirectsPath, redirects);
 }
 
 run();

--- a/test/e2e-website/material-color-playground.spec.ts
+++ b/test/e2e-website/material-color-playground.spec.ts
@@ -1,10 +1,16 @@
 import { test as base, expect } from '@playwright/test';
+import FEATURE_TOGGLE from 'docs/src/featureToggle';
 import { TestFixture } from './playwright.config';
 
 const test = base.extend<TestFixture>({});
 
 test('should be able to change color without crash', async ({ page }) => {
-  await page.goto('/customization/color/#playground', { waitUntil: 'networkidle' });
+  await page.goto(
+    FEATURE_TOGGLE.enable_redirects
+      ? '/material/customization/color/#playground'
+      : '/customization/color/#playground',
+    { waitUntil: 'networkidle' },
+  );
 
   await page.fill('#primary', ''); // clear the input
   await page.type('#primary', '#e91e63');

--- a/test/e2e-website/material-current.spec.ts
+++ b/test/e2e-website/material-current.spec.ts
@@ -33,7 +33,7 @@ test.describe.parallel('Material docs', () => {
       const firstAnchor = await anchors.first();
       const textContent = await firstAnchor.textContent();
 
-      await expect(firstAnchor).toHaveAttribute('href', `/api/${kebabCase(textContent || '')}`);
+      await expect(firstAnchor).toHaveAttribute('href', `/api/${kebabCase(textContent || '')}/`);
     });
 
     test('should have correct link for sidebar anchor', async ({ page }) => {

--- a/test/e2e-website/material-current.spec.ts
+++ b/test/e2e-website/material-current.spec.ts
@@ -10,15 +10,12 @@ test.describe.parallel('Material docs', () => {
 
     const anchors = page.locator('[aria-label="Page table of contents"] ul a');
 
-    const anchorTexts = await anchors.allTextContents();
+    const firstAnchor = await anchors.first();
+    const textContent = await firstAnchor.textContent();
 
-    await Promise.all(
-      anchorTexts.map((text, index) => {
-        return expect(anchors.nth(index)).toHaveAttribute(
-          'href',
-          `/getting-started/installation/#${kebabCase(text)}`,
-        );
-      }),
+    await expect(firstAnchor).toHaveAttribute(
+      'href',
+      `/getting-started/installation/#${kebabCase(textContent || '')}`,
     );
   });
 
@@ -28,13 +25,10 @@ test.describe.parallel('Material docs', () => {
 
       const anchors = await page.locator('div > h2#heading-api ~ ul a');
 
-      const anchorTexts = await anchors.allTextContents();
+      const firstAnchor = await anchors.first();
+      const textContent = await firstAnchor.textContent();
 
-      await Promise.all(
-        anchorTexts.map((text, index) => {
-          return expect(anchors.nth(index)).toHaveAttribute('href', `/api/${kebabCase(text)}/`);
-        }),
-      );
+      await expect(firstAnchor).toHaveAttribute('href', `/api/${kebabCase(textContent || '')}`);
     });
 
     test('should have correct link for sidebar anchor', async ({ page }) => {

--- a/test/e2e-website/material-current.spec.ts
+++ b/test/e2e-website/material-current.spec.ts
@@ -9,7 +9,7 @@ test.beforeEach(async ({}) => {
   test.skip(FEATURE_TOGGLE.enable_redirects, "Migration haven't started yet");
 });
 
-test.describe.parallel('Material docs', () => {
+test.describe('Material docs', () => {
   test('should have correct link with hash in the TOC', async ({ page }) => {
     await page.goto(`/getting-started/installation/`);
 
@@ -24,7 +24,7 @@ test.describe.parallel('Material docs', () => {
     );
   });
 
-  test.describe.parallel('Demo page', () => {
+  test.describe('Demo page', () => {
     test('should have correct link for API section', async ({ page }) => {
       await page.goto(`/components/cards/`);
 
@@ -45,7 +45,7 @@ test.describe.parallel('Material docs', () => {
     });
   });
 
-  test.describe.parallel('API page', () => {
+  test.describe('API page', () => {
     test('should have correct link for sidebar anchor', async ({ page }) => {
       await page.goto(`/api/card/`);
 
@@ -70,7 +70,7 @@ test.describe.parallel('Material docs', () => {
     });
   });
 
-  test.describe.parallel('Search', () => {
+  test.describe('Search', () => {
     const retryToggleSearch = async (page: Page, count = 3) => {
       try {
         await page.keyboard.press('Meta+k');

--- a/test/e2e-website/material-current.spec.ts
+++ b/test/e2e-website/material-current.spec.ts
@@ -1,8 +1,13 @@
 import { test as base, expect, Page } from '@playwright/test';
 import kebabCase from 'lodash/kebabCase';
+import FEATURE_TOGGLE from 'docs/src/featureToggle';
 import { TestFixture } from './playwright.config';
 
 const test = base.extend<TestFixture>({});
+
+test.beforeEach(async ({}) => {
+  test.skip(FEATURE_TOGGLE.enable_redirects, "Migration haven't started yet");
+});
 
 test.describe.parallel('Material docs', () => {
   test('should have correct link with hash in the TOC', async ({ page }) => {

--- a/test/e2e-website/material-new.spec.ts
+++ b/test/e2e-website/material-new.spec.ts
@@ -15,15 +15,12 @@ test.describe.parallel('Material docs', () => {
 
     const anchors = page.locator('[aria-label="Page table of contents"] ul a');
 
-    const anchorTexts = await anchors.allTextContents();
+    const firstAnchor = await anchors.first();
+    const textContent = await firstAnchor.textContent();
 
-    await Promise.all(
-      anchorTexts.map((text, index) => {
-        return expect(anchors.nth(index)).toHaveAttribute(
-          'href',
-          `/material/getting-started/installation/#${kebabCase(text)}`,
-        );
-      }),
+    await expect(firstAnchor).toHaveAttribute(
+      'href',
+      `/material/getting-started/installation/#${kebabCase(textContent || '')}`,
     );
   });
 
@@ -33,15 +30,12 @@ test.describe.parallel('Material docs', () => {
 
       const anchors = await page.locator('div > h2#heading-api ~ ul a');
 
-      const anchorTexts = await anchors.allTextContents();
+      const firstAnchor = await anchors.first();
+      const textContent = await firstAnchor.textContent();
 
-      await Promise.all(
-        anchorTexts.map((text, index) => {
-          return expect(anchors.nth(index)).toHaveAttribute(
-            'href',
-            `/material/api/${kebabCase(text)}/`,
-          );
-        }),
+      await expect(firstAnchor).toHaveAttribute(
+        'href',
+        `/material/api/${kebabCase(textContent || '')}`,
       );
     });
 
@@ -120,6 +114,7 @@ test.describe.parallel('Material docs', () => {
 
       links.forEach((link) => {
         if (
+          link &&
           ['/getting-started', '/customization', '/guides', '/discover-more'].some((path) =>
             link.includes(path),
           )
@@ -129,7 +124,7 @@ test.describe.parallel('Material docs', () => {
 
         expect(link).not.toMatch(/\/components/); // there should be no `/components` in the url anymore
 
-        if (link.startsWith('/system')) {
+        if (link && link.startsWith('/system')) {
           expect(link.startsWith('/system')).toBeTruthy();
           expect(link.match(/\/system{1}/g)).toHaveLength(1); // should not have repeated `/system/system/*`
         }

--- a/test/e2e-website/material-new.spec.ts
+++ b/test/e2e-website/material-new.spec.ts
@@ -35,7 +35,7 @@ test.describe.parallel('Material docs', () => {
 
       await expect(firstAnchor).toHaveAttribute(
         'href',
-        `/material/api/${kebabCase(textContent || '')}`,
+        `/material/api/${kebabCase(textContent || '')}/`,
       );
     });
 

--- a/test/e2e-website/material-new.spec.ts
+++ b/test/e2e-website/material-new.spec.ts
@@ -9,7 +9,7 @@ test.beforeEach(async ({}) => {
   test.skip(!FEATURE_TOGGLE.enable_product_scope, "Migration haven't started yet");
 });
 
-test.describe.parallel('Material docs', () => {
+test.describe('Material docs', () => {
   test('should have correct link with hash in the TOC', async ({ page }) => {
     await page.goto(`/material/getting-started/installation/`);
 
@@ -24,7 +24,7 @@ test.describe.parallel('Material docs', () => {
     );
   });
 
-  test.describe.parallel('Demo page', () => {
+  test.describe('Demo page', () => {
     test('should have correct link for API section', async ({ page }) => {
       await page.goto(`/material/react-card/`);
 
@@ -93,7 +93,7 @@ test.describe.parallel('Material docs', () => {
     });
   });
 
-  test.describe.parallel('API page', () => {
+  test.describe('API page', () => {
     test('should have correct link for sidebar anchor', async ({ page }) => {
       await page.goto(`/material/api/card/`);
 
@@ -132,7 +132,7 @@ test.describe.parallel('Material docs', () => {
     });
   });
 
-  test.describe.parallel('Search', () => {
+  test.describe('Search', () => {
     const retryToggleSearch = async (page: Page, count = 3) => {
       try {
         await page.keyboard.press('Meta+k');

--- a/test/e2e-website/material-redirects.spec.ts
+++ b/test/e2e-website/material-redirects.spec.ts
@@ -8,65 +8,73 @@ test.beforeEach(async ({}) => {
   test.skip(!FEATURE_TOGGLE.enable_redirects, "Redirects haven't started yet");
 });
 
-['checkbox', 'switch'].forEach((component) => {
-  test(`[${component}] should redirect correctly`, async ({ page }) => {
-    await page.goto(`/components/${component}es/`);
+test.describe.parallel('Redirects', () => {
+  ['checkbox', 'switch'].forEach((component) => {
+    test(`[${component}] should redirect correctly`, async ({ page }) => {
+      await page.goto(`/components/${component}es/`);
 
-    await expect(page).toHaveURL(`/material/react-${component}/`);
+      await expect(page).toHaveURL(`/material/react-${component}/`);
 
-    await expect(page.locator('h1')).toHaveText(new RegExp(component, 'i'));
+      await expect(page.locator('h1')).toHaveText(new RegExp(component, 'i'));
+    });
   });
-});
 
-[
-  'button',
-  'radio-button',
-  'select',
-  'text-field',
-  'avatar',
-  'badge',
-  'chip',
-  'divider',
-  'list',
-  'table',
-  'tooltip',
-  'dialog',
-  'snackbar',
-  'card',
-  'drawer',
-  'link',
-  'menu',
-  'stepper',
-].forEach((component) => {
-  test(`[${component}] should redirect correctly`, async ({ page }) => {
-    await page.goto(`/components/${component}s/`);
+  [
+    'button',
+    'radio-button',
+    'select',
+    'text-field',
+    'avatar',
+    'badge',
+    'chip',
+    'divider',
+    'list',
+    'table',
+    'tooltip',
+    'dialog',
+    'snackbar',
+    'card',
+    'drawer',
+    'link',
+    'menu',
+    'stepper',
+  ].forEach((component) => {
+    test(`[${component}] should redirect correctly`, async ({ page }) => {
+      await page.goto(`/components/${component}s/`);
 
-    await expect(page).toHaveURL(`/material/react-${component}/`);
+      await expect(page).toHaveURL(`/material/react-${component}/`);
 
-    await expect(page.locator('h1')).toHaveText(new RegExp(component, 'i'));
+      if (component === 'radio-button') {
+        await expect(page.locator('h1')).toHaveText(/^radio/i);
+      } else if (component === 'text-field') {
+        await expect(page.locator('h1')).toHaveText(/^text field/i);
+      } else {
+        await expect(page.locator('h1')).toHaveText(new RegExp(component, 'i'));
+      }
+    });
   });
-});
 
-test(`autocomplete should redirect correctly`, async ({ page }) => {
-  await page.goto(`/components/autocomplete/`);
+  test(`autocomplete should redirect correctly`, async ({ page }) => {
+    await page.goto(`/components/autocomplete/`);
 
-  await expect(page).toHaveURL(`/material/react-autocomplete/`);
+    await expect(page).toHaveURL(`/material/react-autocomplete/`);
 
-  await expect(page.locator('h1')).toHaveText('Autocomplete');
-});
+    await expect(page.locator('h1')).toHaveText('Autocomplete');
+  });
 
-test(`button api should redirect correctly`, async ({ page }) => {
-  await page.goto(`/api/button/`);
+  test(`button api should redirect correctly`, async ({ page }) => {
+    await page.goto(`/api/button/`);
 
-  await expect(page).toHaveURL(`/material/api/button/`);
+    await expect(page).toHaveURL(`/material/api/button/`);
 
-  await expect(page.locator('h1')).toHaveText('Button API');
-});
+    await expect(page.locator('h1')).toHaveText('Button API');
+  });
 
-test(`styles should redirect correctly`, async ({ page }) => {
-  await page.goto(`/styles/basics/`);
+  test(`styles should redirect correctly`, async ({ page }) => {
+    await page.goto(`/styles/basics/`);
 
-  await expect(page).toHaveURL(`/system/styles/basics/`);
+    await expect(page).toHaveURL(`/system/styles/basics/`);
 
-  await expect(page.locator('h1')).toHaveText('@mui/styles');
+    await expect(page.locator('h1')).toHaveText('@mui/styles');
+  });
 });

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import webfontloader from 'webfontloader';
 import TestViewer from './TestViewer';
+import FEATURE_TOGGLE from '../../docs/src/featureToggle';
 
 // Get all the fixtures specifically written for preventing visual regressions.
 const importRegressionFixtures = require.context('./fixtures', true, /\.(js|ts|tsx)$/, 'lazy');
@@ -203,11 +204,19 @@ function excludeDemoFixture(suite, name) {
 }
 
 // Also use some of the demos to avoid code duplication.
-const importDemos = require.context('docs/src/pages', true, /js$/, 'lazy');
+const importDemos = require.context(
+  FEATURE_TOGGLE.enable_product_scope ? 'docs/data' : 'docs/src/pages',
+  true,
+  /js$/,
+  'lazy',
+);
 const demoFixtures = [];
 importDemos.keys().forEach((path) => {
   const [name, ...suiteArray] = path.replace('./', '').replace('.js', '').split('/').reverse();
-  const suite = `docs-${suiteArray.reverse().join('-')}`;
+  const suite = `docs-${suiteArray
+    .reverse()
+    .join('-')
+    .replace(/^material-/, '')}`;
 
   // TODO: Why does webpack include a key for the absolute and relative path?
   // We just want the relative path

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -204,12 +204,10 @@ function excludeDemoFixture(suite, name) {
 }
 
 // Also use some of the demos to avoid code duplication.
-const importDemos = require.context(
-  FEATURE_TOGGLE.enable_product_scope ? 'docs/data' : 'docs/src/pages',
-  true,
-  /js$/,
-  'lazy',
-);
+let importDemos = require.context('docs/src/pages', true, /js$/, 'lazy');
+if (FEATURE_TOGGLE.enable_product_scope) {
+  importDemos = require.context('docs/data', true, /js$/, 'lazy');
+}
 const demoFixtures = [];
 importDemos.keys().forEach((path) => {
   const [name, ...suiteArray] = path.replace('./', '').replace('.js', '').split('/').reverse();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
### **Summary**

- Fix some e2e mistakes
- add redirects in post-migration script because `nextjs.config` does not work on the production

### **How to test**

I deployed the final result of the site to `https://migration.mui.com`
(which includes migration and post-migration steps)

You can use the e2e-website test to run against the migrated content by
- pull this branch
- update `enable_product_scope` & `enable_redirects` in `docs/src/featureToggle.js` to `true`
- run:
   ```bash
   yarn cross-env PLAYWRIGHT_TEST_BASE_URL=https://migration.mui.com playwright test test/e2e-website --config test/e2e-website/playwright.config.ts
   ```

All the tests should pass.

### Questions

**Do we need to handle legacy languages redirect to the new location?** @oliviertassinari 

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
