### PR TITLE
[autocomplete] Fix text be covered by clear button

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -149,6 +149,12 @@ const AutocompleteRoot = styled('div', {
       padding: '2.5px 4px 2.5px 6px',
     },
   },
+  [`& .${filledInputClasses.root}.${inputBaseClasses.sizeSmall}`]: {
+    paddingBottom: 1,
+    [`& .${filledInputClasses.input}`]: {
+      padding: '2.5px 4px',
+    },
+  },
   [`& .${filledInputClasses.root}`]: {
     paddingTop: 19,
     paddingLeft: 8,
@@ -163,12 +169,6 @@ const AutocompleteRoot = styled('div', {
     },
     [`& .${autocompleteClasses.endAdornment}`]: {
       right: 9,
-    },
-  },
-  [`& .${filledInputClasses.root}.${inputBaseClasses.sizeSmall}`]: {
-    paddingBottom: 1,
-    [`& .${filledInputClasses.input}`]: {
-      padding: '2.5px 4px',
     },
   },
   [`& .${inputBaseClasses.hiddenLabel}`]: {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -128,6 +128,12 @@ const AutocompleteRoot = styled('div', {
       padding: '2px 4px 3px 0',
     },
   },
+  [`& .${outlinedInputClasses.root}.${inputBaseClasses.sizeSmall}`]: {
+    padding: 6,
+    [`& .${autocompleteClasses.input}`]: {
+      padding: '2.5px 4px 2.5px 6px',
+    },
+  },
   [`& .${outlinedInputClasses.root}`]: {
     padding: 9,
     [`.${autocompleteClasses.hasPopupIcon}&, .${autocompleteClasses.hasClearIcon}&`]: {
@@ -141,18 +147,6 @@ const AutocompleteRoot = styled('div', {
     },
     [`& .${autocompleteClasses.endAdornment}`]: {
       right: 9,
-    },
-  },
-  [`& .${outlinedInputClasses.root}.${inputBaseClasses.sizeSmall}`]: {
-    padding: 6,
-    [`& .${autocompleteClasses.input}`]: {
-      padding: '2.5px 4px 2.5px 6px',
-    },
-  },
-  [`& .${filledInputClasses.root}.${inputBaseClasses.sizeSmall}`]: {
-    paddingBottom: 1,
-    [`& .${filledInputClasses.input}`]: {
-      padding: '2.5px 4px',
     },
   },
   [`& .${filledInputClasses.root}`]: {
@@ -169,6 +163,12 @@ const AutocompleteRoot = styled('div', {
     },
     [`& .${autocompleteClasses.endAdornment}`]: {
       right: 9,
+    },
+  },
+  [`& .${filledInputClasses.root}.${inputBaseClasses.sizeSmall}`]: {
+    paddingBottom: 1,
+    [`& .${filledInputClasses.input}`]: {
+      padding: '2.5px 4px',
     },
   },
   [`& .${inputBaseClasses.hiddenLabel}`]: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #34051 

The text will be covered by the clear button when using small TextField

Just changing the position of the CSS related to the small TextField can solve this issue.