### PR TITLE
[docs] Clarify what the name of @mui/material is

### DIFF
--- a/docs/pages/blog/2021.md
+++ b/docs/pages/blog/2021.md
@@ -131,7 +131,7 @@ Our high-level plan is to use the unstyled components and hooks as the basis of 
 There a number of improvements that we can bring to the system (the npm package `@mui/system` used to create the styled components).
 Hopefully, we will bring native support for CSS variables, improve DX, and improve performance.
 
-#### MUI Material
+#### Material UI
 
 Google is rolling out [Material Design 3](https://m3.material.io/), we have to determine how to respond to it.
 Should we implement it later on for v6? Should we ignore it? Should we implement Google's UI that looks cleaner instead?

--- a/docs/pages/blog/material-ui-is-now-mui.md
+++ b/docs/pages/blog/material-ui-is-now-mui.md
@@ -13,6 +13,7 @@ Starting today we are evolving our brand identity to clarifying the difference b
 
 - Material-UI: the organization is now called [**MUI**](https://github.com/mui-org/).
 - Material-UI: the set of foundational MIT React components is now called [**MUI Core**](https://github.com/mui-org/material-ui).
+- Material-UI: the name of the Material Design components **doesn't change**.
 - Material-UI X: the set of advanced React components is now called [**MUI X**](https://github.com/mui-org/material-ui-x).
 
 Our previous name was no longer serving our areas of focus.

--- a/docs/pages/blog/material-ui-is-now-mui.md
+++ b/docs/pages/blog/material-ui-is-now-mui.md
@@ -13,7 +13,7 @@ Starting today we are evolving our brand identity to clarifying the difference b
 
 - Material-UI: the organization is now called [**MUI**](https://github.com/mui-org/).
 - Material-UI: the set of foundational MIT React components is now called [**MUI Core**](https://github.com/mui-org/material-ui).
-- Material-UI: the name of the Material Design components **doesn't change**.
+- Material UI: the Material Design components developed by MUI. Also, we ditched the hyphen!
 - Material-UI X: the set of advanced React components is now called [**MUI X**](https://github.com/mui-org/material-ui-x).
 
 Our previous name was no longer serving our areas of focus.

--- a/docs/pages/material.tsx
+++ b/docs/pages/material.tsx
@@ -54,7 +54,7 @@ export default function Components() {
   return (
     <BrandingProvider>
       <Head
-        title="Components - MUI Material"
+        title="Components - Material UI"
         description="MUI provides a simple, customizable, and accessible library of React components. Follow your own design system, or start with Material Design. You will develop React applications faster."
       />
       <AppHeader />


### PR DESCRIPTION
Reflects https://www.notion.so/mui-org/MUI-Material-or-Material-UI-439dbdb694ab4436924679e4de061b1e. I didn't change "Material-UI" to "Material UI". I think that this can be done in a follow-up. https://github.com/mui-org/material-ui/pull/30861#issuecomment-1026876652