### PR TITLE
[Joy] Use icon inside a Button

### DIFF
--- a/docs/pages/experiments/joy/button.tsx
+++ b/docs/pages/experiments/joy/button.tsx
@@ -24,7 +24,6 @@ const ColorSchemePicker = () => {
   return (
     <Button
       variant="outlined"
-      square
       onClick={() => {
         if (mode === 'light') {
           setMode('dark');
@@ -32,6 +31,7 @@ const ColorSchemePicker = () => {
           setMode('light');
         }
       }}
+      sx={{ '--Button-gutter': '0.25rem', minWidth: 'var(--Button-minHeight)' }}
     >
       {mode === 'light' ? <Moon /> : <Sun />}
     </Button>
@@ -98,7 +98,10 @@ export default function JoyButton() {
               square
             </Typography>
             <Box>
-              <Button variant="light" square>
+              <Button
+                variant="light"
+                sx={{ '--Button-gutter': '0.25rem', minWidth: 'var(--Button-minHeight)' }}
+              >
                 <Add />
               </Button>
               <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
@@ -106,7 +109,12 @@ export default function JoyButton() {
               </Typography>
             </Box>
             <Box>
-              <Button variant="outlined" square size="sm" color="danger">
+              <Button
+                variant="outlined"
+                size="sm"
+                color="danger"
+                sx={{ '--Button-gutter': '0.25rem', minWidth: 'var(--Button-minHeight)' }}
+              >
                 <DeleteForever />
               </Button>
               <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
@@ -114,7 +122,12 @@ export default function JoyButton() {
               </Typography>
             </Box>
             <Box>
-              <Button variant="contained" square size="lg" color="success">
+              <Button
+                variant="contained"
+                size="lg"
+                color="success"
+                sx={{ '--Button-gutter': '0.25rem', minWidth: 'var(--Button-minHeight)' }}
+              >
                 <ThumbUp />
               </Button>
               <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
@@ -123,14 +136,24 @@ export default function JoyButton() {
             </Box>
             <Button
               variant="contained"
-              square
               size="lg"
               color="success"
-              sx={{ '--Button-minHeight': '64px' }}
+              sx={{
+                '--Button-minHeight': '64px',
+                '--Button-gutter': '0.25rem',
+                minWidth: 'var(--Button-minHeight)',
+              }}
             >
               <ThumbUp fontSize="xl4" />
             </Button>
-            <Button variant="outlined" square sx={{ borderRadius: 'var(--Button-minHeight)' }}>
+            <Button
+              variant="outlined"
+              sx={{
+                '--Button-gutter': '0.25rem',
+                minWidth: 'var(--Button-minHeight)',
+                borderRadius: 'var(--Button-minHeight)',
+              }}
+            >
               <Add />
             </Button>
           </Box>
@@ -142,9 +165,10 @@ export default function JoyButton() {
             </Typography>
             <Button
               variant="contained"
-              square
               color="success"
               endIcon={<KeyboardArrowDown fontSize="lg" />}
+              sx={{ '--Button-gutter': '0.5rem' }}
+              // sx={{ px: '0.5rem' }} // should not use `px` because endIcon will have mismatch position
             >
               <ThumbUp />
             </Button>

--- a/docs/pages/experiments/joy/button.tsx
+++ b/docs/pages/experiments/joy/button.tsx
@@ -1,0 +1,626 @@
+import * as React from 'react';
+import Box from '@mui/joy/Box';
+import Button from '@mui/joy/Button';
+import Typography from '@mui/joy/Typography';
+import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
+import Moon from '@mui/icons-material/DarkMode';
+import Sun from '@mui/icons-material/LightMode';
+import Add from '@mui/icons-material/Add';
+import DeleteForever from '@mui/icons-material/DeleteForeverOutlined';
+import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
+import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
+import ThumbUp from '@mui/icons-material/ThumbUp';
+
+const ColorSchemePicker = () => {
+  const { mode, setMode } = useColorScheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outlined"
+      square
+      onClick={() => {
+        if (mode === 'light') {
+          setMode('dark');
+        } else {
+          setMode('light');
+        }
+      }}
+    >
+      {mode === 'light' ? <Moon /> : <Sun />}
+    </Button>
+  );
+};
+
+export default function JoyButton() {
+  const buttonProps = {
+    variant: ['text', 'outlined', 'light', 'contained'],
+    color: ['primary', 'neutral', 'danger', 'info', 'success', 'warning'],
+    size: ['sm', 'md', 'lg'],
+  } as const;
+  return (
+    <CssVarsProvider
+      theme={{
+        components: {
+          MuiSvgIcon: {
+            defaultProps: {
+              fontSize: 'xl',
+            },
+            styleOverrides: {
+              root: ({ ownerState, theme }) => ({
+                ...(ownerState.fontSize &&
+                  ownerState.fontSize !== 'inherit' && {
+                    fontSize: theme.vars.fontSize[ownerState.fontSize],
+                  }),
+                ...(ownerState.color &&
+                  ownerState.color !== 'inherit' && {
+                    color: theme.vars.palette[ownerState.color].textColor,
+                  }),
+              }),
+            },
+          },
+        },
+      }}
+    >
+      <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
+        <Box sx={{ px: 3, pb: 4 }}>
+          <ColorSchemePicker />
+        </Box>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
+          {Object.entries(buttonProps).map(([propName, propValue]) => (
+            <Box
+              key={propName}
+              sx={{ display: 'flex', flexDirection: 'column', gap: 5, p: 2, alignItems: 'center' }}
+            >
+              <Typography level="body2" sx={{ fontWeight: 'bold' }}>
+                {propName}
+              </Typography>
+              {propValue.map((value) => (
+                <Box key={value}>
+                  <Button {...{ [propName]: value }}>Button</Button>
+                  <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
+                    {value || 'default'}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          ))}
+          <Box
+            sx={{ display: 'flex', flexDirection: 'column', gap: 5, p: 2, alignItems: 'center' }}
+          >
+            <Typography level="body2" sx={{ fontWeight: 'bold' }}>
+              square
+            </Typography>
+            <Box>
+              <Button variant="light" square>
+                <Add />
+              </Button>
+              <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
+                40x40
+              </Typography>
+            </Box>
+            <Box>
+              <Button variant="outlined" square size="sm" color="danger">
+                <DeleteForever />
+              </Button>
+              <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
+                32x32
+              </Typography>
+            </Box>
+            <Box>
+              <Button variant="contained" square size="lg" color="success">
+                <ThumbUp />
+              </Button>
+              <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
+                48x48
+              </Typography>
+            </Box>
+            <Button
+              variant="contained"
+              square
+              size="lg"
+              color="success"
+              sx={{ '--Button-minHeight': '64px' }}
+            >
+              <ThumbUp fontSize="xl4" />
+            </Button>
+            <Button variant="outlined" square sx={{ borderRadius: 'var(--Button-minHeight)' }}>
+              <Add />
+            </Button>
+          </Box>
+          <Box
+            sx={{ display: 'flex', flexDirection: 'column', gap: 5, p: 2, alignItems: 'center' }}
+          >
+            <Typography level="body2" sx={{ fontWeight: 'bold' }}>
+              start & end icon
+            </Typography>
+            <Button
+              variant="contained"
+              square
+              color="success"
+              endIcon={<KeyboardArrowDown fontSize="lg" />}
+            >
+              <ThumbUp />
+            </Button>
+            <Button variant="contained" startIcon={<ThumbUp />} size="sm">
+              Add to cart
+            </Button>
+            <Button variant="outlined" startIcon={<Add />} size="sm">
+              Add to cart
+            </Button>
+            <Button variant="contained" startIcon={<Add />}>
+              Add to cart
+            </Button>
+            <Button variant="contained" startIcon={<Add />} size="lg">
+              Add to cart
+            </Button>
+            <Button variant="outlined" endIcon={<KeyboardArrowRight />} color="success">
+              Checkout
+            </Button>
+          </Box>
+        </Box>
+        {/* Danilo's not smart iteration below 😅 - wanted to see each color with every variant. */}
+        <Box sx={{ display: 'flex', py: 16 }}>
+          <Box sx={{ width: '100px', display: 'grid', gap: 2, mr: 4 }}>
+            <Button variant="contained" color="primary">
+              Button
+            </Button>
+            <Button variant="contained" color="neutral">
+              Button
+            </Button>
+            <Button variant="contained" color="danger">
+              Button
+            </Button>
+            <Button variant="contained" color="info">
+              Button
+            </Button>
+            <Button variant="contained" color="success">
+              Button
+            </Button>
+            <Button variant="contained" color="warning">
+              Button
+            </Button>
+          </Box>
+          <Box sx={{ width: '100px', display: 'grid', gap: 2, mr: 4 }}>
+            <Button variant="outlined" color="primary">
+              Button
+            </Button>
+            <Button variant="outlined" color="neutral">
+              Button
+            </Button>
+            <Button variant="outlined" color="danger">
+              Button
+            </Button>
+            <Button variant="outlined" color="info">
+              Button
+            </Button>
+            <Button variant="outlined" color="success">
+              Button
+            </Button>
+            <Button variant="outlined" color="warning">
+              Button
+            </Button>
+          </Box>
+          <Box sx={{ width: '100px', display: 'grid', gap: 2, mr: 4 }}>
+            <Button variant="light" color="primary">
+              Button
+            </Button>
+            <Button variant="light" color="neutral">
+              Button
+            </Button>
+            <Button variant="light" color="danger">
+              Button
+            </Button>
+            <Button variant="light" color="info">
+              Button
+            </Button>
+            <Button variant="light" color="success">
+              Button
+            </Button>
+            <Button variant="light" color="warning">
+              Button
+            </Button>
+          </Box>
+          <Box sx={{ width: '100px', display: 'grid', gap: 2, mr: 4 }}>
+            <Button variant="text" color="primary">
+              Button
+            </Button>
+            <Button variant="text" color="neutral">
+              Button
+            </Button>
+            <Button variant="text" color="danger">
+              Button
+            </Button>
+            <Button variant="text" color="info">
+              Button
+            </Button>
+            <Button variant="text" color="success">
+              Button
+            </Button>
+            <Button variant="text" color="warning">
+              Button
+            </Button>
+          </Box>
+          <Box sx={{ width: '100px', display: 'grid' }}>
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-primary-50)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-primary-100)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-primary-200)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-primary-300)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-primary-400)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-primary-500)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-primary-600)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-primary-700)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-primary-800)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-primary-900)',
+              }}
+            />
+          </Box>
+          <Box sx={{ width: '100px', display: 'grid' }}>
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-info-50)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-info-100)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-info-200)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-info-300)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-info-400)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-info-500)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-info-600)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-info-700)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-info-800)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-info-900)',
+              }}
+            />
+          </Box>
+          <Box sx={{ width: '100px', display: 'grid' }}>
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-neutral-50)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-neutral-100)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-neutral-200)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-neutral-300)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-neutral-400)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-neutral-500)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-neutral-600)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-neutral-700)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-neutral-800)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-neutral-900)',
+              }}
+            />
+          </Box>
+          <Box sx={{ width: '100px', display: 'grid' }}>
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-danger-50)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-danger-100)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-danger-200)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-danger-300)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-danger-400)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-danger-500)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-danger-600)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-danger-700)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-danger-800)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-danger-900)',
+              }}
+            />
+          </Box>
+          <Box sx={{ width: '100px', display: 'grid' }}>
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-success-50)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-success-100)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-success-200)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-success-300)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-success-400)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-success-500)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-success-600)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-success-700)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-success-800)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-success-900)',
+              }}
+            />
+          </Box>
+          <Box sx={{ width: '100px', display: 'grid' }}>
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-warning-50)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-warning-100)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-warning-200)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-warning-300)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-warning-400)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-warning-500)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-warning-600)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-warning-700)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-warning-800)',
+              }}
+            />
+            <Box
+              sx={{
+                width: '50px',
+                backgroundColor: 'var(--joy-palette-warning-900)',
+              }}
+            />
+          </Box>
+        </Box>
+      </Box>
+    </CssVarsProvider>
+  );
+}

