### PR TITLE
[docs] Update link to v5 docs

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -495,7 +495,7 @@ export default function AppNavDrawer(props) {
                         current: true,
                       }
                     : {
-                        text: `v6-next`,
+                        text: `v6`,
                         href: `https://next.mui.com${languagePrefix}/components/data-grid/`,
                       }),
                 },
@@ -507,7 +507,7 @@ export default function AppNavDrawer(props) {
                       }
                     : {
                         text: `v5`,
-                        href: `https://mui.com${languagePrefix}/components/data-grid/`,
+                        href: `https://v5.mui.com${languagePrefix}/components/data-grid/`,
                       }),
                 },
               ])}


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The "v5" link in the drawer is still pointing to https://mui.com. This page now hosts the v6 docs.

![image](https://user-images.githubusercontent.com/42154031/222833796-702575cb-6bc5-4d02-89eb-8691fb66e519.png)
