### PR TITLE
[chip] Fix error when theme value is a CSS variable

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -76,7 +76,6 @@ const ChipRoot = styled('div', {
   },
 })(
   ({ theme, ownerState }) => {
-    const deleteIconColor = alpha(theme.palette.text.primary, 0.26);
     const textColor =
       theme.palette.mode === 'light' ? theme.palette.grey[700] : theme.palette.grey[300];
     return {
@@ -147,14 +146,14 @@ const ChipRoot = styled('div', {
         WebkitTapHighlightColor: 'transparent',
         color: theme.vars
           ? `rgba(${theme.vars.palette.text.primaryChannel} / 0.26)`
-          : deleteIconColor,
+          : alpha(theme.palette.text.primary, 0.26),
         fontSize: 22,
         cursor: 'pointer',
         margin: '0 5px 0 -6px',
         '&:hover': {
           color: theme.vars
             ? `rgba(${theme.vars.palette.text.primaryChannel} / 0.4)`
-            : alpha(deleteIconColor, 0.4),
+            : alpha(theme.palette.text.primary, 0.4),
         },
         ...(ownerState.size === 'small' && {
           fontSize: 16,

--- a/packages/mui-material/src/Chip/Chip.test.js
+++ b/packages/mui-material/src/Chip/Chip.test.js
@@ -12,7 +12,12 @@ import {
 } from 'test/utils';
 import Avatar from '@mui/material/Avatar';
 import Chip, { chipClasses as classes } from '@mui/material/Chip';
-import { ThemeProvider, createTheme, hexToRgb } from '@mui/material/styles';
+import {
+  ThemeProvider,
+  createTheme,
+  hexToRgb,
+  experimental_extendTheme as extendTheme,
+} from '@mui/material/styles';
 import CheckBox from '../internal/svg-icons/CheckBox';
 import defaultTheme from '../styles/defaultTheme';
 
@@ -712,6 +717,24 @@ describe('<Chip />', () => {
       setProps({ disabled: true });
 
       expect(chip).not.to.have.class(classes.focusVisible);
+    });
+  });
+
+  describe('CSS vars', () => {
+    it('should not throw when there is theme value is CSS variable', () => {
+      const theme = extendTheme();
+      theme.palette = theme.colorSchemes.light.palette;
+      theme.palette.text = {
+        ...theme.palette.text,
+        primary: 'var(--mui-palette-grey-900)',
+      };
+      expect(() =>
+        render(
+          <ThemeProvider theme={theme}>
+            <Chip label="Test Chip" />
+          </ThemeProvider>,
+        ),
+      ).not.to.throw();
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**Before**: https://codesandbox.io/s/joy-ui-feat-material-ui-forked-cw0rw5?file=/demo.tsx

## Problem

Chip throws an error if you have custom theme value that is a CSS variable:

```js
const theme = extendTheme({
  colorSchemes: {
    light: {
      palette: {
        text: {
          primary: 'var(--mui-palette-grey-900)',
          primaryChannel: '12 12 12',
        },
      },
    },
  },
});

<CssVarsProvider theme={theme}>
  <Chip label="chip" />
</CssVarsProvider>
```

This is because the calculation of `deleteIconColor` with `alpha()` is done before checking `theme.vars`.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