--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -26,13 +26,16 @@ const ColorSchemePicker = () => {
   return (
     <Button
       variant="outlined"
-      square
       onClick={() => {
         if (mode === 'light') {
           setMode('dark');
         } else {
           setMode('light');
         }
+      }}
+      sx={{
+        p: '0.25rem',
+        width: 'var(--Button-minHeight)',
       }}
     >
       {mode === 'light' ? <Moon /> : <Sun />}

--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -12,6 +12,8 @@ import Moon from '@mui/icons-material/DarkMode';
 import Sun from '@mui/icons-material/LightMode';
 import Add from '@mui/icons-material/Add';
 import DeleteForever from '@mui/icons-material/DeleteForeverOutlined';
+import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
+import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
 import ThumbUp from '@mui/icons-material/ThumbUp';
 
 const Typography = styled('p', {
@@ -110,15 +112,30 @@ export default function JoyComponents() {
             <Typography level="body2" sx={{ fontWeight: 'bold' }}>
               square
             </Typography>
-            <Button variant="light" square>
-              <Add />
-            </Button>
-            <Button variant="outlined" square size="sm" color="danger">
-              <DeleteForever />
-            </Button>
-            <Button variant="contained" square size="lg" color="success">
-              <ThumbUp />
-            </Button>
+            <Box>
+              <Button variant="light" square>
+                <Add />
+              </Button>
+              <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
+                40x40
+              </Typography>
+            </Box>
+            <Box>
+              <Button variant="outlined" square size="sm" color="danger">
+                <DeleteForever />
+              </Button>
+              <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
+                32x32
+              </Typography>
+            </Box>
+            <Box>
+              <Button variant="contained" square size="lg" color="success">
+                <ThumbUp />
+              </Button>
+              <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
+                48x48
+              </Typography>
+            </Box>
             <Button
               variant="contained"
               square
@@ -130,6 +147,36 @@ export default function JoyComponents() {
             </Button>
             <Button variant="outlined" square sx={{ borderRadius: 'var(--Button-minHeight)' }}>
               <Add />
+            </Button>
+          </Box>
+          <Box
+            sx={{ display: 'flex', flexDirection: 'column', gap: 5, p: 2, alignItems: 'center' }}
+          >
+            <Typography level="body2" sx={{ fontWeight: 'bold' }}>
+              start & end icon
+            </Typography>
+            <Button
+              variant="contained"
+              square
+              color="success"
+              endIcon={<KeyboardArrowDown fontSize="lg" />}
+            >
+              <ThumbUp />
+            </Button>
+            <Button variant="contained" startIcon={<ThumbUp />} size="sm">
+              Add to cart
+            </Button>
+            <Button variant="outlined" startIcon={<Add />} size="sm">
+              Add to cart
+            </Button>
+            <Button variant="contained" startIcon={<Add />}>
+              Add to cart
+            </Button>
+            <Button variant="contained" startIcon={<Add />} size="lg">
+              Add to cart
+            </Button>
+            <Button variant="outlined" endIcon={<KeyboardArrowRight />} color="success">
+              Checkout
             </Button>
           </Box>
         </Box>

--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -1,30 +1,17 @@
 import * as React from 'react';
+import { GlobalStyles } from '@mui/system';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
-import {
-  CssVarsProvider,
-  styled,
-  useColorScheme,
-  ColorPaletteProp,
-  TypographySystem,
-} from '@mui/joy/styles';
+import Switch from '@mui/joy/Switch';
+import Typography from '@mui/joy/Typography';
+import { CssVarsProvider, useColorScheme, styled } from '@mui/joy/styles';
 import Moon from '@mui/icons-material/DarkMode';
 import Sun from '@mui/icons-material/LightMode';
 import Add from '@mui/icons-material/Add';
-import DeleteForever from '@mui/icons-material/DeleteForeverOutlined';
-import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
-import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
-import ThumbUp from '@mui/icons-material/ThumbUp';
-
-const Typography = styled('p', {
-  shouldForwardProp: (prop) => prop !== 'color' && prop !== 'level' && prop !== 'sx',
-})<{ color?: ColorPaletteProp; level?: keyof TypographySystem }>(
-  ({ theme, level = 'body1', color }) => [
-    { margin: 0 },
-    theme.typography[level],
-    color && { color: `var(--joy-palette-${color}-textColor)` },
-  ],
-);
+import DeleteForever from '@mui/icons-material/DeleteForever';
+import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
+import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 
 const ColorSchemePicker = () => {
   const { mode, setMode } = useColorScheme();
@@ -53,12 +40,95 @@ const ColorSchemePicker = () => {
   );
 };
 
+const Input = styled('input')(({ theme }) => ({
+  maxWidth: 64,
+  padding: '0.25rem 0.5rem',
+  border: 'none',
+  borderRadius: '4px',
+  minWidth: 0,
+  ...theme.typography.body2,
+  ...theme.variants.light.neutral,
+  cursor: 'pointer',
+  '&:focus-visible': theme.focus.default,
+  flexGrow: 1,
+  paddingRight: '1.5rem',
+}));
+
+const ControlInput = ({ id, label = 'Label', unit, ...props }: any) => {
+  return (
+    <Box
+      sx={{ display: 'flex', alignItems: 'center', my: 1, gap: 1, justifyContent: 'space-between' }}
+    >
+      <Typography
+        htmlFor={id}
+        component="label"
+        sx={{ fontSize: 'var(--joy-fontSize-sm)', flexShrink: 0 }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ position: 'relative' }}>
+        <Input id={id} {...props} />
+        <Typography
+          level="body3"
+          sx={{ position: 'absolute', right: '6px', top: '4px', pointerEvents: 'none' }}
+        >
+          {unit}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+const components = [
+  {
+    name: 'Button',
+    render: (props: any) => (
+      <React.Fragment>
+        <Button {...props}>Text</Button>
+        <Button startIcon={<Add />} variant="light" {...props}>
+          Add more row
+        </Button>
+        <Button endIcon={<DeleteForever />} variant="outlined" {...props}>
+          Delete
+        </Button>
+      </React.Fragment>
+    ),
+    cssVars: [
+      { id: '--Button-minHeight', type: 'number', unit: 'px', defaultValue: 40 },
+      { id: '--Button-gutter', type: 'number', unit: 'px', defaultValue: 24 },
+    ],
+  },
+  {
+    name: 'Switch',
+    render: (props: any) => (
+      <React.Fragment>
+        <Switch {...props} />
+        <Switch defaultChecked {...props} />
+      </React.Fragment>
+    ),
+    cssVars: [
+      { id: '--Switch-track-radius', type: 'number', unit: 'px', defaultValue: 16 },
+      { id: '--Switch-track-width', type: 'number', unit: 'px', defaultValue: 48 },
+      { id: '--Switch-track-height', type: 'number', unit: 'px', defaultValue: 24 },
+      { id: '--Switch-thumb-size', type: 'number', unit: 'px', defaultValue: 16 },
+      { id: '--Switch-thumb-radius', type: 'number', unit: 'px' },
+      { id: '--Switch-thumb-width', type: 'number', unit: 'px' },
+      { id: '--Switch-thumb-offset', type: 'number', unit: 'px' },
+    ],
+  },
+];
+
 export default function JoyComponents() {
-  const buttonProps = {
-    variant: ['text', 'outlined', 'light', 'contained'],
-    color: ['primary', 'neutral', 'danger', 'info', 'success', 'warning'],
-    size: ['sm', 'md', 'lg'],
-  } as const;
+  const [current, setCurrent] = React.useState(components[0].name);
+  const [componentVars, setComponentVars] = React.useState<Record<string, any>>(
+    components.reduce((result, curr) => ({ ...result, [curr.name]: {} }), {}),
+  );
+  const data = components.find(({ name }) => name === current);
+  const renderedSx = data?.name
+    ? Object.entries(componentVars[data?.name])
+        .map(([key, value]) => `  ${key}: ${value}`)
+        .join('\n')
+    : null;
   return (
     <CssVarsProvider
       theme={{
@@ -83,556 +153,115 @@ export default function JoyComponents() {
         },
       }}
     >
-      <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
-        <Box sx={{ px: 3, pb: 4 }}>
-          <ColorSchemePicker />
-        </Box>
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
-          {Object.entries(buttonProps).map(([propName, propValue]) => (
-            <Box
-              key={propName}
-              sx={{ display: 'flex', flexDirection: 'column', gap: 5, p: 2, alignItems: 'center' }}
-            >
-              <Typography level="body2" sx={{ fontWeight: 'bold' }}>
-                {propName}
-              </Typography>
-              {propValue.map((value) => (
-                <Box key={value}>
-                  <Button {...{ [propName]: value }}>Button</Button>
-                  <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
-                    {value || 'default'}
-                  </Typography>
-                </Box>
-              ))}
-            </Box>
-          ))}
-          <Box
-            sx={{ display: 'flex', flexDirection: 'column', gap: 5, p: 2, alignItems: 'center' }}
-          >
-            <Typography level="body2" sx={{ fontWeight: 'bold' }}>
-              square
-            </Typography>
-            <Box>
-              <Button variant="light" square>
-                <Add />
-              </Button>
-              <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
-                40x40
-              </Typography>
-            </Box>
-            <Box>
-              <Button variant="outlined" square size="sm" color="danger">
-                <DeleteForever />
-              </Button>
-              <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
-                32x32
-              </Typography>
-            </Box>
-            <Box>
-              <Button variant="contained" square size="lg" color="success">
-                <ThumbUp />
-              </Button>
-              <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
-                48x48
-              </Typography>
-            </Box>
-            <Button
-              variant="contained"
-              square
-              size="lg"
-              color="success"
-              sx={{ '--Button-minHeight': '64px' }}
-            >
-              <ThumbUp fontSize="xl4" />
-            </Button>
-            <Button variant="outlined" square sx={{ borderRadius: 'var(--Button-minHeight)' }}>
-              <Add />
-            </Button>
+      <GlobalStyles styles={{ body: { margin: 0 } }} />
+      <Box sx={{ maxWidth: { md: 1152, xl: 1536 }, mx: 'auto', display: 'flex' }}>
+        <Box
+          sx={{
+            width: 256,
+            minHeight: '100vh',
+            boxShadow: 'var(--joy-shadow-sm)',
+          }}
+        >
+          <Box sx={{ pl: 5, pt: 2 }}>
+            <ColorSchemePicker />
           </Box>
           <Box
-            sx={{ display: 'flex', flexDirection: 'column', gap: 5, p: 2, alignItems: 'center' }}
+            component="ul"
+            sx={{
+              my: 2,
+              px: 2,
+              listStyle: 'none',
+              '& > li': {
+                marginBottom: '0.25rem',
+              },
+              '& button': { justifyContent: 'flex-start' },
+            }}
           >
-            <Typography level="body2" sx={{ fontWeight: 'bold' }}>
-              start & end icon
-            </Typography>
-            <Button
-              variant="contained"
-              square
-              color="success"
-              endIcon={<KeyboardArrowDown fontSize="lg" />}
-            >
-              <ThumbUp />
-            </Button>
-            <Button variant="contained" startIcon={<ThumbUp />} size="sm">
-              Add to cart
-            </Button>
-            <Button variant="outlined" startIcon={<Add />} size="sm">
-              Add to cart
-            </Button>
-            <Button variant="contained" startIcon={<Add />}>
-              Add to cart
-            </Button>
-            <Button variant="contained" startIcon={<Add />} size="lg">
-              Add to cart
-            </Button>
-            <Button variant="outlined" endIcon={<KeyboardArrowRight />} color="success">
-              Checkout
-            </Button>
+            {components.map((config) => (
+              <li key={config.name}>
+                <Button
+                  fullWidth
+                  variant={config.name === current ? 'outlined' : 'text'}
+                  onClick={() => setCurrent(config.name)}
+                >
+                  {config.name}
+                </Button>
+              </li>
+            ))}
           </Box>
         </Box>
-        {/* Danilo's not smart iteration below 😅 - wanted to see each color with every variant. */}
-        <Box sx={{ display: 'flex', py: 16 }}>
-          <Box sx={{ width: '100px', display: 'grid', gap: 2, mr: 4 }}>
-            <Button variant="contained" color="primary">
-              Button
-            </Button>
-            <Button variant="contained" color="neutral">
-              Button
-            </Button>
-            <Button variant="contained" color="danger">
-              Button
-            </Button>
-            <Button variant="contained" color="info">
-              Button
-            </Button>
-            <Button variant="contained" color="success">
-              Button
-            </Button>
-            <Button variant="contained" color="warning">
-              Button
-            </Button>
+        <Box
+          className="Canvas"
+          sx={{
+            position: 'relative',
+            flexGrow: 1,
+            minWidth: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 2,
+          }}
+        >
+          {data?.render({ sx: componentVars[data.name] })}
+          <Box
+            sx={{
+              position: 'absolute',
+              left: '1rem',
+              right: '1rem',
+              bottom: '1rem',
+            }}
+          >
+            <ThemeProvider theme={createTheme({ palette: { mode: 'dark' } })}>
+              <HighlightedCode
+                component={MarkdownElement}
+                code={`<${current} sx={{${renderedSx ? `\n${renderedSx}\n ` : ''}}}
+/>`}
+                language="jsx"
+              />
+            </ThemeProvider>
           </Box>
-          <Box sx={{ width: '100px', display: 'grid', gap: 2, mr: 4 }}>
-            <Button variant="outlined" color="primary">
-              Button
-            </Button>
-            <Button variant="outlined" color="neutral">
-              Button
-            </Button>
-            <Button variant="outlined" color="danger">
-              Button
-            </Button>
-            <Button variant="outlined" color="info">
-              Button
-            </Button>
-            <Button variant="outlined" color="success">
-              Button
-            </Button>
-            <Button variant="outlined" color="warning">
-              Button
-            </Button>
-          </Box>
-          <Box sx={{ width: '100px', display: 'grid', gap: 2, mr: 4 }}>
-            <Button variant="light" color="primary">
-              Button
-            </Button>
-            <Button variant="light" color="neutral">
-              Button
-            </Button>
-            <Button variant="light" color="danger">
-              Button
-            </Button>
-            <Button variant="light" color="info">
-              Button
-            </Button>
-            <Button variant="light" color="success">
-              Button
-            </Button>
-            <Button variant="light" color="warning">
-              Button
-            </Button>
-          </Box>
-          <Box sx={{ width: '100px', display: 'grid', gap: 2, mr: 4 }}>
-            <Button variant="text" color="primary">
-              Button
-            </Button>
-            <Button variant="text" color="neutral">
-              Button
-            </Button>
-            <Button variant="text" color="danger">
-              Button
-            </Button>
-            <Button variant="text" color="info">
-              Button
-            </Button>
-            <Button variant="text" color="success">
-              Button
-            </Button>
-            <Button variant="text" color="warning">
-              Button
-            </Button>
-          </Box>
-          <Box sx={{ width: '100px', display: 'grid' }}>
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-primary-50)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-primary-100)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-primary-200)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-primary-300)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-primary-400)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-primary-500)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-primary-600)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-primary-700)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-primary-800)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-primary-900)',
-              }}
-            />
-          </Box>
-          <Box sx={{ width: '100px', display: 'grid' }}>
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-info-50)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-info-100)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-info-200)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-info-300)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-info-400)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-info-500)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-info-600)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-info-700)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-info-800)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-info-900)',
-              }}
-            />
-          </Box>
-          <Box sx={{ width: '100px', display: 'grid' }}>
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-neutral-50)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-neutral-100)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-neutral-200)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-neutral-300)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-neutral-400)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-neutral-500)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-neutral-600)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-neutral-700)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-neutral-800)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-neutral-900)',
-              }}
-            />
-          </Box>
-          <Box sx={{ width: '100px', display: 'grid' }}>
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-danger-50)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-danger-100)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-danger-200)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-danger-300)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-danger-400)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-danger-500)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-danger-600)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-danger-700)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-danger-800)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-danger-900)',
-              }}
-            />
-          </Box>
-          <Box sx={{ width: '100px', display: 'grid' }}>
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-success-50)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-success-100)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-success-200)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-success-300)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-success-400)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-success-500)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-success-600)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-success-700)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-success-800)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-success-900)',
-              }}
-            />
-          </Box>
-          <Box sx={{ width: '100px', display: 'grid' }}>
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-warning-50)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-warning-100)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-warning-200)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-warning-300)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-warning-400)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-warning-500)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-warning-600)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-warning-700)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-warning-800)',
-              }}
-            />
-            <Box
-              sx={{
-                width: '50px',
-                backgroundColor: 'var(--joy-palette-warning-900)',
-              }}
-            />
+        </Box>
+        <Box
+          sx={{ width: 300, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}
+        >
+          <Box
+            sx={{
+              bgcolor: 'var(--joy-palette-background-level1)',
+              borderRadius: '4px',
+              minHeight: 300,
+              py: 1.5,
+              px: 2,
+            }}
+          >
+            <Typography level="body2" sx={{ mb: 2 }}>
+              CSS variables
+            </Typography>
+            {data?.cssVars.map((cssVar) => (
+              <ControlInput
+                key={cssVar.id}
+                type="number"
+                label={cssVar.id}
+                placeholder={cssVar.defaultValue}
+                unit={cssVar.unit}
+                value={componentVars[data?.name!]?.[cssVar.id]?.replace(cssVar.unit, '') || ''}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  const value = event.target.value;
+                  setComponentVars((latest) => {
+                    const vars = { ...latest[data.name] };
+                    if (!value) {
+                      delete vars[cssVar.id];
+                    } else {
+                      vars[cssVar.id] = `${value}${cssVar.unit}`;
+                    }
+                    return {
+                      ...latest,
+                      [data.name]: vars,
+                    };
+                  });
+                }}
+              />
+            ))}
           </Box>
         </Box>
       </Box>

