### PR TITLE
[docs] Add missing import to RTL guide

### DIFF
--- a/docs/data/material/guides/right-to-left/right-to-left.md
+++ b/docs/data/material/guides/right-to-left/right-to-left.md
@@ -31,6 +31,8 @@ This can be helpful for creating components to toggle language settings in the l
 Set the direction in your custom theme:
 
 ```js
+import { createTheme } from '@mui/material/styles';
+
 const theme = createTheme({
   direction: 'rtl',
 });

--- a/docs/data/material/guides/right-to-left/right-to-left.md
+++ b/docs/data/material/guides/right-to-left/right-to-left.md
@@ -31,7 +31,7 @@ This can be helpful for creating components to toggle language settings in the l
 Set the direction in your custom theme:
 
 ```js
-import { createTheme } from "@mui/system";
+import { createTheme } from '@mui/material/styles'
 
 const theme = createTheme({
   direction: 'rtl',

--- a/docs/data/material/guides/right-to-left/right-to-left.md
+++ b/docs/data/material/guides/right-to-left/right-to-left.md
@@ -31,6 +31,8 @@ This can be helpful for creating components to toggle language settings in the l
 Set the direction in your custom theme:
 
 ```js
+import { createTheme } from "@mui/system";
+
 const theme = createTheme({
   direction: 'rtl',
 });

--- a/docs/data/material/guides/right-to-left/right-to-left.md
+++ b/docs/data/material/guides/right-to-left/right-to-left.md
@@ -31,8 +31,6 @@ This can be helpful for creating components to toggle language settings in the l
 Set the direction in your custom theme:
 
 ```js
-import { createTheme } from '@mui/material/styles'
-
 const theme = createTheme({
   direction: 'rtl',
 });


### PR DESCRIPTION
i added createtheme method to step 2 in [Right-to-left guide](https://mui.com/guides/right-to-left/) because any new users dont know where is this method
