### PR TITLE
Fix an infinite loop within jss-to-tss-react

### DIFF
--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.js
@@ -1,5 +1,21 @@
 const ruleEndRegEx = /[^a-zA-Z0-9_]+/;
 
+function buildRuleRegex(ruleNames) {
+  if (!ruleNames.length) {
+    // Return a regex matching nothing - https://stackoverflow.com/a/940840/25507
+    return new RegExp('a^');
+  }
+  let ruleRegExString = '(';
+  ruleNames.forEach((ruleName, index) => {
+    if (index > 0) {
+      ruleRegExString += '|';
+    }
+    ruleRegExString += `\\$${ruleName}`;
+  });
+  ruleRegExString += ')';
+  return new RegExp(ruleRegExString, 'g');
+}
+
 function transformNestedKeys(j, comments, propValueNode, ruleRegEx, nestedKeys) {
   propValueNode.properties.forEach((prop) => {
     if (prop.value?.type === 'ObjectExpression') {
@@ -68,15 +84,7 @@ function transformStylesExpression(j, comments, stylesExpression, nestedKeys, se
         ruleNames.push(prop.key.name);
       }
     });
-    let ruleRegExString = '(';
-    ruleNames.forEach((ruleName, index) => {
-      if (index > 0) {
-        ruleRegExString += '|';
-      }
-      ruleRegExString += `\\$${ruleName}`;
-    });
-    ruleRegExString += ')';
-    const ruleRegEx = new RegExp(ruleRegExString, 'g');
+    const ruleRegEx = buildRuleRegex(ruleNames);
     objectExpression.properties.forEach((prop) => {
       if (prop.value) {
         if (prop.value.type !== 'ObjectExpression') {

--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test.js
@@ -148,6 +148,19 @@ describe('@mui/codemod', () => {
         const expected = read('./jss-to-tss-react.test/expected-withStyles.js');
         expect(actual).to.equal(expected, 'The transformed version should be correct');
       });
+      it('handles global-only styles', () => {
+        const actual = transform(
+          {
+            source: read('./jss-to-tss-react.test/actual-global.js'),
+            path: require.resolve('./jss-to-tss-react.test/actual-global.js'),
+          },
+          { jscodeshift },
+          {},
+        );
+
+        const expected = read('./jss-to-tss-react.test/expected-global.js');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
     });
   });
 });

--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/actual-global.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/actual-global.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core";
+
+const useStyles = makeStyles(() => ({
+  '@global': {
+    '.sample': {
+      backgroundColor: "purple",
+      color: "white",
+    }
+}}));
+
+export default function ComponentUsingStyles(props) {
+  useStyles();
+  return <div className="sample">Test</div>;
+}

--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/expected-global.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/expected-global.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { makeStyles } from 'tss-react/mui';
+
+const useStyles = makeStyles()(() => ({
+  '@global': {
+    '.sample': {
+      backgroundColor: "purple",
+      color: "white",
+    }
+}}));
+
+export default function ComponentUsingStyles(props) {
+  useStyles();
+  return <div className="sample">Test</div>;
+}


### PR DESCRIPTION
If a styles object had no usable rule names (for example, if everything was under a `@global` key), then the resulting rule regex was `/()/g`, and jscodeshift would loop forever. This PR fixes the infinite loop, although I haven't extensively investigated to verify whether it still applies appropriate transformations for styles like this.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