--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -10,6 +10,9 @@ import {
 } from '@mui/joy/styles';
 import Moon from '@mui/icons-material/DarkMode';
 import Sun from '@mui/icons-material/LightMode';
+import Add from '@mui/icons-material/Add';
+import DeleteForever from '@mui/icons-material/DeleteForeverOutlined';
+import ThumbUp from '@mui/icons-material/ThumbUp';
 
 const Typography = styled('p', {
   shouldForwardProp: (prop) => prop !== 'color' && prop !== 'level' && prop !== 'sx',
@@ -34,6 +37,7 @@ const ColorSchemePicker = () => {
   return (
     <Button
       variant="outlined"
+      square
       onClick={() => {
         if (mode === 'light') {
           setMode('dark');
@@ -41,7 +45,6 @@ const ColorSchemePicker = () => {
           setMode('light');
         }
       }}
-      sx={{ minWidth: 40, p: '0.25rem' }}
     >
       {mode === 'light' ? <Moon /> : <Sun />}
     </Button>
@@ -101,6 +104,34 @@ export default function JoyComponents() {
               ))}
             </Box>
           ))}
+          <Box
+            sx={{ display: 'flex', flexDirection: 'column', gap: 5, p: 2, alignItems: 'center' }}
+          >
+            <Typography level="body2" sx={{ fontWeight: 'bold' }}>
+              square
+            </Typography>
+            <Button variant="light" square>
+              <Add />
+            </Button>
+            <Button variant="outlined" square size="sm" color="danger">
+              <DeleteForever />
+            </Button>
+            <Button variant="contained" square size="lg" color="success">
+              <ThumbUp />
+            </Button>
+            <Button
+              variant="contained"
+              square
+              size="lg"
+              color="success"
+              sx={{ '--Button-minHeight': '64px' }}
+            >
+              <ThumbUp fontSize="xl4" />
+            </Button>
+            <Button variant="outlined" square sx={{ borderRadius: 'var(--Button-minHeight)' }}>
+              <Add />
+            </Button>
+          </Box>
         </Box>
         {/* Danilo's not smart iteration below 😅 - wanted to see each color with every variant. */}
         <Box sx={{ display: 'flex', py: 16 }}>

