### PR TITLE
[core] Do not reexport Base from Material

### DIFF
--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -74,8 +74,6 @@ export * from './styles';
 
 export * from './utils';
 
-export * from '@mui/base';
-
 export { default as Accordion } from './Accordion';
 export * from './Accordion';
 

--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -476,10 +476,8 @@ export * from './GlobalStyles';
 export { StyledEngineProvider } from './styles';
 
 export { default as unstable_composeClasses } from '@mui/base/composeClasses';
-export * from '@mui/base/composeClasses';
 
 export { default as generateUtilityClass } from '@mui/base/generateUtilityClass';
 export * from '@mui/base/generateUtilityClass';
 
 export { default as generateUtilityClasses } from '@mui/base/generateUtilityClasses';
-export * from '@mui/base/generateUtilityClasses';

--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -474,3 +474,12 @@ export * from './GlobalStyles';
  * @deprecated will be removed in v5.beta, please use StyledEngineProvider from @mui/material/styles instead
  */
 export { StyledEngineProvider } from './styles';
+
+export { default as unstable_composeClasses } from '@mui/base/composeClasses';
+export * from '@mui/base/composeClasses';
+
+export { default as generateUtilityClass } from '@mui/base/generateUtilityClass';
+export * from '@mui/base/generateUtilityClass';
+
+export { default as generateUtilityClasses } from '@mui/base/generateUtilityClasses';
+export * from '@mui/base/generateUtilityClasses';

--- a/packages/mui-material/src/index.js
+++ b/packages/mui-material/src/index.js
@@ -6,8 +6,6 @@ export * from './styles';
 
 export * from './utils';
 
-export * from '@mui/base';
-
 export { default as Accordion } from './Accordion';
 export * from './Accordion';
 

--- a/packages/mui-material/src/index.js
+++ b/packages/mui-material/src/index.js
@@ -403,3 +403,10 @@ export { default as GlobalStyles } from './GlobalStyles';
 export * from './GlobalStyles';
 
 export { StyledEngineProvider } from './styles';
+
+export { default as unstable_composeClasses } from '@mui/base/composeClasses';
+
+export { default as generateUtilityClass } from '@mui/base/generateUtilityClass';
+export * from '@mui/base/generateUtilityClass';
+
+export { default as generateUtilityClasses } from '@mui/base/generateUtilityClasses';


### PR DESCRIPTION
The Base components were exported from @mui/material package and treated as stable even though the @mui/base package is in development. It could create a lot of confusion if developers start using Base components, depend on them, and demand quality found in "proper" Material components. We admit it was a mistake to reexport these components without marking them as unstable.

This PR removes the Base components from @mui/material package. Developers are still encouraged to evaluate the Base components, but they should do so by explicitly installing the @mui/base package.

This is technically a breaking change as it removes a number of components from the @mui/material package. However, we believe that removing the components now and potentially breaking the codebases will do less harm than introducing "silent" breaking changes to Base components while continuing reexporting them from @mui/material.

Note: utility components, such as ClickAwayListener, NoSsr, Portal, and TextareaAutosize continue to be exported from both @mui/material and @mui/base

## Upgrade path

If you're encountering build errors after upgrading @mui/material, do the following:
1. Install @mui/base: `npm install @mui/base` or `yarn add @mui/base`
2. Make sure the version of @mui/base match the version of @mui/material
3. Change the import paths of unstyled components from `@mui/material` to `@mui/base`, e.g.:
   ```diff
   - @import ButtonUnstyled from '@mui/material/ButtonUnstyled';
   + @import ButtonUnstyled from '@mui/base/ButtonUnstyled';
   ```