### PR TITLE
[slider] Fix unnecessary accessibility attribute in root element

### DIFF
--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.js
@@ -46,6 +46,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
   const {
     'aria-label': ariaLabel,
     'aria-valuetext': ariaValuetext,
+    'aria-labelledby': ariaLabelledby,
     className,
     component,
     classes: classesProp,
@@ -282,6 +283,7 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled(props, ref) {
                   data-index={index}
                   aria-label={getAriaLabel ? getAriaLabel(index) : ariaLabel}
                   aria-valuenow={scale(value)}
+                  aria-labelledby={ariaLabelledby}
                   aria-valuetext={
                     getAriaValueText ? getAriaValueText(scale(value), index) : ariaValuetext
                   }

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.test.js
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.test.js
@@ -282,4 +282,47 @@ describe('<SliderUnstyled />', () => {
       expect(container.querySelectorAll(`.${classes.markLabel}`)[1].textContent).to.equal('100');
     });
   });
+
+  describe('ARIA', () => {
+    it('should have the correct aria attributes', () => {
+      const { getByRole, container } = render(
+        <SliderUnstyled
+          value={50}
+          valueLabelDisplay="auto"
+          marks={[
+            {
+              value: 0,
+              label: 0,
+            },
+            {
+              value: 50,
+              label: 50,
+            },
+            {
+              value: 100,
+              label: 100,
+            },
+          ]}
+          aria-label="a slider"
+          aria-labelledby="a slider label"
+        />,
+      );
+
+      const sliderWrapperElement = container.firstChild;
+      const slider = getByRole('slider');
+      const markLabels = container.querySelectorAll(`.${classes.markLabel}`);
+      const input = container.querySelector('input');
+      expect(slider).to.have.attribute('aria-valuemin', '0');
+      expect(slider).to.have.attribute('aria-valuemax', '100');
+      expect(slider).to.have.attribute('aria-valuenow', '50');
+      expect(slider).to.have.attribute('aria-labelledby');
+
+      expect(markLabels[0]).to.have.attribute('aria-hidden', 'true');
+
+      expect(sliderWrapperElement).not.to.have.attribute('aria-labelledby');
+      expect(input).to.have.attribute('aria-labelledby', 'a slider label');
+      expect(input).to.have.attribute('aria-label', 'a slider');
+      expect(input).to.have.attribute('aria-valuenow', '50');
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR fixes #34604 bug with a happy-path test
