### PR TITLE
[autocomplete] Correct padding of filled Autocomplete

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -181,7 +181,6 @@ const AutocompleteRoot = styled('div', {
   [`& .${filledInputClasses.root}.${inputBaseClasses.hiddenLabel}`]: {
     paddingTop: 0,
     paddingBottom: 0,
-
     [`& .${autocompleteClasses.input}`]: {
       paddingTop: 16,
       paddingBottom: 17,

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -178,6 +178,21 @@ const AutocompleteRoot = styled('div', {
   [`& .${inputBaseClasses.hiddenLabel}`]: {
     paddingTop: 8,
   },
+  [`& .${filledInputClasses.root}.${inputBaseClasses.hiddenLabel}`]: {
+    paddingTop: 0,
+    paddingBottom: 0,
+
+    [`& .${autocompleteClasses.input}`]: {
+      paddingTop: 16,
+      paddingBottom: 17,
+    },
+  },
+  [`& .${filledInputClasses.root}.${inputBaseClasses.hiddenLabel}.${inputBaseClasses.sizeSmall}`]: {
+    [`& .${autocompleteClasses.input}`]: {
+      paddingTop: 8,
+      paddingBottom: 9,
+    },
+  },
   [`& .${autocompleteClasses.input}`]: {
     flexGrow: 1,
     textOverflow: 'ellipsis',


### PR DESCRIPTION
A filled variant of Autocomplete with `hiddenLabel` has a different height than a TextField with a similar props. This PR restores the paddings of the Autocomplete's underlying input to match the TextField.

Before:
https://codesandbox.io/s/stoic-williamson-g14hhu?file=/demo.tsx

After:
https://codesandbox.io/s/sad-carson-0jqtvr?file=/demo.tsx

Fixes #34744