### PR TITLE
[autocomplete][joy] Specify `type` attribute for popup indicator

### DIFF
--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -528,6 +528,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(
       disabled,
       'aria-label': popupOpen ? closeText : openText,
       title: popupOpen ? closeText : openText,
+      type: 'button',
     },
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/35646

**Problem:**
- When `Autocomplete` is warpped with HTML `<form>`, popup indicator button submits the form on press.

**Solution:**
- Specify `type` attribute to `'button'` for popup indicator fixes the issue.

**Codesandbox Before:** https://codesandbox.io/s/keen-satoshi-ljygoh
**Codesandbox After:** https://codesandbox.io/s/upbeat-shadow-khhqg1