### PR TITLE
[slider] Fix SliderValueLabelProps type

### DIFF
--- a/docs/data/material/components/slider/CustomizedSlider.tsx
+++ b/docs/data/material/components/slider/CustomizedSlider.tsx
@@ -1,16 +1,11 @@
 import * as React from 'react';
-import Slider, { SliderThumb } from '@mui/material/Slider';
+import Slider, { SliderThumb, SliderValueLabelProps } from '@mui/material/Slider';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import Tooltip from '@mui/material/Tooltip';
 import Box from '@mui/material/Box';
 
-interface Props {
-  children: React.ReactElement;
-  value: number;
-}
-
-function ValueLabelComponent(props: Props) {
+function ValueLabelComponent(props: SliderValueLabelProps) {
   const { children, value } = props;
 
   return (

--- a/docs/pages/base/api/slider-unstyled.json
+++ b/docs/pages/base/api/slider-unstyled.json
@@ -15,7 +15,7 @@
     "componentsProps": {
       "type": {
         "name": "shape",
-        "description": "{ input?: object, mark?: object, markLabel?: object, rail?: object, root?: object, thumb?: object, track?: object, valueLabel?: { className?: string, components?: { Root?: elementType }, style?: object, value?: Array&lt;number&gt;<br>&#124;&nbsp;number, valueLabelDisplay?: 'auto'<br>&#124;&nbsp;'off'<br>&#124;&nbsp;'on' } }"
+        "description": "{ input?: object, mark?: object, markLabel?: object, rail?: object, root?: object, thumb?: object, track?: object, valueLabel?: { children?: element, className?: string, components?: { Root?: elementType }, open?: bool, style?: object, value?: number, valueLabelDisplay?: 'auto'<br>&#124;&nbsp;'off'<br>&#124;&nbsp;'on' } }"
       },
       "default": "{}"
     },

--- a/docs/pages/material-ui/api/slider.json
+++ b/docs/pages/material-ui/api/slider.json
@@ -21,7 +21,7 @@
     "componentsProps": {
       "type": {
         "name": "shape",
-        "description": "{ input?: object, mark?: object, markLabel?: object, rail?: object, root?: object, thumb?: object, track?: object, valueLabel?: { className?: string, components?: { Root?: elementType }, style?: object, value?: Array&lt;number&gt;<br>&#124;&nbsp;number, valueLabelDisplay?: 'auto'<br>&#124;&nbsp;'off'<br>&#124;&nbsp;'on' } }"
+        "description": "{ input?: object, mark?: object, markLabel?: object, rail?: object, root?: object, thumb?: object, track?: object, valueLabel?: { children?: element, className?: string, components?: { Root?: elementType }, open?: bool, style?: object, value?: number, valueLabelDisplay?: 'auto'<br>&#124;&nbsp;'off'<br>&#124;&nbsp;'on' } }"
       },
       "default": "{}"
     },

--- a/docs/src/components/x-grid/EditProgress.tsx
+++ b/docs/src/components/x-grid/EditProgress.tsx
@@ -2,14 +2,10 @@ import * as React from 'react';
 import { GridRenderEditCellParams } from '@mui/x-data-grid';
 import { debounce } from '@mui/material/utils';
 import { alpha } from '@mui/material/styles';
-import Slider from '@mui/material/Slider';
+import Slider, { SliderValueLabelProps } from '@mui/material/Slider';
 import Tooltip from '@mui/material/Tooltip';
 
-function ValueLabelComponent(props: {
-  open: boolean;
-  value: number;
-  children: React.ReactElement;
-}) {
+function ValueLabelComponent(props: SliderValueLabelProps) {
   const { children, open, value } = props;
   return (
     <Tooltip open={open} enterTouchDelay={0} placement="top" title={value} arrow>

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
@@ -354,12 +354,14 @@ SliderUnstyled.propTypes /* remove-proptypes */ = {
     thumb: PropTypes.object,
     track: PropTypes.object,
     valueLabel: PropTypes.shape({
+      children: PropTypes.element,
       className: PropTypes.string,
       components: PropTypes.shape({
         Root: PropTypes.elementType,
       }),
+      open: PropTypes.bool,
       style: PropTypes.object,
-      value: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.number), PropTypes.number]),
+      value: PropTypes.number,
       valueLabelDisplay: PropTypes.oneOf(['auto', 'off', 'on']),
     }),
   }),

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.types.ts
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.types.ts
@@ -23,7 +23,7 @@ export type SliderUnstyledOwnerState = SliderUnstyledProps & {
   valueLabelFormat: string | ((value: number, index: number) => React.ReactNode);
 };
 
-export interface ValueLabelProps extends React.HTMLAttributes<HTMLSpanElement> {
+export interface SliderValueLabelProps extends React.HTMLAttributes<HTMLSpanElement> {
   children: React.ReactElement;
   index: number;
   open: boolean;
@@ -76,7 +76,7 @@ export interface SliderUnstyledTypeMap<P = {}, D extends React.ElementType = 'sp
       thumb?: React.ComponentPropsWithRef<'span'> & SliderUnstyledComponentsPropsOverrides;
       mark?: React.ComponentPropsWithRef<'span'> & SliderUnstyledComponentsPropsOverrides;
       markLabel?: React.ComponentPropsWithRef<'span'> & SliderUnstyledComponentsPropsOverrides;
-      valueLabel?: React.ComponentPropsWithRef<typeof SliderValueLabelUnstyled> &
+      valueLabel?: Partial<React.ComponentPropsWithRef<typeof SliderValueLabelUnstyled>> &
         SliderUnstyledComponentsPropsOverrides;
       input?: React.ComponentPropsWithRef<'input'> & SliderUnstyledComponentsPropsOverrides;
     };

--- a/packages/mui-base/src/SliderUnstyled/SliderValueLabelUnstyled.d.ts
+++ b/packages/mui-base/src/SliderUnstyled/SliderValueLabelUnstyled.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
-export interface ValueLabelUnstyledProps {
+export interface SliderValueLabelUnstyledProps {
+  children?: React.ReactElement;
   className?: string;
   style?: React.CSSProperties;
   /**
@@ -12,10 +13,14 @@ export interface ValueLabelUnstyledProps {
     Root?: React.ElementType;
   };
   /**
+   * If `true`, the value label is visible.
+   */
+  open: boolean;
+  /**
    * The value of the slider.
    * For ranged sliders, provide an array with two values.
    */
-  value?: number | number[];
+  value: number;
   /**
    * Controls when the value label is displayed:
    *
@@ -27,4 +32,4 @@ export interface ValueLabelUnstyledProps {
   valueLabelDisplay?: 'on' | 'auto' | 'off';
 }
 
-export default function SliderValueLabelUnstyled(props: ValueLabelUnstyledProps): JSX.Element;
+export default function SliderValueLabelUnstyled(props: SliderValueLabelUnstyledProps): JSX.Element;

--- a/packages/mui-base/src/SliderUnstyled/SliderValueLabelUnstyled.js
+++ b/packages/mui-base/src/SliderUnstyled/SliderValueLabelUnstyled.js
@@ -20,7 +20,7 @@ const useValueLabelClasses = (props) => {
 /**
  * @ignore - internal component.
  */
-function SliderValueLabelUnstyled(props) {
+export default function SliderValueLabelUnstyled(props) {
   const { children, className, value, theme } = props;
   const classes = useValueLabelClasses(props);
 
@@ -46,5 +46,3 @@ SliderValueLabelUnstyled.propTypes = {
   theme: PropTypes.any,
   value: PropTypes.node,
 };
-
-export default SliderValueLabelUnstyled;

--- a/packages/mui-base/src/SliderUnstyled/index.d.ts
+++ b/packages/mui-base/src/SliderUnstyled/index.d.ts
@@ -1,15 +1,13 @@
 export { default } from './SliderUnstyled';
 export * from './SliderUnstyled';
+export * from './SliderUnstyled.types';
 
 export { default as SliderValueLabelUnstyled } from './SliderValueLabelUnstyled';
 export * from './SliderValueLabelUnstyled';
 
 export { default as useSlider } from './useSlider';
 export * from './useSlider';
-
 export * from './useSlider.types';
-
-export * from './SliderUnstyled.types';
 
 export { default as sliderUnstyledClasses } from './sliderUnstyledClasses';
 export * from './sliderUnstyledClasses';

--- a/packages/mui-material-next/src/Tab/Tab.d.ts
+++ b/packages/mui-material-next/src/Tab/Tab.d.ts
@@ -30,7 +30,6 @@ export type TabTypeMap<P = {}, D extends React.ElementType = 'div'> = ExtendButt
      * The icon to display.
      */
     icon?: string | React.ReactElement;
-
     /**
      * The position of the icon relative to the label.
      * @default 'top'

--- a/packages/mui-material/src/Slider/Slider.d.ts
+++ b/packages/mui-material/src/Slider/Slider.d.ts
@@ -3,6 +3,7 @@ import {
   ExtendSliderUnstyledTypeMap,
   ExtendSliderUnstyled,
   SliderUnstyledTypeMap,
+  SliderValueLabelProps,
 } from '@mui/base/SliderUnstyled';
 import { SxProps } from '@mui/system';
 import { OverridableStringUnion } from '@mui/types';
@@ -55,13 +56,14 @@ export type SliderTypeMap<
   defaultComponent: D;
 }>;
 
+export { SliderValueLabelProps } from '@mui/base/SliderUnstyled';
+
 type SliderRootProps = NonNullable<SliderTypeMap['props']['componentsProps']>['root'];
 type SliderMarkProps = NonNullable<SliderTypeMap['props']['componentsProps']>['mark'];
 type SliderMarkLabelProps = NonNullable<SliderTypeMap['props']['componentsProps']>['markLabel'];
 type SliderRailProps = NonNullable<SliderTypeMap['props']['componentsProps']>['rail'];
 type SliderTrackProps = NonNullable<SliderTypeMap['props']['componentsProps']>['track'];
 type SliderThumbProps = NonNullable<SliderTypeMap['props']['componentsProps']>['thumb'];
-type SliderValueLabelProps = NonNullable<SliderTypeMap['props']['componentsProps']>['valueLabel'];
 type SliderInputProps = NonNullable<SliderTypeMap['props']['componentsProps']>['input'];
 
 export const SliderRoot: React.FC<SliderRootProps>;

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -602,12 +602,14 @@ Slider.propTypes /* remove-proptypes */ = {
     thumb: PropTypes.object,
     track: PropTypes.object,
     valueLabel: PropTypes.shape({
+      children: PropTypes.element,
       className: PropTypes.string,
       components: PropTypes.shape({
         Root: PropTypes.elementType,
       }),
+      open: PropTypes.bool,
       style: PropTypes.object,
-      value: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.number), PropTypes.number]),
+      value: PropTypes.number,
       valueLabelDisplay: PropTypes.oneOf(['auto', 'off', 'on']),
     }),
   }),

--- a/packages/mui-material/src/Tab/Tab.d.ts
+++ b/packages/mui-material/src/Tab/Tab.d.ts
@@ -30,7 +30,6 @@ export type TabTypeMap<P = {}, D extends React.ElementType = 'div'> = ExtendButt
      * The icon to display.
      */
     icon?: string | React.ReactElement;
-
     /**
      * The position of the icon relative to the label.
      * @default 'top'


### PR DESCRIPTION
### Breaking changes

- [Slider] Fix SliderValueLabelProps type.
  The value label component props type is now correctly prefixed:

  ```diff
  -import { ValueLabelProps } from '@mui/base/SliderUnstyled';
  +import { SliderValueLabelProps } from '@mui/base/SliderUnstyled';
  ```

---

This seems really strange https://github.com/mui/mui-x/blob/814b72284d01b9653995b3e05539d88f8ee7cf81/packages/grid/x-data-grid-generator/src/renderer/renderEditProgress.tsx#L4-L5:

1. Why not import from @mui/material exclusively?
2. Why is the component prefix missing?

I solved these two points, and do a couple of cleanups.
