### PR TITLE
[test] Add explicit types to support `noImplicitAny=false`

### DIFF
--- a/test/utils/initMatchers.ts
+++ b/test/utils/initMatchers.ts
@@ -515,7 +515,8 @@ chai.use((chaiAPI, utils) => {
             ? [expectedMessagesInput]
             : expectedMessagesInput.slice();
         const unexpectedMessages: Error[] = [];
-        let caughtError = null;
+        // TODO Remove type once MUI X enables noImplicitAny
+        let caughtError: unknown | null = null;
 
         this.assert(
           expectedMessages.length > 0,
@@ -551,7 +552,8 @@ chai.use((chaiAPI, utils) => {
           const expectedMessage = remainingMessages.shift();
           messagesMatched += 1;
 
-          let message = null;
+          // TODO Remove type once MUI X enables noImplicitAny
+          let message: string | null = null;
           if (expectedMessage === undefined) {
             message = `Expected no more error messages but got:\n"${actualMessage}"`;
           } else if (!actualMessage.includes(expectedMessage)) {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Currently, to be able to create assertions using the custom Chai matchers (e.g. `toErrorDev`) in the tests for the DataGrid in MUI X we need to always [snooze](https://github.com/mui-org/material-ui-x/blob/a7b2ffb7e2f0a41f865ceefc62cd95976f3e6f6a/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx#L462) a TypeScript error, since it can't load the types of these matchers. In https://github.com/mui-org/material-ui-x/pull/3754 I configured the `tsconfig.json` to load the module augmentation provided by `test/utils/initMatchers.ts`. The only problem I faced was that the configuration of `tsconfig.json` is different between MUI Core and MUI X. MUI X sets `noImplicitAny=false` while MUI Core assumes `true` (default if not specified). Because of this difference, `initMatchers.ts` can't be imported directly without explicitly telling the type of two variables.

To visualize better what this PR is doing, go to https://www.typescriptlang.org/play?noUnusedLocals=true&ts=4.5.4#code/DYUwLgBAtiDOsEMDmIIF4IDsCuxgG4AoGeZVDAcjDjAqJMRXQgCYjDDRIGyWAuLLmAQAPhFhgATgEtMSUYKgAjEJOY489OIxAtmVGnWLbezNoSA. Then, disable `noImplicitAny`. You should see the following error:

<img width="400" src="https://user-images.githubusercontent.com/42154031/151277821-591374d0-701a-44e5-806c-4b7c73683df3.png" alt="image" style="max-width: 100%;">

Almost the same reason by which https://github.com/mui-org/material-ui-x/pull/3754 failed:

![image](https://user-images.githubusercontent.com/42154031/151278026-4780e97e-23ed-4af4-96fa-51019662493f.png)