### PR TITLE
[slider] Only call onChange if the value changed

### DIFF
--- a/packages/mui-base/src/SliderUnstyled/useSlider.ts
+++ b/packages/mui-base/src/SliderUnstyled/useSlider.ts
@@ -364,11 +364,9 @@ export default function useSlider(parameters: UseSliderParameters) {
   const getFingerNewValue = ({
     finger,
     move = false,
-    values: values2,
   }: {
     finger: { x: number; y: number };
     move?: boolean;
-    values: number[];
   }) => {
     const { current: slider } = sliderRef;
     const { width, height, bottom, left } = slider!.getBoundingClientRect();
@@ -398,7 +396,7 @@ export default function useSlider(parameters: UseSliderParameters) {
 
     if (range) {
       if (!move) {
-        activeIndex = findClosest(values2, newValue)!;
+        activeIndex = findClosest(values, newValue)!;
       } else {
         activeIndex = previousIndex.current!;
       }
@@ -407,14 +405,14 @@ export default function useSlider(parameters: UseSliderParameters) {
       if (disableSwap) {
         newValue = clamp(
           newValue,
-          values2[activeIndex - 1] || -Infinity,
-          values2[activeIndex + 1] || Infinity,
+          values[activeIndex - 1] || -Infinity,
+          values[activeIndex + 1] || Infinity,
         );
       }
 
       const previousValue = newValue;
       newValue = setValueIndex({
-        values: values2,
+        values,
         newValue,
         index: activeIndex,
       });
@@ -449,7 +447,6 @@ export default function useSlider(parameters: UseSliderParameters) {
     const { newValue, activeIndex } = getFingerNewValue({
       finger,
       move: true,
-      values,
     });
 
     focusThumb({ sliderRef, activeIndex, setActive });
@@ -459,7 +456,7 @@ export default function useSlider(parameters: UseSliderParameters) {
       setDragging(true);
     }
 
-    if (handleChange) {
+    if (handleChange && newValue !== valueDerived) {
       handleChange(nativeEvent, newValue, activeIndex);
     }
   });
@@ -472,7 +469,7 @@ export default function useSlider(parameters: UseSliderParameters) {
       return;
     }
 
-    const { newValue } = getFingerNewValue({ finger, move: true, values });
+    const { newValue } = getFingerNewValue({ finger, move: true });
 
     setActive(-1);
     if (nativeEvent.type === 'touchend') {
@@ -505,7 +502,7 @@ export default function useSlider(parameters: UseSliderParameters) {
     }
     const finger = trackFinger(nativeEvent, touchId);
     if (finger !== false) {
-      const { newValue, activeIndex } = getFingerNewValue({ finger, values });
+      const { newValue, activeIndex } = getFingerNewValue({ finger });
       focusThumb({ sliderRef, activeIndex, setActive });
 
       setValueState(newValue);
@@ -572,7 +569,7 @@ export default function useSlider(parameters: UseSliderParameters) {
       event.preventDefault();
       const finger = trackFinger(event, touchId);
       if (finger !== false) {
-        const { newValue, activeIndex } = getFingerNewValue({ finger, values });
+        const { newValue, activeIndex } = getFingerNewValue({ finger });
         focusThumb({ sliderRef, activeIndex, setActive });
 
         setValueState(newValue);

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -293,6 +293,7 @@ describe('<Slider />', () => {
       expect(handleChange.callCount).to.equal(3);
       expect(handleChange.args[0][1]).to.deep.equal([21, 30]);
       expect(handleChange.args[1][1]).to.deep.equal([22, 30]);
+      // TODO, consider not firing this change event since the values are the same to improve the DX.
       expect(handleChange.args[2][1]).to.deep.equal([22, 30]);
     });
 

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -81,24 +81,30 @@ describe('<Slider />', () => {
     const { container } = render(
       <Slider onChange={handleChange} onChangeCommitted={handleChangeCommitted} value={0} />,
     );
+    stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
+      width: 100,
+      height: 10,
+      bottom: 10,
+      left: 0,
+    }));
 
-    fireEvent.touchStart(container.firstChild, createTouches([{ identifier: 1 }]));
+    fireEvent.touchStart(container.firstChild, createTouches([{ identifier: 1, clientX: 0 }]));
     expect(handleChange.callCount).to.equal(1);
     expect(handleChangeCommitted.callCount).to.equal(0);
 
-    fireEvent.touchEnd(document.body, createTouches([{ identifier: 2 }]));
+    fireEvent.touchStart(document.body, createTouches([{ identifier: 2, clientX: 40 }]));
     expect(handleChange.callCount).to.equal(1);
     expect(handleChangeCommitted.callCount).to.equal(0);
 
-    fireEvent.touchMove(document.body, createTouches([{ identifier: 1 }]));
+    fireEvent.touchMove(document.body, createTouches([{ identifier: 1, clientX: 1 }]));
     expect(handleChange.callCount).to.equal(2);
     expect(handleChangeCommitted.callCount).to.equal(0);
 
-    fireEvent.touchMove(document.body, createTouches([{ identifier: 2 }]));
+    fireEvent.touchMove(document.body, createTouches([{ identifier: 2, clientX: 41 }]));
     expect(handleChange.callCount).to.equal(2);
     expect(handleChangeCommitted.callCount).to.equal(0);
 
-    fireEvent.touchEnd(document.body, createTouches([{ identifier: 1 }]));
+    fireEvent.touchEnd(document.body, createTouches([{ identifier: 1, clientX: 2 }]));
     expect(handleChange.callCount).to.equal(2);
     expect(handleChangeCommitted.callCount).to.equal(1);
   });
@@ -131,6 +137,34 @@ describe('<Slider />', () => {
     });
     // The mouse's button was released, stop the dragging session.
     expect(handleChange.callCount).to.equal(2);
+  });
+
+  it('should only fire onChange when the value changes', () => {
+    const handleChange = spy();
+    const { container } = render(<Slider defaultValue={20} onChange={handleChange} />);
+    stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
+      width: 100,
+      left: 0,
+    }));
+
+    fireEvent.mouseDown(container.firstChild, {
+      buttons: 1,
+      clientX: 21,
+    });
+
+    fireEvent.mouseMove(document.body, {
+      buttons: 1,
+      clientX: 22,
+    });
+    // Sometimes another event with the same position is fired by the browser.
+    fireEvent.mouseMove(document.body, {
+      buttons: 1,
+      clientX: 22,
+    });
+
+    expect(handleChange.callCount).to.equal(2);
+    expect(handleChange.args[0][1]).to.deep.equal(21);
+    expect(handleChange.args[1][1]).to.deep.equal(22);
   });
 
   describe('prop: orientation', () => {
@@ -232,7 +266,7 @@ describe('<Slider />', () => {
       expect(slider).toHaveFocus();
     });
 
-    it('should support mouse events', () => {
+    it('should support touch events', () => {
       const handleChange = spy();
       const { container } = render(<Slider defaultValue={[20, 30]} onChange={handleChange} />);
       stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
@@ -253,13 +287,13 @@ describe('<Slider />', () => {
       );
       fireEvent.touchMove(
         document.body,
-        createTouches([{ identifier: 1, clientX: 22, clientY: 0 }]),
+        createTouches([{ identifier: 1, clientX: 22.1, clientY: 0 }]),
       );
 
       expect(handleChange.callCount).to.equal(3);
       expect(handleChange.args[0][1]).to.deep.equal([21, 30]);
       expect(handleChange.args[1][1]).to.deep.equal([22, 30]);
-      expect(handleChange.args[2][1]).not.to.equal(handleChange.args[1][1]);
+      expect(handleChange.args[2][1]).to.deep.equal([22, 30]);
     });
 
     it('should not react to right clicks', () => {


### PR DESCRIPTION
This is a continuation of #28472. The goal is to not fire onChange unless the value did change, this reduces surprises for developers. You can see the regression test for how to reproduce the issue (`git checkout master packages/mui-base/src/SliderUnstyled/useSlider.ts && yarn t Slider`). This is a behavior that the other components are following, for example, a select won't fire onChange if an end-user selects the value that is already selected.

I didn't bring this improvement to the range slider because pulling it off wouldn't be as simple, We would need to compare an array of number deep, it would add a bit of bundle/runtime overhead for end-users that I'm not sure is worth the DX win yet.