### PR TITLE
[docs] Remove migration from the versions page

### DIFF
--- a/docs/pages/versions.js
+++ b/docs/pages/versions.js
@@ -39,7 +39,7 @@ async function getBranches() {
 }
 
 Page.getInitialProps = async () => {
-  const FILTERED_BRANCHES = ['latest', 'l10n', 'next', 'material-ui.com'];
+  const FILTERED_BRANCHES = ['latest', 'l10n', 'next', 'migration', 'material-ui.com'];
 
   const branches = await getBranches();
   /**


### PR DESCRIPTION
Previously: https://mui.com/versions/#released-versions
<img src="https://user-images.githubusercontent.com/4512430/151960464-5aebbcfa-5259-42f4-90df-d3796ae8ab13.png" width="700px" />

Now: https://deploy-preview-30863--material-ui.netlify.app/versions/#released-versions
<img src="https://user-images.githubusercontent.com/4512430/151960618-3a6835dc-fec9-41b8-bac2-f69936042ebb.png" width="700px" />