### PR TITLE
[Fab] supporting other colors

### DIFF
--- a/docs/pages/api-docs/fab.json
+++ b/docs/pages/api-docs/fab.json
@@ -4,8 +4,8 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "union",
-        "description": "'default'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
+        "name": "enum",
+        "description": "'default'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'warning'"
       },
       "default": "'default'"
     },

--- a/packages/mui-material/src/Fab/Fab.d.ts
+++ b/packages/mui-material/src/Fab/Fab.d.ts
@@ -25,7 +25,10 @@ export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendB
      * The color of the component. It supports those theme colors that make sense for this component.
      * @default 'default'
      */
-    color?: OverridableStringUnion<PropTypes.Color, FabPropsColorOverrides>;
+    color?: OverridableStringUnion<
+      PropTypes.Color | 'success' | 'error' | 'info' | 'warning',
+      FabPropsColorOverrides
+    >;
     /**
      * If `true`, the component is disabled.
      * @default false

--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -184,9 +184,15 @@ Fab.propTypes /* remove-proptypes */ = {
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'default'
    */
-  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['default', 'inherit', 'primary', 'secondary']),
-    PropTypes.string,
+  color: PropTypes.oneOf([
+    'default',
+    'error',
+    'info',
+    'inherit',
+    'primary',
+    'secondary',
+    'success',
+    'warning',
   ]),
   /**
    * The component used for the root node.

--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -12,14 +12,7 @@ const useUtilityClasses = (ownerState) => {
   const { color, variant, classes, size } = ownerState;
 
   const slots = {
-    root: [
-      'root',
-      variant,
-      `size${capitalize(size)}`,
-      color === 'inherit' && 'colorInherit',
-      color === 'primary' && 'primary',
-      color === 'secondary' && 'secondary',
-    ],
+    root: ['root', variant, `size${capitalize(size)}`, color],
   };
 
   return composeClasses(slots, getFabUtilityClass, classes);
@@ -36,8 +29,8 @@ const FabRoot = styled(ButtonBase, {
       styles[ownerState.variant],
       styles[`size${capitalize(ownerState.size)}`],
       ownerState.color === 'inherit' && styles.colorInherit,
-      ownerState.color === 'primary' && styles.primary,
-      ownerState.color === 'secondary' && styles.secondary,
+      styles[capitalize(ownerState.size)],
+      styles[ownerState.color],
     ];
   },
 })(
@@ -111,28 +104,19 @@ const FabRoot = styled(ButtonBase, {
     }),
   }),
   ({ theme, ownerState }) => ({
-    ...(ownerState.color === 'primary' && {
-      color: theme.palette.primary.contrastText,
-      backgroundColor: theme.palette.primary.main,
-      '&:hover': {
-        backgroundColor: theme.palette.primary.dark,
-        // Reset on touch devices, it doesn't add specificity
-        '@media (hover: none)': {
-          backgroundColor: theme.palette.primary.main,
+    ...(ownerState.color !== 'inherit' &&
+      ownerState.color !== 'default' &&
+      theme.palette[ownerState.color] != null && {
+        color: theme.palette[ownerState.color].contrastText,
+        backgroundColor: theme.palette[ownerState.color].main,
+        '&:hover': {
+          backgroundColor: theme.palette[ownerState.color].dark,
+          // Reset on touch devices, it doesn't add specificity
+          '@media (hover: none)': {
+            backgroundColor: theme.palette[ownerState.color].main,
+          },
         },
-      },
-    }),
-    ...(ownerState.color === 'secondary' && {
-      color: theme.palette.secondary.contrastText,
-      backgroundColor: theme.palette.secondary.main,
-      '&:hover': {
-        backgroundColor: theme.palette.secondary.dark,
-        // Reset on touch devices, it doesn't add specificity
-        '@media (hover: none)': {
-          backgroundColor: theme.palette.secondary.main,
-        },
-      },
-    }),
+      }),
   }),
 );
 

--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -12,7 +12,12 @@ const useUtilityClasses = (ownerState) => {
   const { color, variant, classes, size } = ownerState;
 
   const slots = {
-    root: ['root', variant, `size${capitalize(size)}`, color],
+    root: [
+      'root',
+      variant,
+      `size${capitalize(size)}`,
+      color === 'inherit' ? 'colorInherit' : color,
+    ],
   };
 
   return composeClasses(slots, getFabUtilityClass, classes);

--- a/packages/mui-material/src/Fab/Fab.test.js
+++ b/packages/mui-material/src/Fab/Fab.test.js
@@ -60,6 +60,16 @@ describe('<Fab />', () => {
     expect(button).not.to.have.class(classes.primary);
     expect(button).to.have.class(classes.secondary);
   });
+  ['info', 'error', 'warning', 'success'].forEach((color) => {
+    it(`should render a ${color} floating action button`, () => {
+      const { getByRole } = render(<Fab color={color}>Fab</Fab>);
+      const button = getByRole('button');
+
+      expect(button).to.have.class(classes.root);
+      expect(button).not.to.have.class(classes.primary);
+      expect(button).to.have.class(classes[color]);
+    });
+  });
 
   it('should render a small floating action button', () => {
     const { getByRole } = render(<Fab size="small">Fab</Fab>);

--- a/packages/mui-material/src/Fab/fabClasses.ts
+++ b/packages/mui-material/src/Fab/fabClasses.ts
@@ -41,6 +41,10 @@ const fabClasses: FabClasses = generateUtilityClasses('MuiFab', [
   'sizeSmall',
   'sizeMedium',
   'sizeLarge',
+  'info',
+  'error',
+  'warning',
+  'success',
 ]);
 
 export default fabClasses;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes: #30665

[CodeSandBox Demo](https://codesandbox.io/s/floatingactionbuttons-material-demo-forked-vsk24?file=/demo.js)

**Problems:**
Fab component only supports primary and secondary values for its color, and it does not support other values such as info, success, etc. It is expected that Fab component accepts them, such as the Button component.

**Solution:**
changing the condition for the color classes and values, and adding them to its valid proptypes.
