### PR TITLE
[autocomplete] / Types - Move 'defaultValue' definition below 'multiple'  - useAutocomplete.d.ts

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.d.ts
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.d.ts
@@ -88,11 +88,6 @@ export interface UseAutocompleteProps<
    */
   componentName?: string;
   /**
-   * The default value. Use when the component is not controlled.
-   * @default props.multiple ? [] : null
-   */
-  defaultValue?: AutocompleteValue<T, Multiple, DisableClearable, FreeSolo>;
-  /**
    * If `true`, the input can't be cleared.
    * @default false
    */
@@ -197,6 +192,11 @@ export interface UseAutocompleteProps<
    * @default false
    */
   multiple?: Multiple;
+  /**
+   * The default value. Use when the component is not controlled.
+   * @default props.multiple ? [] : null
+   */
+  defaultValue?: AutocompleteValue<T, Multiple, DisableClearable, FreeSolo>;
   /**
    * Callback fired when the value changes.
    *


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## **Description:**
### Fix: 
Reordered the `defaultValue` prop in `packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.d.ts`, to be below `multiple`, which its definition depends on (ternary).

In #33269, the props in `useAutocomplete.d.ts` were re-ordered alphabetically. The definition of `defaultValues` is:
```
/**
   * The default value. Use when the component is not controlled.
   * @default props.multiple ? [] : null
   */
  defaultValue?: AutocompleteValue<T, Multiple, DisableClearable, FreeSolo>;
```

As the definition now appears above the definition of `multiple`, an extra `[]` is added to the definition and TypeScript errors are encountered:

![2022-08-05 12 30 31](https://user-images.githubusercontent.com/49581958/182989015-f4663662-54e4-43ea-900b-da88b4a077e1.png)

Moving the `defaultValues` definition below `multiple` resolves this issue.

First PR, apologies if anything isn't quite right. Thanks in advance.