### PR TITLE
[chip] Assign classnames and associated styles for `filled` variant

### DIFF
--- a/docs/pages/material-ui/api/chip.json
+++ b/docs/pages/material-ui/api/chip.json
@@ -57,6 +57,8 @@
       "filled",
       "outlinedPrimary",
       "outlinedSecondary",
+      "filledPrimary",
+      "filledSecondary",
       "avatar",
       "avatarSmall",
       "avatarMedium",
@@ -77,6 +79,8 @@
       "deleteIconColorSecondary",
       "deleteIconOutlinedColorPrimary",
       "deleteIconOutlinedColorSecondary",
+      "deleteIconFilledColorPrimary",
+      "deleteIconFilledColorSecondary",
       "focusVisible"
     ],
     "globalClasses": { "disabled": "Mui-disabled", "focusVisible": "Mui-focusVisible" },

--- a/docs/translations/api-docs/chip/chip.json
+++ b/docs/translations/api-docs/chip/chip.json
@@ -93,6 +93,16 @@
       "nodeName": "the root element",
       "conditions": "<code>variant=\"outlined\"</code> and <code>color=\"secondary\"</code>"
     },
+    "filledPrimary": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"filled\"</code> and <code>color=\"primary\"</code>"
+    },
+    "filledSecondary": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"filled\"</code> and <code>color=\"secondary\"</code>"
+    },
     "avatar": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the avatar element"
@@ -185,6 +195,16 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the deleteIcon element",
       "conditions": "<code>color=\"secondary\"</code> and <code>variant=\"outlined\"</code>"
+    },
+    "deleteIconFilledColorPrimary": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the deleteIcon element",
+      "conditions": "<code>color=\"primary\"</code> and <code>variant=\"filled\"</code>"
+    },
+    "deleteIconFilledColorSecondary": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the deleteIcon element",
+      "conditions": "<code>color=\"secondary\"</code> and <code>variant=\"filled\"</code>"
     },
     "focusVisible": {
       "description": "State class applied to {{nodeName}} if {{conditions}}.",

--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -387,7 +387,6 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   };
 
   const clickable = clickableProp !== false && onClick ? true : clickableProp;
-  const small = size === 'small';
 
   const component = clickable || onDelete ? ButtonBase : ComponentProp || 'div';
 

--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -415,25 +415,14 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
 
   let deleteIcon = null;
   if (onDelete) {
-    const customClasses = clsx({
-      [classes.deleteIconSmall]: small,
-      [classes[`deleteIconColor${capitalize(color)}`]]:
-        color !== 'default' && variant !== 'outlined',
-      [classes[`deleteIconOutlinedColor${capitalize(color)}`]]:
-        color !== 'default' && variant === 'outlined',
-    });
-
     deleteIcon =
       deleteIconProp && React.isValidElement(deleteIconProp) ? (
         React.cloneElement(deleteIconProp, {
-          className: clsx(deleteIconProp.props.className, classes.deleteIcon, customClasses),
+          className: clsx(deleteIconProp.props.className, classes.deleteIcon),
           onClick: handleDeleteIconClick,
         })
       ) : (
-        <CancelIcon
-          className={clsx(classes.deleteIcon, customClasses)}
-          onClick={handleDeleteIconClick}
-        />
+        <CancelIcon className={clsx(classes.deleteIcon)} onClick={handleDeleteIconClick} />
       );
   }
 

--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -35,7 +35,7 @@ const useUtilityClasses = (ownerState) => {
       'deleteIcon',
       `deleteIcon${capitalize(size)}`,
       `deleteIconColor${capitalize(color)}`,
-      `deleteIconOutlinedColor${capitalize(color)}`,
+      `deleteIcon${capitalize(variant)}Color${capitalize(color)}`,
     ],
   };
 
