### PR TITLE
[autocomplete] Update unstyled demo to not import Material UI

### DIFF
--- a/docs/data/material/components/autocomplete/UseAutocomplete.js
+++ b/docs/data/material/components/autocomplete/UseAutocomplete.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useAutocomplete } from '@mui/base/AutocompleteUnstyled';
-import { styled } from '@mui/material/styles';
-import { autocompleteClasses } from '@mui/material/Autocomplete';
+import { styled } from '@mui/system';
 
 const Label = styled('label')({
   display: 'block',
@@ -9,8 +8,8 @@ const Label = styled('label')({
 
 const Input = styled('input')(({ theme }) => ({
   width: 200,
-  backgroundColor: theme.palette.background.paper,
-  color: theme.palette.getContrastText(theme.palette.background.paper),
+  backgroundColor: theme.palette.mode === 'light' ? '#fff' : '#000',
+  color: theme.palette.mode === 'light' ? '#000' : '#fff',
 }));
 
 const Listbox = styled('ul')(({ theme }) => ({
@@ -20,11 +19,11 @@ const Listbox = styled('ul')(({ theme }) => ({
   zIndex: 1,
   position: 'absolute',
   listStyle: 'none',
-  backgroundColor: theme.palette.background.paper,
+  backgroundColor: theme.palette.mode === 'light' ? '#fff' : '#000',
   overflow: 'auto',
   maxHeight: 200,
   border: '1px solid rgba(0,0,0,.25)',
-  [`& li.${autocompleteClasses.focused}`]: {
+  '& li.Mui-focused': {
     backgroundColor: '#4a8df6',
     color: 'white',
     cursor: 'pointer',

--- a/docs/data/material/components/autocomplete/UseAutocomplete.tsx
+++ b/docs/data/material/components/autocomplete/UseAutocomplete.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useAutocomplete } from '@mui/base/AutocompleteUnstyled';
-import { styled } from '@mui/material/styles';
-import { autocompleteClasses } from '@mui/material/Autocomplete';
+import { styled } from '@mui/system';
 
 const Label = styled('label')({
   display: 'block',
@@ -9,8 +8,8 @@ const Label = styled('label')({
 
 const Input = styled('input')(({ theme }) => ({
   width: 200,
-  backgroundColor: theme.palette.background.paper,
-  color: theme.palette.getContrastText(theme.palette.background.paper),
+  backgroundColor: theme.palette.mode === 'light' ? '#fff' : '#000',
+  color: theme.palette.mode === 'light' ? '#000' : '#fff',
 }));
 
 const Listbox = styled('ul')(({ theme }) => ({
@@ -20,11 +19,11 @@ const Listbox = styled('ul')(({ theme }) => ({
   zIndex: 1,
   position: 'absolute',
   listStyle: 'none',
-  backgroundColor: theme.palette.background.paper,
+  backgroundColor: theme.palette.mode === 'light' ? '#fff' : '#000',
   overflow: 'auto',
   maxHeight: 200,
   border: '1px solid rgba(0,0,0,.25)',
-  [`& li.${autocompleteClasses.focused}`]: {
+  '& li.Mui-focused': {
     backgroundColor: '#4a8df6',
     color: 'white',
     cursor: 'pointer',


### PR DESCRIPTION
Make the demo truly unstyled. Any use of `@mui/material` is a red flag IMHO. I was inspired to work on this (quick-win) while I was looking into https://deploy-preview-5504--material-ui-x.netlify.app/x/react-date-pickers/date-field/#headless-usage

**Before**

<img width="755" alt="Screenshot 2022-08-25 at 15 15 23" src="https://user-images.githubusercontent.com/3165635/186674747-e5043d94-7f64-4732-ad39-b726da6367c2.png">

https://mui.com/material-ui/react-autocomplete/#useautocomplete

**After**

<img width="750" alt="Screenshot 2022-08-25 at 15 14 59" src="https://user-images.githubusercontent.com/3165635/186674662-8315bf39-479b-432b-82b8-7500b0e474cb.png">

https://deploy-preview-34060--material-ui.netlify.app/material-ui/react-autocomplete/#useautocomplete