### PR TITLE
[alert] Update icon color in all variants

### DIFF
--- a/packages/mui-material/src/Alert/Alert.js
+++ b/packages/mui-material/src/Alert/Alert.js
@@ -61,10 +61,7 @@ const AlertRoot = styled(Paper, {
         [`& .${alertClasses.icon}`]: theme.vars
           ? { color: theme.vars.palette.Alert[`${color}IconColor`] }
           : {
-              color:
-                theme.palette.mode === 'dark'
-                  ? theme.palette[color].main
-                  : theme.palette[color].light,
+              color: theme.palette[color].main,
             },
       }),
     ...(color &&
@@ -76,10 +73,7 @@ const AlertRoot = styled(Paper, {
         [`& .${alertClasses.icon}`]: theme.vars
           ? { color: theme.vars.palette.Alert[`${color}IconColor`] }
           : {
-              color:
-                theme.palette.mode === 'dark'
-                  ? theme.palette[color].main
-                  : theme.palette[color].light,
+              color: theme.palette[color].main,
             },
       }),
     ...(color &&
@@ -95,11 +89,7 @@ const AlertRoot = styled(Paper, {
                 theme.palette.mode === 'dark'
                   ? theme.palette[color].dark
                   : theme.palette[color].main,
-              color: theme.palette.getContrastText(
-                theme.palette.mode === 'dark'
-                  ? theme.palette[color].dark
-                  : theme.palette[color].main,
-              ),
+              color: theme.palette.getContrastText(theme.palette[color].main),
             }),
       }),
   };

--- a/packages/mui-material/src/styles/experimental_extendTheme.js
+++ b/packages/mui-material/src/styles/experimental_extendTheme.js
@@ -153,10 +153,10 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.Alert, 'infoStandardBg', safeLighten(palette.info.light, 0.9));
       setColor(palette.Alert, 'successStandardBg', safeLighten(palette.success.light, 0.9));
       setColor(palette.Alert, 'warningStandardBg', safeLighten(palette.warning.light, 0.9));
-      setColor(palette.Alert, 'errorIconColor', getCssVar('palette-error-light'));
-      setColor(palette.Alert, 'infoIconColor', getCssVar('palette-info-light'));
-      setColor(palette.Alert, 'successIconColor', getCssVar('palette-success-light'));
-      setColor(palette.Alert, 'warningIconColor', getCssVar('palette-warning-light'));
+      setColor(palette.Alert, 'errorIconColor', getCssVar('palette-error-main'));
+      setColor(palette.Alert, 'infoIconColor', getCssVar('palette-info-main'));
+      setColor(palette.Alert, 'successIconColor', getCssVar('palette-success-main'));
+      setColor(palette.Alert, 'warningIconColor', getCssVar('palette-warning-main'));
       setColor(palette.AppBar, 'defaultBg', getCssVar('palette-grey-100'));
       setColor(palette.Avatar, 'defaultBg', getCssVar('palette-grey-400'));
       setColor(palette.Chip, 'defaultBorder', getCssVar('palette-grey-400'));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR makes the icon color within the Alerts use the main palette value. It not only looks better and more aligned with the title text color but it also now stays in parity with the Alerts on the Design Kits. Closes https://github.com/mui/material-ui/issues/35401
