### PR TITLE
[slider] Prevent rendering for marks that are out of min&max bounds

### DIFF
--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
@@ -155,57 +155,59 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
         className={clsx(classes.track, trackProps.className)}
         style={{ ...trackStyle, ...trackProps.style }}
       />
-      {marks.map((mark, index) => {
-        const percent = valueToPercent(mark.value, min, max);
-        const style = axisProps[axis].offset(percent);
+      {marks
+        .filter((mark) => mark.value >= min && mark.value <= max)
+        .map((mark, index) => {
+          const percent = valueToPercent(mark.value, min, max);
+          const style = axisProps[axis].offset(percent);
 
-        let markActive;
-        if (track === false) {
-          markActive = values.indexOf(mark.value) !== -1;
-        } else {
-          markActive =
-            (track === 'normal' &&
-              (range
-                ? mark.value >= values[0] && mark.value <= values[values.length - 1]
-                : mark.value <= values[0])) ||
-            (track === 'inverted' &&
-              (range
-                ? mark.value <= values[0] || mark.value >= values[values.length - 1]
-                : mark.value >= values[0]));
-        }
+          let markActive;
+          if (track === false) {
+            markActive = values.indexOf(mark.value) !== -1;
+          } else {
+            markActive =
+              (track === 'normal' &&
+                (range
+                  ? mark.value >= values[0] && mark.value <= values[values.length - 1]
+                  : mark.value <= values[0])) ||
+              (track === 'inverted' &&
+                (range
+                  ? mark.value <= values[0] || mark.value >= values[values.length - 1]
+                  : mark.value >= values[0]));
+          }
 
-        return (
-          <React.Fragment key={mark.value}>
-            <Mark
-              data-index={index}
-              {...markProps}
-              {...(!isHostComponent(Mark) && {
-                markActive,
-              })}
-              style={{ ...style, ...markProps.style }}
-              className={clsx(classes.mark, markProps.className, {
-                [classes.markActive]: markActive,
-              })}
-            />
-            {mark.label != null ? (
-              <MarkLabel
-                aria-hidden
+          return (
+            <React.Fragment key={mark.value}>
+              <Mark
                 data-index={index}
-                {...markLabelProps}
-                {...(!isHostComponent(MarkLabel) && {
-                  markLabelActive: markActive,
+                {...markProps}
+                {...(!isHostComponent(Mark) && {
+                  markActive,
                 })}
-                style={{ ...style, ...markLabelProps.style }}
-                className={clsx(classes.markLabel, markLabelProps.className, {
-                  [classes.markLabelActive]: markActive,
+                style={{ ...style, ...markProps.style }}
+                className={clsx(classes.mark, markProps.className, {
+                  [classes.markActive]: markActive,
                 })}
-              >
-                {mark.label}
-              </MarkLabel>
-            ) : null}
-          </React.Fragment>
-        );
-      })}
+              />
+              {mark.label != null ? (
+                <MarkLabel
+                  aria-hidden
+                  data-index={index}
+                  {...markLabelProps}
+                  {...(!isHostComponent(MarkLabel) && {
+                    markLabelActive: markActive,
+                  })}
+                  style={{ ...style, ...markLabelProps.style }}
+                  className={clsx(classes.markLabel, markLabelProps.className, {
+                    [classes.markLabelActive]: markActive,
+                  })}
+                >
+                  {mark.label}
+                </MarkLabel>
+              ) : null}
+            </React.Fragment>
+          );
+        })}
       {values.map((value, index) => {
         const percent = valueToPercent(value, min, max);
         const style = axisProps[axis].offset(percent);

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.test.js
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.test.js
@@ -248,7 +248,7 @@ describe('<SliderUnstyled />', () => {
   });
 
   describe('marks', () => {
-    it('should not render marks that are out of min&max bounds', () => {
+    it('should not render marks that are out of min&max bounds', function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.test.js
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.test.js
@@ -246,4 +246,40 @@ describe('<SliderUnstyled />', () => {
       expect(thumb).to.have.attribute('aria-valuenow', '21');
     });
   });
+
+  describe('marks', () => {
+    it('should not render marks that are out of min&max bounds', () => {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const { container } = render(
+        <SliderUnstyled
+          marks={[
+            {
+              value: -1,
+              label: -1,
+            },
+            {
+              value: 0,
+              label: 0,
+            },
+            {
+              value: 100,
+              label: 100,
+            },
+            {
+              value: 120,
+              label: 120,
+            },
+          ]}
+        />,
+      );
+
+      expect(container.querySelectorAll(`.${classes.markLabel}`).length).to.equal(2);
+      expect(container.querySelectorAll(`.${classes.mark}`).length).to.equal(2);
+      expect(container.querySelectorAll(`.${classes.markLabel}`)[0].textContent).to.equal('0');
+      expect(container.querySelectorAll(`.${classes.markLabel}`)[1].textContent).to.equal('100');
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This fixes an issue when Slider component renders marks that are out of `min` and `max` bounds, e.g. when user wants to render a mark for `120` value when min is `0` and max is `100`. See [CodeSandbox](https://codesandbox.io/s/nostalgic-raman-7szz2j?file=/src/Demo.tsx) for reference.

P.S. - sorry for posting this PR twice. I accidentally checked out into outdated version of mui.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
