### PR TITLE
[autocomplete] hide browser default search input cancel button

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -181,6 +181,11 @@ const AutocompleteRoot = styled('div', {
     ...(ownerState.inputFocused && {
       opacity: 1,
     }),
+    ...(ownerState.hasClearIcon && {
+      '&::-webkit-search-cancel-button': {
+        WebkitAppearance: 'none',
+      },
+    }),
   },
 }));
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Problem

In the docs site, [the Autocomplete "search input" demo](https://mui.com/material-ui/react-autocomplete/#search-input) explicitly sets `disableClearable`. Without this, any consumer using an input with `type="search"` will see both the MUI "clear icon" - and the browser default cancel button: 

<img width="314" alt="Two clear buttons" src="https://user-images.githubusercontent.com/1750797/177414604-c3a0c8ff-55d5-40e6-937a-38ac7004c1c7.png">

Demo: https://codesandbox.io/s/freesolo-search-input-dual-clear-button-test-case-material-ui-8jjnr0?file=/demo.tsx:435-463

### Proposed Solution

Set the style for the `::-webkit-search-cancel-button` pseudo-element to `WebkitAppearance: none` when `ownerState.hasClearIcon` is true within the styled `AutocompleteRoot` component.

<img width="313" alt="No duplicate clear button" src="https://user-images.githubusercontent.com/1750797/177415367-07fff370-34d9-46d8-9379-62b3ce47cbdd.png">

> *I couldn't think of a good way to unit test this since JSDOM doesn't support `querySelector`'s second argument, but if there's another way you'd like this to be tested - I'm all ears.*