### PR TITLE
[slider][material] Fix type dependency on @types/prop-types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,15 +266,6 @@ jobs:
             yarn workspace @mui/material typescript:module-augmentation
             yarn workspace @mui/base typescript:module-augmentation
             yarn workspace @mui/joy typescript:module-augmentation
-
-      - restore_cache:
-          name: Restore generated declaration files
-          keys:
-            # #default-branch-switch
-            # We assume that the target branch is `master` and that declaration files are persisted in commit order.
-            # "If there are multiple matches, the most recently generated cache will be used."
-            - typescript-declaration-files-master
-
       - run:
           name: Diff declaration files
           command: |
@@ -283,7 +274,6 @@ jobs:
             git add -f packages/mui-utils/build || echo '/utils declarations do not exist'
             yarn lerna run build:types
             git --no-pager diff
-
       - run:
           name: Any defect declaration files?
           command: node scripts/testBuiltTypes.mjs

--- a/packages/mui-material-next/src/Button/Ripple.tsx
+++ b/packages/mui-material-next/src/Button/Ripple.tsx
@@ -53,7 +53,7 @@ function Ripple(props: RippleProps) {
   );
 }
 
-(Ripple as any).propTypes = {
+Ripple.propTypes = {
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
@@ -84,6 +84,6 @@ function Ripple(props: RippleProps) {
    * exit delay
    */
   timeout: PropTypes.number.isRequired,
-};
+} as any;
 
-export default Ripple;
+export default Ripple as (props: RippleProps) => JSX.Element;

--- a/packages/mui-material-next/src/Button/Ripple.tsx
+++ b/packages/mui-material-next/src/Button/Ripple.tsx
@@ -53,7 +53,7 @@ function Ripple(props: RippleProps) {
   );
 }
 
-Ripple.propTypes = {
+(Ripple as any).propTypes = {
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
@@ -84,6 +84,6 @@ Ripple.propTypes = {
    * exit delay
    */
   timeout: PropTypes.number.isRequired,
-} as any;
+};
 
 export default Ripple;

--- a/packages/mui-material-next/src/Button/Ripple.tsx
+++ b/packages/mui-material-next/src/Button/Ripple.tsx
@@ -84,6 +84,6 @@ Ripple.propTypes = {
    * exit delay
    */
   timeout: PropTypes.number.isRequired,
-};
+} as any;
 
 export default Ripple;

--- a/packages/mui-material-next/src/Button/TouchRipple.tsx
+++ b/packages/mui-material-next/src/Button/TouchRipple.tsx
@@ -277,7 +277,7 @@ const TouchRipple = React.forwardRef<TouchRippleActions, TouchRippleProps>(funct
   );
 }) as React.ForwardRefExoticComponent<TouchRippleProps & React.RefAttributes<TouchRippleActions>>;
 
-(TouchRipple as any).propTypes = {
+TouchRipple.propTypes = {
   /**
    * If `true`, the ripple starts at the center of the component
    * rather than at the point of interaction.
@@ -292,6 +292,6 @@ const TouchRipple = React.forwardRef<TouchRippleActions, TouchRippleProps>(funct
    * @ignore
    */
   className: PropTypes.string,
-};
+} as any;
 
 export default TouchRipple;

--- a/packages/mui-material-next/src/Button/TouchRipple.tsx
+++ b/packages/mui-material-next/src/Button/TouchRipple.tsx
@@ -292,6 +292,6 @@ TouchRipple.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
-} as any;
+};
 
 export default TouchRipple;

--- a/packages/mui-material-next/src/Button/TouchRipple.tsx
+++ b/packages/mui-material-next/src/Button/TouchRipple.tsx
@@ -277,7 +277,7 @@ const TouchRipple = React.forwardRef<TouchRippleActions, TouchRippleProps>(funct
   );
 }) as React.ForwardRefExoticComponent<TouchRippleProps & React.RefAttributes<TouchRippleActions>>;
 
