### PR TITLE
[docs] Fix typo in containedSizeMedium class

### DIFF
--- a/docs/translations/api-docs/button/button.json
+++ b/docs/translations/api-docs/button/button.json
@@ -137,7 +137,7 @@
     "containedSizeMedium": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>size=\"small\"</code> and <code>variant=\"contained\"</code>"
+      "conditions": "<code>size=\"medium\"</code> and <code>variant=\"contained\"</code>"
     },
     "containedSizeLarge": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",

--- a/docs/translations/api-docs/loading-button/loading-button.json
+++ b/docs/translations/api-docs/loading-button/loading-button.json
@@ -130,7 +130,7 @@
     "containedSizeMedium": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "<code>size=\"small\"</code> and <code>variant=\"contained\"</code>"
+      "conditions": "<code>size=\"medium\"</code> and <code>variant=\"contained\"</code>"
     },
     "containedSizeLarge": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",

--- a/packages/mui-material/src/Button/buttonClasses.ts
+++ b/packages/mui-material/src/Button/buttonClasses.ts
@@ -49,7 +49,7 @@ export interface ButtonClasses {
   outlinedSizeLarge: string;
   /** Styles applied to the root element if `size="small"` and `variant="contained"`. */
   containedSizeSmall: string;
-  /** Styles applied to the root element if `size="small"` and `variant="contained"`. */
+  /** Styles applied to the root element if `size="medium"` and `variant="contained"`. */
   containedSizeMedium: string;
   /** Styles applied to the root element if `size="large"` and `variant="contained"`. */
   containedSizeLarge: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Please let me know if there are any other files that should be changed: I read in the docs that there's no need to update `button-locale.json` files, so I didn't. I did check that the correct text shows up when running the docs site locally 🙂 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
