### PR TITLE
[autocomplete] useAutocomplete resets too frequently for complex value

### DIFF
--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -241,7 +241,9 @@ export default function useAutocomplete(props) {
     const valueChange =
       value !== previousProps.value &&
       (previousProps.value === undefined ||
+        previousProps.value === null ||
         value === undefined ||
+        value === null ||
         !isOptionEqualToValue(value, previousProps.value));
 
     if (focused && !valueChange) {

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -242,7 +242,7 @@ export default function useAutocomplete(props) {
       value !== previousProps.value &&
       (previousProps.value === undefined ||
         value === undefined ||
-        getOptionLabel(value) !== getOptionLabel(previousProps.value));
+        getOptionLabelProp(value) !== getOptionLabelProp(previousProps.value));
 
     if (focused && !valueChange) {
       return;
@@ -254,7 +254,7 @@ export default function useAutocomplete(props) {
     }
 
     resetInputValue(null, value);
-  }, [value, resetInputValue, focused, previousProps.value, freeSolo, getOptionLabel]);
+  }, [value, resetInputValue, focused, previousProps.value, freeSolo, getOptionLabelProp]);
 
   const listboxAvailable = open && filteredOptions.length > 0 && !readOnly;
 

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -242,7 +242,7 @@ export default function useAutocomplete(props) {
       value !== previousProps.value &&
       (previousProps.value === undefined ||
         value === undefined ||
-        getOptionLabelProp(value) !== getOptionLabelProp(previousProps.value));
+        !isOptionEqualToValue(value, previousProps.value));
 
     if (focused && !valueChange) {
       return;
@@ -254,7 +254,7 @@ export default function useAutocomplete(props) {
     }
 
     resetInputValue(null, value);
-  }, [value, resetInputValue, focused, previousProps.value, freeSolo, getOptionLabelProp]);
+  }, [value, resetInputValue, focused, previousProps.value, freeSolo, isOptionEqualToValue]);
 
   const listboxAvailable = open && filteredOptions.length > 0 && !readOnly;
 

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -236,7 +236,13 @@ export default function useAutocomplete(props) {
   });
 
   React.useEffect(() => {
-    const valueChange = value !== previousProps.value;
+    // The value can be an instance of object and thus comparing it with basic equality lead to
+    // invalid results. Instead we should compare its final label to detect a value change.
+    const valueChange =
+      value !== previousProps.value &&
+      (previousProps.value === undefined ||
+        value === undefined ||
+        getOptionLabel(value) !== getOptionLabel(previousProps.value));
 
     if (focused && !valueChange) {
       return;
@@ -248,7 +254,7 @@ export default function useAutocomplete(props) {
     }
 
     resetInputValue(null, value);
-  }, [value, resetInputValue, focused, previousProps.value, freeSolo]);
+  }, [value, resetInputValue, focused, previousProps.value, freeSolo, getOptionLabel]);
 
   const listboxAvailable = open && filteredOptions.length > 0 && !readOnly;
 


### PR DESCRIPTION
When receiving complex instances as `value`, the hook `useAutocomplete` may reset its `inputValue` to often. Indeed, the current version of the code is performing a reference comparison of the value, while in some cases some user might pass an always changing value.

This PR is mostly a proposal to make the code more resilient to potential values changing in reference but not in real target value.

Here is a repro of the issue:

```jsx
import { useState, useEffect } from "react";
import { Autocomplete, TextField } from "@mui/material";

export default function App() {
  const [s, setS] = useState(0);

  useEffect(() => {
    const it = setInterval(() => {
      setS((s) => s + 1);
    }, 10000);
    return () => clearInterval(it);
  });
  return (
    <div className="App">
      <Autocomplete
        id="combo-box-demo"
        value={{ id: "001", label: "Label for 001" }}
        options={[
          { id: "001", label: "Label for 001" },
          { id: "002", label: "Label for 002" }
        ]}
        sx={{ width: 300 }}
        renderInput={(params) => <TextField {...params} label="Movie" />}
      />
    </div>
  );
}
```

Open the autocomplete, start to search for 003, wait max 10s. Your search would have been reset.

Repro at: https://codesandbox.io/s/compassionate-rosalind-yztt3r?file=/src/App.js:0-702

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
