### PR TITLE
[docs] Redirect to MUI X v5 docs

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -443,4 +443,4 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 ### MUI Design kits
 /figma/getting-started/ https://mui-org.notion.site/MUI-for-Figma-docs-4eb22360388047a9a31fc19d300a285e 302
 
-/* https://mui.com/:splat 301!
+https://v5.mui.com/* https://mui.com/:splat 301!


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This change is to put live https://v5.mui.com/ with only the docs for the v5 version of the data grid and date pickers.
