### PR TITLE
[slider] Don't modify the value array provided by the user

### DIFF
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -85,11 +85,6 @@ function roundValueToStep(value, step, min) {
 }
 
 function setValueIndex({ values, source, newValue, index }) {
-  // Performance shortcut
-  if (values[index] === newValue) {
-    return source;
-  }
-
   const output = values.slice();
   output[index] = newValue;
   return output;

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -385,8 +385,8 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const marks =
     marksProp === true && step !== null
       ? [...Array(Math.floor((max - min) / step) + 1)].map((_, index) => ({
-          value: min + step * index,
-        }))
+        value: min + step * index,
+      }))
       : marksProp || [];
 
   const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
@@ -503,7 +503,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
     axis += '-reverse';
   }
 
-  const getFingerNewValue = ({ finger, move = false, values: values2, source }) => {
+  const getFingerNewValue = ({ finger, move = false, values: values2 }) => {
     const { current: slider } = sliderRef;
     const { width, height, bottom, left } = slider.getBoundingClientRect();
     let percent;
@@ -562,7 +562,6 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       finger,
       move: true,
       values,
-      source: valueDerived,
     });
 
     focusThumb({ sliderRef, activeIndex, setActive });
@@ -580,7 +579,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       return;
     }
 
-    const { newValue } = getFingerNewValue({ finger, values, source: valueDerived });
+    const { newValue } = getFingerNewValue({ finger, values: valueDerived });
 
     setActive(-1);
     if (event.type === 'touchend') {
@@ -609,7 +608,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       touchId.current = touch.identifier;
     }
     const finger = trackFinger(event, touchId);
-    const { newValue, activeIndex } = getFingerNewValue({ finger, values, source: valueDerived });
+    const { newValue, activeIndex } = getFingerNewValue({ finger, values: valueDerived });
     focusThumb({ sliderRef, activeIndex, setActive });
 
     setValueState(newValue);
@@ -644,7 +643,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
 
     event.preventDefault();
     const finger = trackFinger(event, touchId);
-    const { newValue, activeIndex } = getFingerNewValue({ finger, values, source: valueDerived });
+    const { newValue, activeIndex } = getFingerNewValue({ finger, values: valueDerived });
     focusThumb({ sliderRef, activeIndex, setActive });
 
     setValueState(newValue);
@@ -877,14 +876,14 @@ Slider.propTypes = {
   /**
    * Callback function that is fired when the slider's value changed.
    *
-   * @param {object} event The event source of the callback.
+   * @param {object} event The even of the callback.
    * @param {number | number[]} value The new value.
    */
   onChange: PropTypes.func,
   /**
    * Callback function that is fired when the `mouseup` is triggered.
    *
-   * @param {object} event The event source of the callback.
+   * @param {object} event The even of the callback.
    * @param {number | number[]} value The new value.
    */
   onChangeCommitted: PropTypes.func,

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -16,7 +16,6 @@ import ValueLabel from './ValueLabel';
 function asc(a, b) {
   return a - b;
 }
-
 function clamp(value, min, max) {
   return Math.min(Math.max(min, value), max);
 }
@@ -385,8 +384,8 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const marks =
     marksProp === true && step !== null
       ? [...Array(Math.floor((max - min) / step) + 1)].map((_, index) => ({
-        value: min + step * index,
-      }))
+          value: min + step * index,
+        }))
       : marksProp || [];
 
   const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -578,7 +578,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       return;
     }
 
-    const { newValue } = getFingerNewValue({ finger, values: valueDerived });
+    const { newValue } = getFingerNewValue({ finger, values });
 
     setActive(-1);
     if (event.type === 'touchend') {
@@ -607,7 +607,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       touchId.current = touch.identifier;
     }
     const finger = trackFinger(event, touchId);
-    const { newValue, activeIndex } = getFingerNewValue({ finger, values: valueDerived });
+    const { newValue, activeIndex } = getFingerNewValue({ finger, values });
     focusThumb({ sliderRef, activeIndex, setActive });
 
     setValueState(newValue);

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -84,7 +84,7 @@ function roundValueToStep(value, step, min) {
   return Number(nearest.toFixed(getDecimalPrecision(step)));
 }
 
-function setValueIndex({ values, source, newValue, index }) {
+function setValueIndex({ values, newValue, index }) {
   const output = values.slice();
   output[index] = newValue;
   return output;
@@ -480,7 +480,6 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       const previousValue = newValue;
       newValue = setValueIndex({
         values,
-        source: valueDerived,
         newValue,
         index,
       }).sort(asc);
@@ -542,7 +541,6 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       const previousValue = newValue;
       newValue = setValueIndex({
         values: values2,
-        source,
         newValue,
         index: activeIndex,
       }).sort(asc);

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -384,8 +384,8 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const marks =
     marksProp === true && step !== null
       ? [...Array(Math.floor((max - min) / step) + 1)].map((_, index) => ({
-          value: min + step * index,
-        }))
+        value: min + step * index,
+      }))
       : marksProp || [];
 
   const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
@@ -875,14 +875,14 @@ Slider.propTypes = {
   /**
    * Callback function that is fired when the slider's value changed.
    *
-   * @param {object} event The even of the callback.
+   * @param {object} event The event source of the callback.
    * @param {number | number[]} value The new value.
    */
   onChange: PropTypes.func,
   /**
    * Callback function that is fired when the `mouseup` is triggered.
    *
-   * @param {object} event The even of the callback.
+   * @param {object} event The event source of the callback.
    * @param {number | number[]} value The new value.
    */
   onChangeCommitted: PropTypes.func,

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -384,8 +384,8 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const marks =
     marksProp === true && step !== null
       ? [...Array(Math.floor((max - min) / step) + 1)].map((_, index) => ({
-        value: min + step * index,
-      }))
+          value: min + step * index,
+        }))
       : marksProp || [];
 
   const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
@@ -642,7 +642,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
 
     event.preventDefault();
     const finger = trackFinger(event, touchId);
-    const { newValue, activeIndex } = getFingerNewValue({ finger, values: valueDerived });
+    const { newValue, activeIndex } = getFingerNewValue({ finger, values });
     focusThumb({ sliderRef, activeIndex, setActive });
 
     setValueState(newValue);

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -181,7 +181,7 @@ describe('<Slider />', () => {
       expect(handleChange.callCount).to.equal(3);
       expect(handleChange.args[0][1]).to.deep.equal([21, 30]);
       expect(handleChange.args[1][1]).to.deep.equal([22, 30]);
-      expect(handleChange.args[2][1]).to.equal(handleChange.args[1][1]);
+      expect(handleChange.args[2][1]).to.deep.equal(handleChange.args[1][1]);
     });
   });
 


### PR DESCRIPTION
See #33317 

The performance shortcut in `setValueIndex` would return the `source` array, which is the array passed in by the user of the `Slider` component.
Since the code calls:
```
newValue = setValueIndex(...).sort(asc);
```
returning the user-provided array in `setValueIndex` would call `sort` on that array, which might alter the user-provided array.

- When this is a read-only array, errors would be thrown
- But even if the array is not a read-only one, modifying the input provided by the user is just bad behavior

For the proposed fix, I removed the whole performance optimization step. The alternative would be to either

- Return `values`: the problem with this is that `values` is used throughout the rest of the `Slider` code, and I had no idea how calling that `sort` method on it would affect the rest of the `Slider`
- Return `values.slice()`: returning this would avoid the problem of potentially changing `values`, but now, the performance optimization becomes so small that you might as well remove it (which I did in this proposed change)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
