### PR TITLE
[docs] Fix WithStyles import statement for @mui/styles

### DIFF
--- a/docs/data/styles/advanced/advanced.md
+++ b/docs/data/styles/advanced/advanced.md
@@ -627,8 +627,7 @@ interface Props {
 However this isn't very [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) because it requires you to maintain the class names (`'root'`, `'paper'`, `'button'`, ...) in two different places. We provide a type operator `WithStyles` to help with this, so that you can just write:
 
 ```ts
-import { createStyles } from '@mui/styles';
-import { WithStyles } from '@mui/material';
+import { createStyles, WithStyles } from '@mui/styles';
 
 const styles = (theme: Theme) =>
   createStyles({


### PR DESCRIPTION
Steps to reproduce:
- Visit https://mui.com/styles/advanced/#augmenting-your-props-using-withstyles
- Second code sample references previous import location for `WithStyles`

Screenshot:
<img width="397" alt="WithStyles" src="https://user-images.githubusercontent.com/937917/152671956-42cb398f-e020-4762-a736-a1feafb46d70.png">


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