-TouchRipple.propTypes = {
+(TouchRipple as any).propTypes = {
   /**
    * If `true`, the ripple starts at the center of the component
    * rather than at the point of interaction.

--- a/packages/mui-material-next/src/Button/TouchRipple.tsx
+++ b/packages/mui-material-next/src/Button/TouchRipple.tsx
@@ -292,6 +292,6 @@ TouchRipple.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
-};
+} as any;
 
 export default TouchRipple;

--- a/packages/mui-material-next/src/Slider/Slider.tsx
+++ b/packages/mui-material-next/src/Slider/Slider.tsx
@@ -104,7 +104,7 @@ SliderRoot.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-} as any;
+};
 
 export { SliderRoot };
 
@@ -144,7 +144,7 @@ SliderRail.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-} as any;
+};
 
 export { SliderRail };
 
@@ -192,7 +192,7 @@ SliderTrack.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-} as any;
+};
 
 export { SliderTrack };
 
@@ -293,7 +293,7 @@ SliderThumb.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-} as any;
+};
 
 export { SliderThumb };
 
@@ -390,7 +390,7 @@ SliderValueLabel.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.element,
-} as any;
+};
 
 export { SliderValueLabel };
 
@@ -437,7 +437,7 @@ SliderMark.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-} as any;
+};
 
 export { SliderMark };
 
@@ -489,7 +489,7 @@ SliderMarkLabel.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-} as any;
+};
 
 export { SliderMarkLabel };
 
@@ -1083,6 +1083,6 @@ Slider.propTypes /* remove-proptypes */ = {
    * }
    */
   valueLabelFormat: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-} as any;
+};
 
 export default Slider;

--- a/packages/mui-material-next/src/Slider/Slider.tsx
+++ b/packages/mui-material-next/src/Slider/Slider.tsx
@@ -1083,6 +1083,6 @@ Slider.propTypes /* remove-proptypes */ = {
    * }
    */
   valueLabelFormat: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-};
+} as any;
 
 export default Slider;

--- a/packages/mui-material-next/src/Slider/Slider.tsx
+++ b/packages/mui-material-next/src/Slider/Slider.tsx
@@ -104,7 +104,7 @@ SliderRoot.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-};
+} as any;
 
 export { SliderRoot };
 
@@ -144,7 +144,7 @@ SliderRail.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-};
+} as any;
 
 export { SliderRail };
 
@@ -192,7 +192,7 @@ SliderTrack.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-};
+} as any;
 
 export { SliderTrack };
 
@@ -293,7 +293,7 @@ SliderThumb.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-};
+} as any;
 
 export { SliderThumb };
 
@@ -390,7 +390,7 @@ SliderValueLabel.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.element,
-};
+} as any;
 
 export { SliderValueLabel };
 
@@ -437,7 +437,7 @@ SliderMark.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-};
+} as any;
 
 export { SliderMark };
 
@@ -489,7 +489,7 @@ SliderMarkLabel.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-};
+} as any;
 
 export { SliderMarkLabel };
 

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -66,6 +66,7 @@
     "@mui/system": "^5.13.7",
     "@mui/types": "^7.2.4",
     "@mui/utils": "^5.13.7",
+    "@types/prop-types": "^15.7.5",
     "@types/react-transition-group": "^4.4.6",
     "clsx": "^1.2.1",
     "csstype": "^3.1.2",

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -66,7 +66,6 @@
     "@mui/system": "^5.13.7",
     "@mui/types": "^7.2.4",
     "@mui/utils": "^5.13.7",
-    "@types/prop-types": "^15.7.5",
     "@types/react-transition-group": "^4.4.6",
     "clsx": "^1.2.1",
     "csstype": "^3.1.2",

--- a/packages/mui-material/src/Slider/SliderValueLabel.tsx
+++ b/packages/mui-material/src/Slider/SliderValueLabel.tsx
@@ -45,8 +45,8 @@ export default function SliderValueLabel(props: SliderValueLabelProps) {
   );
 }
 
