### PR TITLE
[slider] add custom styling for mark at the end for horizontal slider

### DIFF
--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -686,9 +686,10 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
         .filter((mark) => mark.value >= min && mark.value <= max)
         .map((mark, index) => {
           const percent = valueToPercent(mark.value, min, max);
-          const style = (axis==='horizontal' && percent === 100)
-          ? {right: "0", transform: "unset"}
-          : axisProps[axis].offset(percent);
+          const style =
+            axis === 'horizontal' && percent === 100
+              ? { right: '0', transform: 'unset' }
+              : axisProps[axis].offset(percent);
 
           let markActive;
           if (track === false) {

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -686,7 +686,9 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
         .filter((mark) => mark.value >= min && mark.value <= max)
         .map((mark, index) => {
           const percent = valueToPercent(mark.value, min, max);
-          const style = axisProps[axis].offset(percent);
+          const style = (axis==='horizontal' && percent === 100)
+          ? {right: "0", transform: "unset"}
+          : axisProps[axis].offset(percent);
 
           let markActive;
           if (track === false) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

fixes: https://github.com/mui/material-ui/issues/32345

This PR add custom styling to the mark at the end of the slider. Instead of having the mark text on the middle of the mark, now the text is alligned to the right of the mark, so that the text doesn't get out of bound.

This solution might be too specific. Feedback would be greatly appreciated.

An alternative solution I had is to call `getBoundingClientRect` function to check if the mark is inside the Slider Component. But I'm reluctant to try that because it is an expensive function to call for all marks.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
