### PR TITLE
[autocomplete] prevent highlight index from resetting when options are added

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -61,6 +61,14 @@ function findIndex(array, comp) {
   return -1;
 }
 
+function usePrevious(value) {
+  const ref = React.useRef(null);
+  React.useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+}
+
 const defaultFilterOptions = createFilterOptions();
 
 // Number of options to jump in list box when pageup and pagedown keys are used.
@@ -235,6 +243,8 @@ export default function useAutocomplete(props) {
         },
       )
     : [];
+
+  const prevFilteredOptionsLength = usePrevious(filteredOptions.length);
 
   const listboxAvailable = open && filteredOptions.length > 0 && !readOnly;
 
@@ -455,8 +465,18 @@ export default function useAutocomplete(props) {
 
     const valueItem = multiple ? value[0] : value;
 
-    // The popup is empty, reset
-    if (filteredOptions.length === 0 || valueItem == null) {
+    if (valueItem == null) {
+      const prevNoResults = prevFilteredOptionsLength === 0 && filteredOptions.length > 0;
+      if (filteredOptions.length === 0 || prevFilteredOptionsLength === null || prevNoResults) {
+        changeHighlightedIndex({ diff: 'reset' });
+        return;
+      }
+
+      const resultsAdded = filteredOptions.length > prevFilteredOptionsLength;
+      if (resultsAdded) {
+        return;
+      }
+
       changeHighlightedIndex({ diff: 'reset' });
       return;
     }

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1517,9 +1517,9 @@ describe('<Autocomplete />', () => {
 
       checkHighlightIs(listbox, 'two');
 
-      // three option is added and autocomplete re-renders, reset the highlight
+      // three option is added and autocomplete re-renders, do not reset the highlight
       setProps({ options: ['one', 'two', 'three'] });
-      checkHighlightIs(listbox, null);
+      checkHighlightIs(listbox, 'two');
     });
 
     it('should not select undefined', () => {


### PR DESCRIPTION
fix #29508

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
