### PR TITLE
[examples] Fix `SliderUnstyled` slots `key` name

### DIFF
--- a/examples/base-cra-tailwind-ts/src/Slider.tsx
+++ b/examples/base-cra-tailwind-ts/src/Slider.tsx
@@ -30,7 +30,7 @@ const Slider = React.forwardRef(function Slider(
       {...props}
       ref={ref}
       slots={{
-        Thumb,
+        thumb: Thumb,
       }}
       slotProps={{
         root: { className: 'w-full relative inline-block h-2 cursor-pointer' },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes https://github.com/mui/material-ui/issues/36827
before :  <img width="1388" alt="Screenshot 2023-04-10 at 2 39 30 PM" src="https://user-images.githubusercontent.com/60743144/230871736-a18d1ea1-9eb4-40d3-8b6d-77bc9a54921d.png">

after: <img width="1415" alt="Screenshot 2023-04-10 at 2 38 32 PM" src="https://user-images.githubusercontent.com/60743144/230871821-749dcd86-8d7d-4fc1-8744-5d80a99c5498.png">



- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
