### PR TITLE
[chip] Fix hover and focus style with CSS Variables

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -180,9 +180,7 @@ const ChipRoot = styled('div', {
       ...(ownerState.onDelete && {
         [`&.${chipClasses.focusVisible}`]: {
           backgroundColor: theme.vars
-            ? `rgba(${theme.vars.palette.action.selectedChannel} / calc(${
-                theme.vars.palette.action.selectedOpacity + theme.vars.palette.action.focusOpacity
-              }))`
+            ? `rgba(${theme.vars.palette.action.selectedChannel} / calc(${theme.vars.palette.action.selectedOpacity} + ${theme.vars.palette.action.focusOpacity}))`
             : alpha(
                 theme.palette.action.selected,
                 theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
@@ -204,9 +202,7 @@ const ChipRoot = styled('div', {
       cursor: 'pointer',
       '&:hover': {
         backgroundColor: theme.vars
-          ? `rgba(${theme.vars.palette.action.selectedChannel} / calc(${
-              theme.vars.palette.action.selectedOpacity + theme.vars.palette.action.hoverOpacity
-            }))`
+          ? `rgba(${theme.vars.palette.action.selectedChannel} / calc(${theme.vars.palette.action.selectedOpacity} + ${theme.vars.palette.action.hoverOpacity}))`
           : alpha(
               theme.palette.action.selected,
               theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
@@ -214,9 +210,7 @@ const ChipRoot = styled('div', {
       },
       [`&.${chipClasses.focusVisible}`]: {
         backgroundColor: theme.vars
-          ? `rgba(${theme.vars.palette.action.selectedChannel} / calc(${
-              theme.vars.palette.action.selectedOpacity + theme.vars.palette.action.focusOpacity
-            }))`
+          ? `rgba(${theme.vars.palette.action.selectedChannel} / calc(${theme.vars.palette.action.selectedOpacity} + ${theme.vars.palette.action.focusOpacity}))`
           : alpha(
               theme.palette.action.selected,
               theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,


### PR DESCRIPTION
This PR fixes the chip hover and focus styles when using the CSSVarsProvider.

There were some missing braces which caused calc not to work and resulted in way lower numbers. This should align the behavior between css vars and regular themes

Before: https://codesandbox.io/s/elegant-sound-v0os54?file=/src/App.tsx:0-2257

After: https://codesandbox.io/s/create-react-app-with-typescript-forked-556ttt?file=/src/App.tsx