### PR TITLE
Don't trigger error when textarea is used as an autocomplete input element

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -525,10 +525,10 @@ export default function useAutocomplete(props) {
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {
-      if (!inputRef.current || inputRef.current.nodeName !== 'INPUT') {
+      if (!inputRef.current || !['INPUT', 'TEXTAREA'].includes(inputRef.current.nodeName)) {
         console.error(
           [
-            `MUI: Unable to find the input element. It was resolved to ${inputRef.current} while an HTMLInputElement was expected.`,
+            `MUI: Unable to find the input element. It was resolved to ${inputRef.current} while an HTMLInputElement or HTMLTextAreaElement was expected.`,
             `Instead, ${componentName} expects an input element.`,
             '',
             componentName === 'useAutocomplete'


### PR DESCRIPTION
The `<TextField>` element uses `<textarea>` when `multiline=true`, and this appears to work just fine with the `<Autocomplete>` element, aside from this warning message.

_I made these changes through the new [web-based-editor](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor), and it didn't populate any PR template when I opened this; sorry about that!_