-(SliderValueLabel as any).propTypes = {
+SliderValueLabel.propTypes = {
   children: PropTypes.element.isRequired,
   className: PropTypes.string,
   value: PropTypes.node,
-};
+} as any;

--- a/packages/mui-material/src/Slider/SliderValueLabel.tsx
+++ b/packages/mui-material/src/Slider/SliderValueLabel.tsx
@@ -45,8 +45,8 @@ export default function SliderValueLabel(props: SliderValueLabelProps) {
   );
 }
 
-SliderValueLabel.propTypes = {
+(SliderValueLabel as any).propTypes = {
   children: PropTypes.element.isRequired,
   className: PropTypes.string,
   value: PropTypes.node,
-} as any;
+};

--- a/packages/mui-material/src/Slider/SliderValueLabel.tsx
+++ b/packages/mui-material/src/Slider/SliderValueLabel.tsx
@@ -49,4 +49,4 @@ SliderValueLabel.propTypes = {
   children: PropTypes.element.isRequired,
   className: PropTypes.string,
   value: PropTypes.node,
-};
+} as any;

--- a/scripts/buildTypes.mjs
+++ b/scripts/buildTypes.mjs
@@ -65,7 +65,7 @@ async function main() {
         [
           `${declarationFile} imports from 'prop-types', this is wrong.`,
           "It's likely missing a cast to any on the propTypes declaration:",
-          'ComponentName.propTypes = { /* prop */ } as any;',
+          '(ComponentName as any).propTypes = { /* prop */ };',
         ].join('\n'),
       );
     }

--- a/scripts/buildTypes.mjs
+++ b/scripts/buildTypes.mjs
@@ -65,7 +65,7 @@ async function main() {
         [
           `${declarationFile} imports from 'prop-types', this is wrong.`,
           "It's likely missing a cast to any on the propTypes declaration:",
-          '(ComponentName as any).propTypes = { /* prop */ };',
+          'ComponentName.propTypes = { /* prop */ } as any;',
         ].join('\n'),
       );
     }

--- a/scripts/buildTypes.mjs
+++ b/scripts/buildTypes.mjs
@@ -54,6 +54,22 @@ async function main() {
 
   async function rewriteImportPaths(declarationFile) {
     const code = await fse.readFile(declarationFile, { encoding: 'utf8' });
+    const basename = path.basename(declarationFile);
+
+    if (
+      // Only consider React components
+      basename[0] === basename[0].toUpperCase() &&
+      code.indexOf("import PropTypes from 'prop-types';") !== -1
+    ) {
+      throw new Error(
+        [
+          `${declarationFile} imports from 'prop-types', this is wrong.`,
+          "It's likely missing a cast to any on the propTypes declaration:",
+          'ComponentName.propTypes = { /* prop */ } as any;',
+        ].join('\n'),
+      );
+    }
+
     let fixedCode = code;
     const changes = [];
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

There is a type error when using a strict package manager because `SliderValueLabel.d.ts` imports from `@types/prop-types`, but `@mui/material` has no dependency on `@types/prop-types`:

```
ERROR in ./node_modules/@mui/material/Slider/SliderValueLabel.d.ts:2:23
TS7016: Could not find a declaration file for module 'prop-types'. 'C:/Users/nbier/Documents/ParagonCore/.yarn/cache/prop-types-npm-15.8.1-17c71ee7ee-c056d3f1c0.zip/node_modules/prop-types/index.js' implicitly has an 'any' type.    
  If the 'prop-types' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/prop-types'
    1 | import * as React from 'react';
  > 2 | import PropTypes from 'prop-types';
      |                       ^^^^^^^^^^^^
    3 | import { SliderValueLabelProps } from './SliderValueLabel.types';
    4 | /**
    5 |  * @ignore - internal component.
```

This PR fixes this error by adding a dependency on `@types/prop-types`.
