### PR TITLE
[test] Codify the difference between keyup and keydown in SelectUnstyled

### DIFF
--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
@@ -11,6 +11,7 @@ import {
   describeConformanceUnstyled,
   userEvent,
   act,
+  fireEvent,
 } from 'test/utils';
 
 describe('MultiSelectUnstyled', () => {
@@ -48,20 +49,34 @@ describe('MultiSelectUnstyled', () => {
   }));
 
   describe('keyboard navigation', () => {
-    ['Enter', ' ', 'ArrowDown', 'ArrowUp'].forEach((key) => {
-      it(`opens the dropdown when the "${key}" key is pressed on the button`, () => {
+    ['Enter', 'ArrowDown', 'ArrowUp'].forEach((key) => {
+      it(`opens the dropdown when the "${key}" key is down on the button`, () => {
         // can't use the default native `button` as it doesn't treat enter or space press as a click
         const { getByRole } = render(<MultiSelectUnstyled components={{ Root: 'div' }} />);
         const button = getByRole('button');
         act(() => {
           button.focus();
         });
-        userEvent.keyPress(button, { key });
+        fireEvent.keyDown(button, { key });
 
         expect(button).to.have.attribute('aria-expanded', 'true');
         expect(getByRole('listbox')).not.to.equal(null);
         expect(document.activeElement).to.equal(getByRole('listbox'));
       });
+    });
+
+    it(`opens the dropdown when the " " key is let go on the button`, () => {
+      // can't use the default native `button` as it doesn't treat enter or space press as a click
+      const { getByRole } = render(<MultiSelectUnstyled components={{ Root: 'div' }} />);
+      const button = getByRole('button');
+      act(() => {
+        button.focus();
+      });
+      fireEvent.keyUp(button, { key: ' ' });
+
+      expect(button).to.have.attribute('aria-expanded', 'true');
+      expect(getByRole('listbox')).not.to.equal(null);
+      expect(document.activeElement).to.equal(getByRole('listbox'));
     });
 
     describe('item selection', () => {

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.test.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.test.tsx
@@ -47,20 +47,34 @@ describe('SelectUnstyled', () => {
   }));
 
   describe('keyboard navigation', () => {
-    ['Enter', ' ', 'ArrowDown', 'ArrowUp'].forEach((key) => {
-      it(`opens the dropdown when the "${key}" key is pressed on the button`, () => {
+    ['Enter', 'ArrowDown', 'ArrowUp'].forEach((key) => {
+      it(`opens the dropdown when the "${key}" key is down on the button`, () => {
         // can't use the default native `button` as it doesn't treat enter or space press as a click
         const { getByRole } = render(<SelectUnstyled components={{ Root: 'div' }} />);
         const button = getByRole('button');
         act(() => {
           button.focus();
         });
-        userEvent.keyPress(button, { key });
+        fireEvent.keyDown(button, { key });
 
         expect(button).to.have.attribute('aria-expanded', 'true');
         expect(getByRole('listbox')).not.to.equal(null);
         expect(document.activeElement).to.equal(getByRole('listbox'));
       });
+    });
+
+    it(`opens the dropdown when the " " key is let go on the button`, () => {
+      // can't use the default native `button` as it doesn't treat enter or space press as a click
+      const { getByRole } = render(<SelectUnstyled components={{ Root: 'div' }} />);
+      const button = getByRole('button');
+      act(() => {
+        button.focus();
+      });
+      fireEvent.keyUp(button, { key: ' ' });
+
+      expect(button).to.have.attribute('aria-expanded', 'true');
+      expect(getByRole('listbox')).not.to.equal(null);
+      expect(document.activeElement).to.equal(getByRole('listbox'));
     });
 
     ['Enter', ' ', 'Escape'].forEach((key) => {


### PR DESCRIPTION
Failing GH status checks are expected due to git-diff in React 18 pipeline.


There's a difference for <kbd>Enter</kbd> and <kbd>Space</kbd> in `keydown` and `keyup` with regards to activation behavior. For <kbd>Enter</kbd> `keydown` will activate the element. For <kbd>Space</kbd> `keyup` will activate the element.

This was not codified in tests and started failing for React 18. It should be codified in tests anyway. Other usages of `userEvent.keypress` should also be investigated. `userEvent` was really just a temporary solution for timing related changes between React 17 and 18. It shouldn't be used freely.

[React 17 pipeline](https://app.circleci.com/pipelines/github/mui-org/material-ui/63135/workflows/845a50b9-bd20-4257-9dce-ef81ff66a56b)
[React 18 pipeline](https://app.circleci.com/pipelines/github/mui-org/material-ui/63136/workflows/4a073366-cdaf-4048-a5fd-4deb45f56ec6)