--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -40,8 +40,9 @@ const ColorSchemePicker = () => {
   );
 };
 
-const Input = styled('input')(({ theme }) => ({
-  maxWidth: 64,
+const Input = styled('input')<{ ownerState: any }>(({ theme, ownerState }) => ({
+  boxSizing: 'border-box',
+  maxWidth: 80,
   padding: '0.25rem 0.5rem',
   border: 'none',
   borderRadius: '4px',
@@ -51,7 +52,9 @@ const Input = styled('input')(({ theme }) => ({
   cursor: 'pointer',
   '&:focus-visible': theme.focus.default,
   flexGrow: 1,
-  paddingRight: '1.5rem',
+  ...(ownerState.unit && {
+    paddingRight: '1.5rem',
+  }),
 }));
 
 const ControlInput = ({ id, label = 'Label', unit, ...props }: any) => {
@@ -67,13 +70,15 @@ const ControlInput = ({ id, label = 'Label', unit, ...props }: any) => {
         {label}
       </Typography>
       <Box sx={{ position: 'relative' }}>
-        <Input id={id} {...props} />
-        <Typography
-          level="body3"
-          sx={{ position: 'absolute', right: '6px', top: '4px', pointerEvents: 'none' }}
-        >
-          {unit}
-        </Typography>
+        <Input id={id} ownerState={{ unit, ...props }} {...props} />
+        {unit && (
+          <Typography
+            level="body3"
+            sx={{ position: 'absolute', right: '6px', top: '4px', pointerEvents: 'none' }}
+          >
+            {unit}
+          </Typography>
+        )}
       </Box>
     </Box>
   );
@@ -96,6 +101,8 @@ const components = [
     cssVars: [
       { id: '--Button-minHeight', type: 'number', unit: 'px', defaultValue: 40 },
       { id: '--Button-gutter', type: 'number', unit: 'px', defaultValue: 24 },
+      { id: '--Button-iconOffsetStep', type: 'number', defaultValue: 2 },
+      { id: '--Button-gap', type: 'number', unit: 'px' },
     ],
   },
   {
@@ -242,9 +249,12 @@ export default function JoyComponents() {
                 key={cssVar.id}
                 type="number"
                 label={cssVar.id}
-                placeholder={cssVar.defaultValue}
                 unit={cssVar.unit}
-                value={componentVars[data?.name!]?.[cssVar.id]?.replace(cssVar.unit, '') || ''}
+                value={
+                  componentVars[data?.name!]?.[cssVar.id]?.replace(cssVar.unit, '') ||
+                  cssVar.defaultValue ||
+                  ''
+                }
                 onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                   const value = event.target.value;
                   setComponentVars((latest) => {
@@ -252,7 +262,7 @@ export default function JoyComponents() {
                     if (!value) {
                       delete vars[cssVar.id];
                     } else {
-                      vars[cssVar.id] = `${value}${cssVar.unit}`;
+                      vars[cssVar.id] = cssVar.unit ? `${value}${cssVar.unit}` : value;
                     }
                     return {
                       ...latest,

--- a/packages/mui-joy/src/Button/Button.spec.tsx
+++ b/packages/mui-joy/src/Button/Button.spec.tsx
@@ -62,3 +62,20 @@ function CustomLink({
 <Button component={CustomLink} to="/" href="/" />;
 
 <Button sx={{ borderRadius: 0 }}>Button</Button>;
+
+function Icon() {
+  return null;
+}
+
+<Button square>
+  <Icon />
+</Button>;
+<Button variant="contained" square color="success" endIcon={<Icon />}>
+  <Icon />
+</Button>;
+<Button variant="contained" startIcon={<Icon />} size="sm">
+  Add to cart
+</Button>;
+<Button variant="outlined" endIcon={<Icon />} color="success">
+  Checkout
+</Button>;

--- a/packages/mui-joy/src/Button/Button.spec.tsx
+++ b/packages/mui-joy/src/Button/Button.spec.tsx
@@ -67,10 +67,15 @@ function Icon() {
   return null;
 }
 
-<Button square>
+<Button sx={{ width: 'var(--Button-minHeight)' }}>
   <Icon />
 </Button>;
-<Button variant="contained" square color="success" endIcon={<Icon />}>
+<Button
+  variant="contained"
+  color="success"
+  endIcon={<Icon />}
+  sx={{ width: 'var(--Button-minHeight)' }}
+>
   <Icon />
 </Button>;
 <Button variant="contained" startIcon={<Icon />} size="sm">

--- a/packages/mui-joy/src/Button/Button.test.js
+++ b/packages/mui-joy/src/Button/Button.test.js
@@ -73,4 +73,11 @@ describe('Joy <Button />', () => {
 
     expect(button).to.have.class(classes.fullWidth);
   });
+
+  it('should render a square button', () => {
+    const { getByRole } = render(<Button square>S</Button>);
+    const button = getByRole('button');
+
+    expect(button).to.have.class(classes.square);
+  });
 });

--- a/packages/mui-joy/src/Button/Button.test.js
+++ b/packages/mui-joy/src/Button/Button.test.js
@@ -7,7 +7,7 @@ import { ThemeProvider } from '@mui/joy/styles';
 describe('Joy <Button />', () => {
   const { render } = createRenderer();
 
-  describeConformance(<Button>Conformance?</Button>, () => ({
+  describeConformance(<Button startIcon="icon">Conformance?</Button>, () => ({
     render,
     classes,
     ThemeProvider,

--- a/packages/mui-joy/src/Button/Button.test.js
+++ b/packages/mui-joy/src/Button/Button.test.js
@@ -75,13 +75,6 @@ describe('Joy <Button />', () => {
     expect(button).to.have.class(classes.fullWidth);
   });
 
-  it('should render a square button', () => {
-    const { getByRole } = render(<Button square>S</Button>);
-    const button = getByRole('button');
-
-    expect(button).to.have.class(classes.square);
-  });
-
   it('should render a button with startIcon', () => {
     const { getByRole } = render(<Button startIcon={<span>icon</span>}>Hello World</Button>);
     const button = getByRole('button');

--- a/packages/mui-joy/src/Button/Button.test.js
+++ b/packages/mui-joy/src/Button/Button.test.js
@@ -13,6 +13,7 @@ describe('Joy <Button />', () => {
     ThemeProvider,
     refInstanceof: window.HTMLButtonElement,
     muiName: 'MuiButton',
+    testDeepOverrides: { slotName: 'startIcon', slotClassName: classes.startIcon },
     testVariantProps: { variant: 'contained', fullWidth: true },
     skip: ['propsSpread', 'componentsProp', 'classesRoot'],
   }));
@@ -79,5 +80,23 @@ describe('Joy <Button />', () => {
     const button = getByRole('button');
 
     expect(button).to.have.class(classes.square);
+  });
+
+  it('should render a button with startIcon', () => {
+    const { getByRole } = render(<Button startIcon={<span>icon</span>}>Hello World</Button>);
+    const button = getByRole('button');
+    const startIcon = button.querySelector(`.${classes.startIcon}`);
+
+    expect(button).to.have.class(classes.root);
+    expect(startIcon).not.to.have.class(classes.endIcon);
+  });
+
+  it('should render a button with endIcon', () => {
+    const { getByRole } = render(<Button endIcon={<span>icon</span>}>Hello World</Button>);
+    const button = getByRole('button');
+    const endIcon = button.querySelector(`.${classes.endIcon}`);
+
+    expect(button).to.have.class(classes.root);
+    expect(endIcon).not.to.have.class(classes.startIcon);
   });
 });

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -236,6 +236,10 @@ Button.propTypes /* remove-proptypes */ = {
    */
   component: PropTypes.elementType,
   /**
+   * Element placed after the children.
+   */
+  endIcon: PropTypes.node,
+  /**
    * If `true`, the button will take up the full width of its container.
    * @default false
    */
@@ -244,6 +248,15 @@ Button.propTypes /* remove-proptypes */ = {
    * The size of the component.
    */
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  /**
+   * If `true`, the component has min-width equal to var(--Button-minHeight).
+   * @default false
+   */
+  square: PropTypes.bool,
+  /**
+   * Element placed before the children.
+   */
+  startIcon: PropTypes.node,
   /**
    * The variant to use.
    * @default 'contained'

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -9,7 +9,7 @@ import { ExtendButton, ButtonTypeMap, ButtonProps } from './ButtonProps';
 import buttonClasses, { getButtonUtilityClass } from './buttonClasses';
 
 const useUtilityClasses = (ownerState: ButtonProps & { focusVisible: boolean }) => {
-  const { color, disabled, focusVisible, focusVisibleClassName, fullWidth, size, variant, square } =
+  const { color, disabled, focusVisible, focusVisibleClassName, fullWidth, size, variant } =
     ownerState;
 
   const slots = {
@@ -21,7 +21,6 @@ const useUtilityClasses = (ownerState: ButtonProps & { focusVisible: boolean }) 
       variant && `variant${capitalize(variant)}`,
       color && `color${capitalize(color)}`,
       size && `size${capitalize(size)}`,
-      square && 'square',
     ],
     startIcon: ['startIcon'],
     endIcon: ['endIcon'],
@@ -66,7 +65,7 @@ const ButtonRoot = styled('button', {
       '--Button-minHeight': '2.5rem', // use min-height instead of height to make the button resilient to its content
       '--Button-gutter': '1.5rem', // gutter is the padding-x
       '--Button-iconOffsetStep': 2, // negative margin of the start/end icon
-      '--Button-gap': 'min(var(--Button-gutter) * 0.5, 0.5rem)', // gap between start/end icon and content (limit upper bound to 0.5rem)
+      '--Button-gap': 'clamp(0.25rem, var(--Button-gutter) * 0.5, 0.5rem)', // gap between start/end icon and content [0.25rem, x, 0.5rem]
       ...(ownerState.size === 'sm' && {
         '--Button-minHeight': '2rem',
         '--Button-gutter': '1rem',
@@ -74,12 +73,6 @@ const ButtonRoot = styled('button', {
       ...(ownerState.size === 'lg' && {
         '--Button-minHeight': '3rem',
         '--Button-gutter': '2rem',
-      }),
-      ...(ownerState.square && {
-        '--Button-gutter': '0.5rem',
-        ...(ownerState.size === 'sm' && {
-          '--Button-gutter': '0.25rem', // reduce the padding to make the button square because icon size is 24px by default
-        }),
       }),
     },
     {
@@ -105,9 +98,6 @@ const ButtonRoot = styled('button', {
         lineHeight: '1.25rem',
       }),
       ...(ownerState.size === 'lg' && theme.typography.h6),
-      ...(ownerState.square && {
-        minWidth: 'var(--Button-minHeight)',
-      }),
       [`&.${buttonClasses.focusVisible}`]: theme.focus.default,
     },
     ownerState.fullWidth && {
@@ -135,7 +125,6 @@ const Button = React.forwardRef(function Button(inProps, ref) {
     variant = 'contained',
     size = 'md',
     fullWidth = false,
-    square = false,
     startIcon: startIconProp,
     endIcon: endIconProp,
     ...other
@@ -171,7 +160,6 @@ const Button = React.forwardRef(function Button(inProps, ref) {
     variant,
     size,
     focusVisible,
-    square,
   };
 
   const classes = useUtilityClasses(ownerState);
@@ -250,11 +238,6 @@ Button.propTypes /* remove-proptypes */ = {
    * The size of the component.
    */
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
-  /**
-   * If `true`, the component has min-width equal to var(--Button-minHeight).
-   * @default false
-   */
-  square: PropTypes.bool,
   /**
    * Element placed before the children.
    */

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -9,7 +9,7 @@ import { ExtendButton, ButtonTypeMap, ButtonProps } from './ButtonProps';
 import buttonClasses, { getButtonUtilityClass } from './buttonClasses';
 
 const useUtilityClasses = (ownerState: ButtonProps & { focusVisible: boolean }) => {
-  const { color, disabled, focusVisible, focusVisibleClassName, fullWidth, size, variant } =
+  const { color, disabled, focusVisible, focusVisibleClassName, fullWidth, size, variant, square } =
     ownerState;
 
   const slots = {
@@ -21,7 +21,10 @@ const useUtilityClasses = (ownerState: ButtonProps & { focusVisible: boolean }) 
       variant && `variant${capitalize(variant)}`,
       color && `color${capitalize(color)}`,
       size && `size${capitalize(size)}`,
+      square && 'square',
     ],
+    startIcon: ['startIcon'],
+    endIcon: ['endIcon'],
   };
 
   const composedClasses = composeClasses(slots, getButtonUtilityClass, {});
@@ -33,6 +36,26 @@ const useUtilityClasses = (ownerState: ButtonProps & { focusVisible: boolean }) 
   return composedClasses;
 };
 
+const ButtonStartIcon = styled('span', {
+  name: 'MuiButton',
+  slot: 'StartIcon',
+  overridesResolver: (props, styles) => styles.startIcon,
+})<{ ownerState: ButtonProps }>({
+  display: 'inherit',
+  marginLeft: 'calc(var(--Button-gutter) / -2)',
+  marginRight: 'min(var(--Button-gutter) / 2, 0.5rem)', // limit upper bound to 0.5rem
+});
+
+const ButtonEndIcon = styled('span', {
+  name: 'MuiButton',
+  slot: 'EndIcon',
+  overridesResolver: (props, styles) => styles.endIcon,
+})<{ ownerState: ButtonProps }>({
+  display: 'inherit',
+  marginLeft: 'min(var(--Button-gutter) / 2, 0.5rem)', // limit upper bound to 0.5rem
+  marginRight: 'calc(var(--Button-gutter) / -2)',
+});
+
 const ButtonRoot = styled('button', {
   name: 'MuiButton',
   slot: 'Root',
@@ -40,22 +63,28 @@ const ButtonRoot = styled('button', {
 })<{ ownerState: ButtonProps }>(({ theme, ownerState }) => {
   return [
     {
-      '--Button-minHeight': '40px',
-      '--Button-gutter': '1.5rem',
+      '--Button-minHeight': '2.5rem', // use min-height instead of height to make the button resilient to its content
+      '--Button-gutter': '1.5rem', // gutter is the padding-x
       ...(ownerState.size === 'sm' && {
-        '--Button-minHeight': '32px',
+        '--Button-minHeight': '2rem',
         '--Button-gutter': '1rem',
       }),
       ...(ownerState.size === 'lg' && {
-        '--Button-minHeight': '48px',
+        '--Button-minHeight': '3rem',
         '--Button-gutter': '2rem',
       }),
       ...(ownerState.square && {
-        '--Button-gutter': '0.25rem',
+        '--Button-gutter': '0.5rem',
+        ...(ownerState.size === 'sm' && {
+          '--Button-gutter': '0.25rem', // reduce the padding to make the button square because icon size is 24px by default
+        }),
       }),
     },
     {
       padding: '0.25rem var(--Button-gutter)', // the padding-top, bottom act as a minimum spacing between content and root element
+      ...(ownerState.variant === 'outlined' && {
+        padding: 'calc(0.25rem - 1px) calc(var(--Button-gutter) - 1px)', // account for the border width
+      }),
       minHeight: 'var(--Button-minHeight)',
       borderRadius: theme.vars.radius.sm,
       border: 'none',
@@ -105,6 +134,8 @@ const Button = React.forwardRef(function Button(inProps, ref) {
     size = 'md',
     fullWidth = false,
     square = false,
+    startIcon: startIconProp,
+    endIcon: endIconProp,
     ...other
   } = props;
 
@@ -143,6 +174,18 @@ const Button = React.forwardRef(function Button(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
+  const startIcon = startIconProp && (
+    <ButtonStartIcon className={classes.startIcon} ownerState={ownerState}>
+      {startIconProp}
+    </ButtonStartIcon>
+  );
+
+  const endIcon = endIconProp && (
+    <ButtonEndIcon className={classes.endIcon} ownerState={ownerState}>
+      {endIconProp}
+    </ButtonEndIcon>
+  );
+
   return (
     <ButtonRoot
       as={ComponentProp}
@@ -151,7 +194,9 @@ const Button = React.forwardRef(function Button(inProps, ref) {
       {...other}
       {...getRootProps()}
     >
+      {startIcon}
       {children}
+      {endIcon}
     </ButtonRoot>
   );
 }) as ExtendButton<ButtonTypeMap>;

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -42,8 +42,8 @@ const ButtonStartIcon = styled('span', {
   overridesResolver: (props, styles) => styles.startIcon,
 })<{ ownerState: ButtonProps }>({
   display: 'inherit',
-  marginLeft: 'calc(var(--Button-gutter) / -2)',
-  marginRight: 'min(var(--Button-gutter) / 2, 0.5rem)', // limit upper bound to 0.5rem
+  marginLeft: 'calc(var(--Button-gutter) * var(--Button-iconOffsetStep) * -0.25)',
+  marginRight: 'var(--Button-gap)',
 });
 
 const ButtonEndIcon = styled('span', {
@@ -52,8 +52,8 @@ const ButtonEndIcon = styled('span', {
   overridesResolver: (props, styles) => styles.endIcon,
 })<{ ownerState: ButtonProps }>({
   display: 'inherit',
-  marginLeft: 'min(var(--Button-gutter) / 2, 0.5rem)', // limit upper bound to 0.5rem
-  marginRight: 'calc(var(--Button-gutter) / -2)',
+  marginLeft: 'var(--Button-gap)',
+  marginRight: 'calc(var(--Button-gutter) * var(--Button-iconOffsetStep) * -0.25)',
 });
 
 const ButtonRoot = styled('button', {
@@ -65,6 +65,8 @@ const ButtonRoot = styled('button', {
     {
       '--Button-minHeight': '2.5rem', // use min-height instead of height to make the button resilient to its content
       '--Button-gutter': '1.5rem', // gutter is the padding-x
+      '--Button-iconOffsetStep': 2, // negative margin of the start/end icon
+      '--Button-gap': 'min(var(--Button-gutter) * 0.5, 0.5rem)', // gap between start/end icon and content (limit upper bound to 0.5rem)
       ...(ownerState.size === 'sm' && {
         '--Button-minHeight': '2rem',
         '--Button-gutter': '1rem',

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -40,8 +40,23 @@ const ButtonRoot = styled('button', {
 })<{ ownerState: ButtonProps }>(({ theme, ownerState }) => {
   return [
     {
-      padding: '0.25rem 1.5rem', // the padding-top, bottom act as a minimum spacing between content and root element
-      minHeight: '40px',
+      '--Button-minHeight': '40px',
+      '--Button-gutter': '1.5rem',
+      ...(ownerState.size === 'sm' && {
+        '--Button-minHeight': '32px',
+        '--Button-gutter': '1rem',
+      }),
+      ...(ownerState.size === 'lg' && {
+        '--Button-minHeight': '48px',
+        '--Button-gutter': '2rem',
+      }),
+      ...(ownerState.square && {
+        '--Button-gutter': '0.25rem',
+      }),
+    },
+    {
+      padding: '0.25rem var(--Button-gutter)', // the padding-top, bottom act as a minimum spacing between content and root element
+      minHeight: 'var(--Button-minHeight)',
       borderRadius: theme.vars.radius.sm,
       border: 'none',
       backgroundColor: 'transparent',
@@ -55,16 +70,12 @@ const ButtonRoot = styled('button', {
         'background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
       ...theme.typography.body1,
       ...(ownerState.size === 'sm' && {
-        paddingLeft: '1rem',
-        paddingRight: '1rem',
-        minHeight: '32px',
         ...theme.typography.body2,
+        lineHeight: '1.25rem',
       }),
-      ...(ownerState.size === 'lg' && {
-        paddingLeft: '2rem',
-        paddingRight: '2rem',
-        minHeight: '48px',
-        ...theme.typography.h6,
+      ...(ownerState.size === 'lg' && theme.typography.h6),
+      ...(ownerState.square && {
+        minWidth: 'var(--Button-minHeight)',
       }),
       [`&.${buttonClasses.focusVisible}`]: theme.focus.default,
     },
@@ -93,6 +104,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
     variant = 'contained',
     size = 'md',
     fullWidth = false,
+    square = false,
     ...other
   } = props;
 
@@ -126,6 +138,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
     variant,
     size,
     focusVisible,
+    square,
   };
 
   const classes = useUtilityClasses(ownerState);

--- a/packages/mui-joy/src/Button/ButtonProps.ts
+++ b/packages/mui-joy/src/Button/ButtonProps.ts
@@ -35,6 +35,10 @@ export interface ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> {
      */
     disabled?: boolean;
     /**
+     * Element placed after the children.
+     */
+    endIcon?: React.ReactNode;
+    /**
      * This prop can help identify which element has keyboard focus.
      * The class name will be applied when the element gains the focus through keyboard interaction.
      * It's a polyfill for the [CSS :focus-visible selector](https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo).
@@ -52,6 +56,10 @@ export interface ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> {
      * The size of the component.
      */
     size?: OverridableStringUnion<'sm' | 'md' | 'lg', ButtonPropsSizeOverrides>;
+    /**
+     * Element placed before the children.
+     */
+    startIcon?: React.ReactNode;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/mui-joy/src/Button/ButtonProps.ts
+++ b/packages/mui-joy/src/Button/ButtonProps.ts
@@ -65,11 +65,6 @@ export interface ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> {
      */
     sx?: SxProps;
     /**
-     * If `true`, the component has min-width equal to var(--Button-minHeight).
-     * @default false
-     */
-    square?: boolean;
-    /**
      * @default 0
      */
     tabIndex?: NonNullable<React.HTMLAttributes<any>['tabIndex']>;

--- a/packages/mui-joy/src/Button/ButtonProps.ts
+++ b/packages/mui-joy/src/Button/ButtonProps.ts
@@ -57,6 +57,11 @@ export interface ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> {
      */
     sx?: SxProps;
     /**
+     * If `true`, the component has min-width equal to var(--Button-minHeight).
+     * @default false
+     */
+    square?: boolean;
+    /**
      * @default 0
      */
     tabIndex?: NonNullable<React.HTMLAttributes<any>['tabIndex']>;

--- a/packages/mui-joy/src/Button/buttonClasses.ts
+++ b/packages/mui-joy/src/Button/buttonClasses.ts
@@ -37,6 +37,10 @@ export interface ButtonClasses {
   fullWidth: string;
   /** Styles applied to the root element if `square={true}`. */
   square: string;
+  /** Styles applied to the startIcon element if supplied. */
+  startIcon: string;
+  /** Styles applied to the endIcon element if supplied. */
+  endIcon: string;
 }
 
 export type ButtonClassKey = keyof ButtonClasses;
@@ -64,6 +68,8 @@ const buttonClasses: ButtonClasses = generateUtilityClasses('MuiButton', [
   'sizeLg',
   'fullWidth',
   'square',
+  'startIcon',
+  'endIcon',
 ]);
 
 export default buttonClasses;

--- a/packages/mui-joy/src/Button/buttonClasses.ts
+++ b/packages/mui-joy/src/Button/buttonClasses.ts
@@ -35,6 +35,8 @@ export interface ButtonClasses {
   sizeLg: string;
   /** Styles applied to the root element if `fullWidth={true}`. */
   fullWidth: string;
+  /** Styles applied to the root element if `square={true}`. */
+  square: string;
 }
 
 export type ButtonClassKey = keyof ButtonClasses;
@@ -61,6 +63,7 @@ const buttonClasses: ButtonClasses = generateUtilityClasses('MuiButton', [
   'sizeMd',
   'sizeLg',
   'fullWidth',
+  'square',
 ]);
 
 export default buttonClasses;

--- a/packages/mui-joy/src/Button/buttonClasses.ts
+++ b/packages/mui-joy/src/Button/buttonClasses.ts
@@ -35,8 +35,6 @@ export interface ButtonClasses {
   sizeLg: string;
   /** Styles applied to the root element if `fullWidth={true}`. */
   fullWidth: string;
-  /** Styles applied to the root element if `square={true}`. */
-  square: string;
   /** Styles applied to the startIcon element if supplied. */
   startIcon: string;
   /** Styles applied to the endIcon element if supplied. */
@@ -67,7 +65,6 @@ const buttonClasses: ButtonClasses = generateUtilityClasses('MuiButton', [
   'sizeMd',
   'sizeLg',
   'fullWidth',
-  'square',
   'startIcon',
   'endIcon',
 ]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Preview:

**Playground**: https://deploy-preview-30803--material-ui.netlify.app/experiments/joy/components/  
**Demo**: https://deploy-preview-30803--material-ui.netlify.app/experiments/joy/button/

## Design highlights:
- add Button CSS variables (naming can be discussed later). The great benefit about using CSS variables is that we don't need to use pseudo selectors like in `@mui/material/Button`. Also, the customization experience is a lot better because developers only need to change the value without writing the whole stylesheet for every size.
  - `--Button-minHeight`: to make the button's height explicit and predictable for different sizes.
  - `--Button-gutter`: represents the padding-left & right of the button to be used to calculate icon margin.
  - `--Button-iconOffsetStep`: the negative margin of the start/end icon
  - `--Button-gap`: the space between start/end icon and the text
- add `startIcon` & `endIcon` prop to the Button
- (it makes theming harder) ~add `square` prop to the Button (to create IconButton). I think this is a lot easier than creating another component, aka `IconButton`, and maintaining both of these buttons. Here is my thought process.~
  - ~I want a button with an icon inside, so I write this `<Button><PlusIcon /></Button>`~
  - ~I see it on the screen that the button is a rectangle but I want the shape to be a square.~
  - ~I expect to add one more prop like `<Button square><PlusIcon /></Button>` to make the width & height equally and if I want it to be rounded, I would add `sx` or style overrides depending on the whole design look & feel.~
  
  ~You might ask, why not `shape="square | circular"`. I have tried that out and it did not work well because `shape: square` and `shape: circular` target different CSS properties or more than 1 property depending on how you interpreted them.~
  - ~`square`: target the width to equal to the height~
  - ~`circular`: target the border-radius~

  ~It is hard to predict the UI when 1 prop targets different CSS properties. However, this is just from my experience of using it and I might be wrong. We will be able to test this out with the UI examples and revisit it again.~

## What's next?

- Add `IconButton` component
- We will need to think about how to document CSS variables.
- CSS variables naming for using inside the components. Should it be
   - `--MuiButton-minHeight` or
   - `--joy-Button-minHeight` or
   - `--Button-minHeight`
- Add `loading` prop to Button

---
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
