### PR TITLE
Delete component in omitted TablePagination props

### DIFF
--- a/packages/mui-material-next/src/TablePagination/TablePagination.d.ts
+++ b/packages/mui-material-next/src/TablePagination/TablePagination.d.ts
@@ -163,7 +163,7 @@ declare const TablePagination: OverridableComponent<
   TablePaginationTypeMap<{}, React.JSXElementConstructor<TablePaginationBaseProps>>
 >;
 
-export type TablePaginationBaseProps = Omit<TableCellProps, 'classes' | 'component' | 'children'>;
+export type TablePaginationBaseProps = Omit<TableCellProps, 'classes' | 'children'>;
 
 export type TablePaginationProps<
   D extends React.ElementType = React.JSXElementConstructor<TablePaginationBaseProps>,


### PR DESCRIPTION
1. Without the `component ='div'` property, TablePagination component does not stretch to the full width of the table.
2. Instead of writing `component ='div'` each time we call TablePagination, we set it in our default ThemeOptions
3. The deleted code prevents us from adding `component` as a prop to our default ThemeOptions

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
