### PR TITLE
[DateTimePicker] Fix month view highlight wrong tab

### DIFF
--- a/packages/mui-lab/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/packages/mui-lab/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -14,7 +14,7 @@ type TabValue = 'date' | 'time';
 
 const viewToTab = (openView: DateTimePickerView): TabValue => {
   // TODO: what happens if `openView` is `month`?
-  if (openView === 'day' || openView === 'year') {
+  if (['day', 'month', 'year'].includes(openView)) {
     return 'date';
   }
 


### PR DESCRIPTION
Simple issue where using the api views prop would result in the user seeing the Month picker but having the Time Tab highlighted instead.

![image](https://user-images.githubusercontent.com/1245858/150980785-078c0b21-89e2-42d7-b5a2-6df3d715e3c2.png)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
