### PR TITLE
[slider] Slider having marks should be customizable in theme

### DIFF
--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
@@ -78,7 +78,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
   // consider extracting to hook an reusing the lint rule for the varints
   const ownerState = {
     ...props,
-    mark: marksProp,
+    marks: marksProp,
     classes: classesProp,
     disabled,
     isRtl,

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -33,22 +33,11 @@ const SliderRoot = styled('span', {
   overridesResolver: (props, styles) => {
     const { ownerState } = props;
 
-    const marks =
-      ownerState.marksProp === true && ownerState.step !== null
-        ? [...Array(Math.floor((ownerState.max - ownerState.min) / ownerState.step) + 1)].map(
-            (_, index) => ({
-              value: ownerState.min + ownerState.step * index,
-            }),
-          )
-        : ownerState.marksProp || [];
-
-    const marked = marks.length > 0 && marks.some((mark) => mark.label);
-
     return [
       styles.root,
       styles[`color${capitalize(ownerState.color)}`],
       ownerState.size !== 'medium' && styles[`size${capitalize(ownerState.size)}`],
-      marked && styles.marked,
+      ownerState.marked && styles.marked,
       ownerState.orientation === 'vertical' && styles.vertical,
       ownerState.track === 'inverted' && styles.trackInverted,
       ownerState.track === false && styles.trackFalse,

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1216,4 +1216,40 @@ describe('<Slider />', () => {
       expect(getByTestId(dataTestId).id).to.equal(id);
     });
   });
+
+  it('marked slider should be customizable in the theme', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const theme = createTheme({
+      components: {
+        MuiSlider: {
+          styleOverrides: {
+            marked: {
+              marginTop: 40,
+              marginBottom: 0,
+            },
+          },
+        },
+      },
+    });
+
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Slider
+          marks={[
+            { label: '1', value: 1 },
+            { label: '2', value: 2 },
+          ]}
+          step={null}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(container.querySelector(`.${classes.marked}`)).toHaveComputedStyle({
+      marginTop: '40px',
+      marginBottom: '0px',
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #32789 

Slider's `ownerState` does not have `marksProp` property which is used to calculate marked but anyway `marked` is already calculated in the `useSlider` hook which is then later added in the `ownerState`.

**Before:** https://codesandbox.io/s/small-platform-us0i9x?file=/src/Demo.tsx
**Now:** https://codesandbox.io/s/winter-surf-gxrp6z?file=/src/Demo.tsx