### PR TITLE
[styled-engine] Create cache only if `document` is available

### DIFF
--- a/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
+++ b/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
@@ -5,7 +5,10 @@ import createCache from '@emotion/cache';
 
 // prepend: true moves MUI styles to the top of the <head> so they're loaded first.
 // It allows developers to easily override MUI styles with other styling solutions, like CSS modules.
-const cache = createCache({ key: 'css', prepend: true });
+let cache;
+if (typeof document === 'object') {
+  cache = createCache({ key: 'css', prepend: true });
+}
 
 export default function StyledEngineProvider(props) {
   const { injectFirst, children } = props;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In https://github.com/mui/mui-x/pull/7770, I need to use MUI Core inside a web worker. As soon as the package imported we create the emotion cache, which access `document`, however, inside workers it's not available so it crashes. My solution here was to simply not instantiate the cache if the document is not defined.