### PR TITLE
[internal] Fix leaking theme color override

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -105,7 +105,7 @@ function AppLayoutDocs(props) {
         styles={{
           ':root': {
             '--MuiDocs-navDrawer-width': '300px',
-            '--MuiDocs-toc-width': '240px',
+            '--MuiDocs-toc-width': '242px',
           },
         }}
       />

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -14,7 +14,8 @@ import TableOfContentsBanner from 'docs/src/components/banner/TableOfContentsBan
 const Nav = styled('nav')(({ theme }) => ({
   top: 0,
   order: 1,
-  width: 240,
+  width: 'var(--MuiDocs-toc-width)',
+  paddingLeft: 2, // Fix truncated focus outline style
   flexShrink: 0,
   position: 'sticky',
   height: '100vh',


### PR DESCRIPTION
The `overflow: auto` leads to a truncated focus outline (I use <kbd>Tab</kbd> from time to time when I'm too lazy to move the cursor to navigate):

<img width="230" alt="Screenshot 2022-12-11 at 12 45 06" src="https://user-images.githubusercontent.com/3165635/206901718-fcca68e4-bc8e-4ac4-b39b-f9a2ff3dd3bf.png">

After:

<img width="221" alt="Screenshot 2022-12-11 at 12 46 56" src="https://user-images.githubusercontent.com/3165635/206901748-546aab5d-5730-4920-9424-664554272e80.png">

https://deploy-preview-35444--material-ui.netlify.app/material-ui/getting-started/overview/