@@ -59,7 +59,10 @@ const ChipRoot = styled('div', {
       { [`& .${chipClasses.deleteIcon}`]: styles.deleteIcon },
       { [`& .${chipClasses.deleteIcon}`]: styles[`deleteIcon${capitalize(size)}`] },
       { [`& .${chipClasses.deleteIcon}`]: styles[`deleteIconColor${capitalize(color)}`] },
-      { [`& .${chipClasses.deleteIcon}`]: styles[`deleteIconOutlinedColor${capitalize(color)}`] },
+      {
+        [`& .${chipClasses.deleteIcon}`]:
+          styles[`deleteIcon${capitalize(variant)}Color${capitalize(color)}`],
+      },
       styles.root,
       styles[`size${capitalize(size)}`],
       styles[`color${capitalize(color)}`],
@@ -68,7 +71,7 @@ const ChipRoot = styled('div', {
       onDelete && styles.deletable,
       onDelete && color !== 'default' && styles[`deletableColor${capitalize(color)}`],
       styles[variant],
-      variant === 'outlined' && styles[`outlined${capitalize(color)}`],
+      styles[`${variant}${capitalize(color)}`],
     ];
   },
 })(

--- a/packages/mui-material/src/Chip/Chip.test.js
+++ b/packages/mui-material/src/Chip/Chip.test.js
@@ -149,7 +149,7 @@ describe('<Chip />', () => {
       expect(chip).to.have.class(classes.outlinedPrimary);
     });
 
-    it('should render with the root and clickable secondary class', () => {
+    it('should render with the root and outlined clickable secondary class', () => {
       const { getByRole } = render(
         <Chip color="secondary" label="My Chip" onClick={() => {}} variant="outlined" />,
       );
@@ -159,6 +159,36 @@ describe('<Chip />', () => {
       expect(button).to.have.class(classes.colorSecondary);
       expect(button).to.have.class(classes.clickable);
       expect(button).to.have.class(classes.clickableColorSecondary);
+      expect(button).to.have.class(classes.outlined);
+      expect(button).to.have.class(classes.outlinedSecondary);
+    });
+
+    it('should render with the root and filled clickable primary class', () => {
+      const { getByRole } = render(
+        <Chip color="primary" label="My Chip" onClick={() => {}} variant="filled" />,
+      );
+
+      const chip = getByRole('button');
+      expect(chip).to.have.class(classes.root);
+      expect(chip).to.have.class(classes.colorPrimary);
+      expect(chip).to.have.class(classes.clickable);
+      expect(chip).to.have.class(classes.clickableColorPrimary);
+      expect(chip).to.have.class(classes.filled);
+      expect(chip).to.have.class(classes.filledPrimary);
+    });
+
+    it('should render with the root and filled clickable secondary class', () => {
+      const { getByRole } = render(
+        <Chip color="secondary" label="My Chip" onClick={() => {}} variant="filled" />,
+      );
+
+      const chip = getByRole('button');
+      expect(chip).to.have.class(classes.root);
+      expect(chip).to.have.class(classes.colorSecondary);
+      expect(chip).to.have.class(classes.clickable);
+      expect(chip).to.have.class(classes.clickableColorSecondary);
+      expect(chip).to.have.class(classes.filled);
+      expect(chip).to.have.class(classes.filledSecondary);
     });
   });
 
@@ -288,15 +318,15 @@ describe('<Chip />', () => {
 
   describe('prop: deleteIcon', () => {
     it('should render a default icon with the root, deletable and deleteIcon classes', () => {
-      const { container, getByRole, getByTestId } = render(
+      const { getByRole, getByTestId } = render(
         <Chip label="Custom delete icon Chip" onDelete={() => {}} />,
       );
 
-      const chip = container.querySelector(`.${classes.root}`);
-      expect(chip).to.have.class(classes.deletable);
-
+      const chip = getByRole('button');
       const icon = getByTestId('CancelIcon');
-      expect(getByRole('button')).to.contain(icon);
+
+      expect(chip).to.have.class(classes.deletable);
+      expect(chip).to.contain(icon);
       expect(icon).to.have.class(classes.deleteIcon);
     });
 

--- a/packages/mui-material/src/Chip/Chip.test.js
+++ b/packages/mui-material/src/Chip/Chip.test.js
@@ -358,6 +358,46 @@ describe('<Chip />', () => {
       expect(icon).to.have.class(classes.deleteIconColorSecondary);
     });
 
+    it('should render default icon with the root, deletable, deleteIcon primary class and deleteIcon filled primary class', () => {
+      const { container, getByTestId } = render(
+        <Chip
+          label="Custom delete icon Chip"
+          onDelete={() => {}}
+          color="primary"
+          variant="filled"
+        />,
+      );
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.colorPrimary);
+      expect(chip).to.have.class(classes.deletable);
+      expect(chip).to.have.class(classes.deletableColorPrimary);
+      const icon = getByTestId('CancelIcon');
+      expect(icon).to.have.class(classes.deleteIcon);
+      expect(icon).to.have.class(classes.deleteIconColorPrimary);
+      expect(icon).to.have.class(classes.deleteIconFilledColorPrimary);
+    });
+
+    it('should render default icon with the root, deletable, deleteIcon primary class and deleteIcon outlined primary class', () => {
+      const { container, getByTestId } = render(
+        <Chip
+          label="Custom delete icon Chip"
+          onDelete={() => {}}
+          color="primary"
+          variant="outlined"
+        />,
+      );
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.colorPrimary);
+      expect(chip).to.have.class(classes.deletable);
+      expect(chip).to.have.class(classes.deletableColorPrimary);
+      const icon = getByTestId('CancelIcon');
+      expect(icon).to.have.class(classes.deleteIcon);
+      expect(icon).to.have.class(classes.deleteIconColorPrimary);
+      expect(icon).to.have.class(classes.deleteIconOutlinedColorPrimary);
+    });
+
     it('accepts a custom icon', () => {
       const handleDelete = spy();
       const { getByTestId } = render(

--- a/packages/mui-material/src/Chip/Chip.test.js
+++ b/packages/mui-material/src/Chip/Chip.test.js
@@ -287,20 +287,13 @@ describe('<Chip />', () => {
   });
 
   describe('prop: deleteIcon', () => {
-    it('should render a default icon with the root, deletable, deleteIcon and deleteIconOutlinedColorSecondary classes', () => {
-      const { getByRole, getByTestId } = render(
-        <Chip label="Custom delete icon Chip" onDelete={() => {}} />,
-      );
-
-      const icon = getByTestId('CancelIcon');
-      expect(getByRole('button')).to.contain(icon);
-      expect(icon).to.have.class(classes.deleteIcon);
-    });
-
     it('should render a default icon with the root, deletable and deleteIcon classes', () => {
-      const { getByRole, getByTestId } = render(
+      const { container, getByRole, getByTestId } = render(
         <Chip label="Custom delete icon Chip" onDelete={() => {}} />,
       );
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.deletable);
 
       const icon = getByTestId('CancelIcon');
       expect(getByRole('button')).to.contain(icon);

--- a/packages/mui-material/src/Chip/chipClasses.ts
+++ b/packages/mui-material/src/Chip/chipClasses.ts
@@ -33,6 +33,10 @@ export interface ChipClasses {
   outlinedPrimary: string;
   /** Styles applied to the root element if `variant="outlined"` and `color="secondary"`. */
   outlinedSecondary: string;
+  /** Styles applied to the root element if `variant="filled"` and `color="primary"`. */
+  filledPrimary: string;
+  /** Styles applied to the root element if `variant="filled"` and `color="secondary"`. */
+  filledSecondary: string;
   /** Styles applied to the avatar element. */
   avatar: string;
   /** Styles applied to the avatar element if `size="small"`. */
@@ -73,6 +77,10 @@ export interface ChipClasses {
   deleteIconOutlinedColorPrimary: string;
   /** Styles applied to the deleteIcon element if `color="secondary"` and `variant="outlined"`. */
   deleteIconOutlinedColorSecondary: string;
+  /** Styles applied to the deleteIcon element if `color="primary"` and `variant="filled"`. */
+  deleteIconFilledColorPrimary: string;
+  /** Styles applied to the deleteIcon element if `color="secondary"` and `variant="filled"`. */
+  deleteIconFilledColorSecondary: string;
   /** State class applied to the root element if keyboard focused. */
   focusVisible: string;
 }
@@ -100,6 +108,8 @@ const chipClasses: ChipClasses = generateUtilityClasses('MuiChip', [
   'filled',
   'outlinedPrimary',
   'outlinedSecondary',
+  'filledPrimary',
+  'filledSecondary',
   'avatar',
   'avatarSmall',
   'avatarMedium',
@@ -120,6 +130,8 @@ const chipClasses: ChipClasses = generateUtilityClasses('MuiChip', [
   'deleteIconColorSecondary',
   'deleteIconOutlinedColorPrimary',
   'deleteIconOutlinedColorSecondary',
+  'deleteIconFilledColorPrimary',
+  'deleteIconFilledColorSecondary',
   'focusVisible',
 ]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/33568

**Problem**:
- (1) Classnames `deleteIconOutlinedColorPrimary` / `deleteIconOutlinedColorSecondary` get assigned to not only `outlined` variant but other variants too
- (2) Classnames `outlinedPrimary` / `outlinedSecondary` exist for `outlined` variant, but not for `filled` variant. Hence, assigning styles to `styleOverrides` by targeting `filledPrimary` or `filledSecondary` doesn't work.

**Solution**:
- (1) Create Classnames `deleteIconFilledColorPrimary` / `deleteIconFilledColorSecondary` / `filledPrimary` / `filledSecondary`.
- (2) Make sure that correct classnames assigned to correct combination of props.

**Codesandboxes**:
For Problem (1)
- [Before](https://codesandbox.io/s/material-ui-forked-cyi5gl)
- [After](https://codesandbox.io/s/material-ui-forked-xtwh8o)

For Problem (2)
- [Before](https://codesandbox.io/s/material-ui-forked-7tsre3)
- [After](https://codesandbox.io/s/material-ui-forked-4twk08)