### PR TITLE
[test] Fix tests on Node 16

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.test.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.test.js
@@ -254,14 +254,21 @@ describe('useAutocomplete', () => {
       );
     };
 
+    const node16ErrorMessage =
+      "Error: Uncaught [TypeError: Cannot read properties of null (reading 'removeAttribute')]";
+    const olderNodeErrorMessage =
+      "Error: Uncaught [TypeError: Cannot read property 'removeAttribute' of null]";
+
+    const nodeVersion = Number(process.versions.node.split('.')[0]);
+    const errorMessage = nodeVersion >= 16 ? node16ErrorMessage : olderNodeErrorMessage;
+
     const devErrorMessages = [
-      "Error: Uncaught [TypeError: Cannot read property 'removeAttribute' of null]",
+      errorMessage,
       'MUI: Unable to find the input element.',
-      "Error: Uncaught [TypeError: Cannot read property 'removeAttribute' of null]",
+      errorMessage,
       // strict effects runs effects twice
       React.version.startsWith('18') && 'MUI: Unable to find the input element.',
-      React.version.startsWith('18') &&
-        "Error: Uncaught [TypeError: Cannot read property 'removeAttribute' of null]",
+      React.version.startsWith('18') && errorMessage,
       'The above error occurred in the <ul> component',
       React.version.startsWith('16') && 'The above error occurred in the <ul> component',
       'The above error occurred in the <Test> component',


### PR DESCRIPTION
Node 16 changed the error message associated with reading a property of a null reference.
This PR adds logic to detect node version and assert on the correct error message.