### PR TITLE
[CardContent] Use `theme.spacing()` instead of hardcoded values

### DIFF
--- a/packages/mui-material/src/CardContent/CardContent.js
+++ b/packages/mui-material/src/CardContent/CardContent.js
@@ -20,11 +20,11 @@ const CardContentRoot = styled('div', {
   name: 'MuiCardContent',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})(() => {
+})(({ theme }) => {
   return {
-    padding: styled.theme.spacing(2),
+    padding: theme.spacing(2),
     '&:last-child': {
-      paddingBottom: styled.theme.spacing(3),
+      paddingBottom: theme.spacing(3),
     },
   };
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #32155 