### PR TITLE
[mui-codemod] Add missing script to README

### DIFF
--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -62,6 +62,19 @@ npx @mui/codemod <transform> <path> --jscodeshift="--printOptions='{\"quote\":\"
 
 ### v5.0.0
 
+### `base-remove-unstyled-suffix`
+
+The `Unstyled` suffix has been removed from all Base UI component names, including names of types and other related identifiers.
+
+```diff
+-  <Input component='a' href='url' />;
++  <Input slots={{ root: 'a' }} href='url' />;
+```
+
+```sh
+npx @mui/codemod v5.0.0/base-remove-unstyled-suffix <path>
+```
+
 #### `base-remove-component-prop`
 
 Remove `component` prop from all Base UI components by transferring its value into `slots.root`.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

`base-remove-unstyled-suffix` codemod script was missing in the readme.