### PR TITLE
[chip][material-next] Copy chip component from material

### DIFF
--- a/packages/mui-material-next/src/Chip/Chip.d.ts
+++ b/packages/mui-material-next/src/Chip/Chip.d.ts
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { OverridableStringUnion, OverridableComponent, OverrideProps } from '@mui/types';
+import { SxProps } from '@mui/system';
+import { Theme } from '..';
+import { ChipClasses } from './chipClasses';
+
+export interface ChipPropsVariantOverrides {}
+
+export interface ChipPropsSizeOverrides {}
+
+export interface ChipPropsColorOverrides {}
+
+export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
+  props: P & {
+    /**
+     * The Avatar element to display.
+     */
+    avatar?: React.ReactElement;
+    /**
+     * This prop isn't supported.
+     * Use the `component` prop if you need to change the children structure.
+     */
+    children?: null;
+    /**
+     * Override or extend the styles applied to the component.
+     */
+    classes?: Partial<ChipClasses>;
+    /**
+     * If `true`, the chip will appear clickable, and will raise when pressed,
+     * even if the onClick prop is not defined.
+     * If `false`, the chip will not appear clickable, even if onClick prop is defined.
+     * This can be used, for example,
+     * along with the component prop to indicate an anchor Chip is clickable.
+     * Note: this controls the UI and does not affect the onClick event.
+     */
+    clickable?: boolean;
+    /**
+     * The color of the component.
+     * It supports both default and custom theme colors, which can be added as shown in the
+     * [palette customization guide](https://mui.com/material-ui/customization/palette/#adding-new-colors).
+     * @default 'default'
+     */
+    color?: OverridableStringUnion<
+      'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning',
+      ChipPropsColorOverrides
+    >;
+    /**
+     * Override the default delete icon element. Shown only if `onDelete` is set.
+     */
+    deleteIcon?: React.ReactElement;
+    /**
+     * If `true`, the component is disabled.
+     * @default false
+     */
+    disabled?: boolean;
+    /**
+     * Icon element.
+     */
+    icon?: React.ReactElement;
+    /**
+     * The content of the component.
+     */
+    label?: React.ReactNode;
+    /**
+     * Callback fired when the delete icon is clicked.
+     * If set, the delete icon will be shown.
+     */
+    onDelete?: React.EventHandler<any>;
+    /**
+     * The size of the component.
+     * @default 'medium'
+     */
+    size?: OverridableStringUnion<'small' | 'medium', ChipPropsSizeOverrides>;
+    /**
+     * If `true`, allows the disabled chip to escape focus.
+     * If `false`, allows the disabled chip to receive focus.
+     * @default false
+     */
+    skipFocusWhenDisabled?: boolean;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
+    /**
+     *  @ignore
+     */
+    tabIndex?: number;
+    /**
+     * The variant to use.
+     * @default 'filled'
+     */
+    variant?: OverridableStringUnion<'filled' | 'outlined', ChipPropsVariantOverrides>;
+  };
+  defaultComponent: D;
+}
+
+/**
+ * Chips represent complex entities in small blocks, such as a contact.
+ *
+ * Demos:
+ *
+ * - [Chip](https://mui.com/material-ui/react-chip/)
+ *
+ * API:
+ *
+ * - [Chip API](https://mui.com/material-ui/api/chip/)
+ */
+declare const Chip: OverridableComponent<ChipTypeMap>;
+
+export type ChipProps<
+  D extends React.ElementType = ChipTypeMap['defaultComponent'],
+  P = {},
+> = OverrideProps<ChipTypeMap<P, D>, D>;
+
+export default Chip;

--- a/packages/mui-material-next/src/Chip/Chip.d.ts
+++ b/packages/mui-material-next/src/Chip/Chip.d.ts
@@ -10,8 +10,11 @@ export interface ChipPropsSizeOverrides {}
 
 export interface ChipPropsColorOverrides {}
 
-export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface ChipTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * The Avatar element to display.
      */
@@ -91,7 +94,7 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
      */
     variant?: OverridableStringUnion<'filled' | 'outlined', ChipPropsVariantOverrides>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**
@@ -108,8 +111,8 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
 declare const Chip: OverridableComponent<ChipTypeMap>;
 
 export type ChipProps<
-  D extends React.ElementType = ChipTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ChipTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ChipTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ChipTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Chip;

--- a/packages/mui-material-next/src/Chip/Chip.js
+++ b/packages/mui-material-next/src/Chip/Chip.js
@@ -1,0 +1,587 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import {
+  unstable_capitalize as capitalize,
+  unstable_useForkRef as useForkRef,
+  unstable_unsupportedProp as unsupportedProp,
+} from '@mui/utils';
+import { alpha } from '@mui/system';
+import ButtonBase from '@mui/material/ButtonBase';
+import CancelIcon from '../internal/svg-icons/Cancel';
+import { useThemeProps, styled } from '../styles';
+import chipClasses, { getChipUtilityClass } from './chipClasses';
+
+const useUtilityClasses = (ownerState) => {
+  const { classes, disabled, size, color, iconColor, onDelete, clickable, variant } = ownerState;
+
+  const slots = {
+    root: [
+      'root',
+      variant,
+      disabled && 'disabled',
+      `size${capitalize(size)}`,
+      `color${capitalize(color)}`,
+      clickable && 'clickable',
+      clickable && `clickableColor${capitalize(color)}`,
+      onDelete && 'deletable',
+      onDelete && `deletableColor${capitalize(color)}`,
+      `${variant}${capitalize(color)}`,
+    ],
+    label: ['label', `label${capitalize(size)}`],
+    avatar: ['avatar', `avatar${capitalize(size)}`, `avatarColor${capitalize(color)}`],
+    icon: ['icon', `icon${capitalize(size)}`, `iconColor${capitalize(iconColor)}`],
+    deleteIcon: [
+      'deleteIcon',
+      `deleteIcon${capitalize(size)}`,
+      `deleteIconColor${capitalize(color)}`,
+      `deleteIcon${capitalize(variant)}Color${capitalize(color)}`,
+    ],
+  };
+
+  return composeClasses(slots, getChipUtilityClass, classes);
+};
+
+const ChipRoot = styled('div', {
+  name: 'MuiChip',
+  slot: 'Root',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+    const { color, iconColor, clickable, onDelete, size, variant } = ownerState;
+
+    return [
+      { [`& .${chipClasses.avatar}`]: styles.avatar },
+      { [`& .${chipClasses.avatar}`]: styles[`avatar${capitalize(size)}`] },
+      { [`& .${chipClasses.avatar}`]: styles[`avatarColor${capitalize(color)}`] },
+      { [`& .${chipClasses.icon}`]: styles.icon },
+      { [`& .${chipClasses.icon}`]: styles[`icon${capitalize(size)}`] },
+      { [`& .${chipClasses.icon}`]: styles[`iconColor${capitalize(iconColor)}`] },
+      { [`& .${chipClasses.deleteIcon}`]: styles.deleteIcon },
+      { [`& .${chipClasses.deleteIcon}`]: styles[`deleteIcon${capitalize(size)}`] },
+      { [`& .${chipClasses.deleteIcon}`]: styles[`deleteIconColor${capitalize(color)}`] },
+      {
+        [`& .${chipClasses.deleteIcon}`]:
+          styles[`deleteIcon${capitalize(variant)}Color${capitalize(color)}`],
+      },
+      styles.root,
+      styles[`size${capitalize(size)}`],
+      styles[`color${capitalize(color)}`],
+      clickable && styles.clickable,
+      clickable && color !== 'default' && styles[`clickableColor${capitalize(color)})`],
+      onDelete && styles.deletable,
+      onDelete && color !== 'default' && styles[`deletableColor${capitalize(color)}`],
+      styles[variant],
+      styles[`${variant}${capitalize(color)}`],
+    ];
+  },
+})(
+  ({ theme, ownerState }) => {
+    const textColor = theme.vars.palette.grey[700];
+    return {
+      maxWidth: '100%',
+      fontFamily: theme.typography.fontFamily,
+      fontSize: theme.typography.pxToRem(13),
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: 32,
+      color: (theme.vars || theme).palette.text.primary,
+      backgroundColor: (theme.vars || theme).palette.action.selected,
+      borderRadius: 32 / 2,
+      whiteSpace: 'nowrap',
+      transition: theme.transitions.create(['background-color', 'box-shadow']),
+      // label will inherit this from root, then `clickable` class overrides this for both
+      cursor: 'default',
+      // We disable the focus ring for mouse, touch and keyboard users.
+      outline: 0,
+      textDecoration: 'none',
+      border: 0, // Remove `button` border
+      padding: 0, // Remove `button` padding
+      verticalAlign: 'middle',
+      boxSizing: 'border-box',
+      [`&.${chipClasses.disabled}`]: {
+        opacity: (theme.vars || theme).palette.action.disabledOpacity,
+        pointerEvents: 'none',
+      },
+      [`& .${chipClasses.avatar}`]: {
+        marginLeft: 5,
+        marginRight: -6,
+        width: 24,
+        height: 24,
+        color: theme.vars ? theme.vars.palette.Chip.defaultAvatarColor : textColor,
+        fontSize: theme.typography.pxToRem(12),
+      },
+      [`& .${chipClasses.avatarColorPrimary}`]: {
+        color: (theme.vars || theme).palette.primary.contrastText,
+        backgroundColor: (theme.vars || theme).palette.primary.dark,
+      },
+      [`& .${chipClasses.avatarColorSecondary}`]: {
+        color: (theme.vars || theme).palette.secondary.contrastText,
+        backgroundColor: (theme.vars || theme).palette.secondary.dark,
+      },
+      [`& .${chipClasses.avatarSmall}`]: {
+        marginLeft: 4,
+        marginRight: -4,
+        width: 18,
+        height: 18,
+        fontSize: theme.typography.pxToRem(10),
+      },
+      [`& .${chipClasses.icon}`]: {
+        marginLeft: 5,
+        marginRight: -6,
+        ...(ownerState.size === 'small' && {
+          fontSize: 18,
+          marginLeft: 4,
+          marginRight: -4,
+        }),
+        ...(ownerState.iconColor === ownerState.color && {
+          color: theme.vars ? theme.vars.palette.Chip.defaultIconColor : textColor,
+          ...(ownerState.color !== 'default' && {
+            color: 'inherit',
+          }),
+        }),
+      },
+      [`& .${chipClasses.deleteIcon}`]: {
+        WebkitTapHighlightColor: 'transparent',
+        color: theme.vars
+          ? `rgba(${theme.vars.palette.text.primaryChannel} / 0.26)`
+          : alpha(theme.palette.text.primary, 0.26),
+        fontSize: 22,
+        cursor: 'pointer',
+        margin: '0 5px 0 -6px',
+        '&:hover': {
+          color: theme.vars
+            ? `rgba(${theme.vars.palette.text.primaryChannel} / 0.4)`
+            : alpha(theme.palette.text.primary, 0.4),
+        },
+        ...(ownerState.size === 'small' && {
+          fontSize: 16,
+          marginRight: 4,
+          marginLeft: -4,
+        }),
+        ...(ownerState.color !== 'default' && {
+          color: theme.vars
+            ? `rgba(${theme.vars.palette[ownerState.color].contrastTextChannel} / 0.7)`
+            : alpha(theme.palette[ownerState.color].contrastText, 0.7),
+          '&:hover, &:active': {
+            color: (theme.vars || theme).palette[ownerState.color].contrastText,
+          },
+        }),
+      },
+      ...(ownerState.size === 'small' && {
+        height: 24,
+      }),
+      ...(ownerState.color !== 'default' && {
+        backgroundColor: (theme.vars || theme).palette[ownerState.color].main,
+        color: (theme.vars || theme).palette[ownerState.color].contrastText,
+      }),
+      ...(ownerState.onDelete && {
+        [`&.${chipClasses.focusVisible}`]: {
+          backgroundColor: theme.vars
+            ? `rgba(${theme.vars.palette.action.selectedChannel} / calc(${theme.vars.palette.action.selectedOpacity} + ${theme.vars.palette.action.focusOpacity}))`
+            : alpha(
+                theme.palette.action.selected,
+                theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
+              ),
+        },
+      }),
+      ...(ownerState.onDelete &&
+        ownerState.color !== 'default' && {
+          [`&.${chipClasses.focusVisible}`]: {
+            backgroundColor: (theme.vars || theme).palette[ownerState.color].dark,
+          },
+        }),
+    };
+  },
+  ({ theme, ownerState }) => ({
+    ...(ownerState.clickable && {
+      userSelect: 'none',
+      WebkitTapHighlightColor: 'transparent',
+      cursor: 'pointer',
+      '&:hover': {
+        backgroundColor: theme.vars
+          ? `rgba(${theme.vars.palette.action.selectedChannel} / calc(${theme.vars.palette.action.selectedOpacity} + ${theme.vars.palette.action.hoverOpacity}))`
+          : alpha(
+              theme.palette.action.selected,
+              theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
+            ),
+      },
+      [`&.${chipClasses.focusVisible}`]: {
+        backgroundColor: theme.vars
+          ? `rgba(${theme.vars.palette.action.selectedChannel} / calc(${theme.vars.palette.action.selectedOpacity} + ${theme.vars.palette.action.focusOpacity}))`
+          : alpha(
+              theme.palette.action.selected,
+              theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
+            ),
+      },
+      '&:active': {
+        boxShadow: (theme.vars || theme).shadows[1],
+      },
+    }),
+    ...(ownerState.clickable &&
+      ownerState.color !== 'default' && {
+        [`&:hover, &.${chipClasses.focusVisible}`]: {
+          backgroundColor: (theme.vars || theme).palette[ownerState.color].dark,
+        },
+      }),
+  }),
+  ({ theme, ownerState }) => ({
+    ...(ownerState.variant === 'outlined' && {
+      backgroundColor: 'transparent',
+      border: theme.vars
+        ? `1px solid ${theme.vars.palette.Chip.defaultBorder}`
+        : `1px solid ${theme.palette.grey[400]}`,
+      [`&.${chipClasses.clickable}:hover`]: {
+        backgroundColor: (theme.vars || theme).palette.action.hover,
+      },
+      [`&.${chipClasses.focusVisible}`]: {
+        backgroundColor: (theme.vars || theme).palette.action.focus,
+      },
+      [`& .${chipClasses.avatar}`]: {
+        marginLeft: 4,
+      },
+      [`& .${chipClasses.avatarSmall}`]: {
+        marginLeft: 2,
+      },
+      [`& .${chipClasses.icon}`]: {
+        marginLeft: 4,
+      },
+      [`& .${chipClasses.iconSmall}`]: {
+        marginLeft: 2,
+      },
+      [`& .${chipClasses.deleteIcon}`]: {
+        marginRight: 5,
+      },
+      [`& .${chipClasses.deleteIconSmall}`]: {
+        marginRight: 3,
+      },
+    }),
+    ...(ownerState.variant === 'outlined' &&
+      ownerState.color !== 'default' && {
+        color: (theme.vars || theme).palette[ownerState.color].main,
+        border: `1px solid ${
+          theme.vars
+            ? `rgba(${theme.vars.palette[ownerState.color].mainChannel} / 0.7)`
+            : alpha(theme.palette[ownerState.color].main, 0.7)
+        }`,
+        [`&.${chipClasses.clickable}:hover`]: {
+          backgroundColor: theme.vars
+            ? `rgba(${theme.vars.palette[ownerState.color].mainChannel} / ${
+                theme.vars.palette.action.hoverOpacity
+              })`
+            : alpha(theme.palette[ownerState.color].main, theme.palette.action.hoverOpacity),
+        },
+        [`&.${chipClasses.focusVisible}`]: {
+          backgroundColor: theme.vars
+            ? `rgba(${theme.vars.palette[ownerState.color].mainChannel} / ${
+                theme.vars.palette.action.focusOpacity
+              })`
+            : alpha(theme.palette[ownerState.color].main, theme.palette.action.focusOpacity),
+        },
+        [`& .${chipClasses.deleteIcon}`]: {
+          color: theme.vars
+            ? `rgba(${theme.vars.palette[ownerState.color].mainChannel} / 0.7)`
+            : alpha(theme.palette[ownerState.color].main, 0.7),
+          '&:hover, &:active': {
+            color: (theme.vars || theme).palette[ownerState.color].main,
+          },
+        },
+      }),
+  }),
+);
+
+const ChipLabel = styled('span', {
+  name: 'MuiChip',
+  slot: 'Label',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+    const { size } = ownerState;
+
+    return [styles.label, styles[`label${capitalize(size)}`]];
+  },
+})(({ ownerState }) => ({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  paddingLeft: 12,
+  paddingRight: 12,
+  whiteSpace: 'nowrap',
+  ...(ownerState.size === 'small' && {
+    paddingLeft: 8,
+    paddingRight: 8,
+  }),
+}));
+
+function isDeleteKeyboardEvent(keyboardEvent) {
+  return keyboardEvent.key === 'Backspace' || keyboardEvent.key === 'Delete';
+}
+
+/**
+ * Chips represent complex entities in small blocks, such as a contact.
+ */
+const Chip = React.forwardRef(function Chip(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiChip' });
+  const {
+    avatar: avatarProp,
+    className,
+    clickable: clickableProp,
+    color = 'default',
+    component: ComponentProp,
+    deleteIcon: deleteIconProp,
+    disabled = false,
+    icon: iconProp,
+    label,
+    onClick,
+    onDelete,
+    onKeyDown,
+    onKeyUp,
+    size = 'medium',
+    variant = 'filled',
+    tabIndex,
+    skipFocusWhenDisabled = false, // TODO v6: Rename to `focusableWhenDisabled`.
+    ...other
+  } = props;
+
+  const chipRef = React.useRef(null);
+  const handleRef = useForkRef(chipRef, ref);
+
+  const handleDeleteIconClick = (event) => {
+    // Stop the event from bubbling up to the `Chip`
+    event.stopPropagation();
+    if (onDelete) {
+      onDelete(event);
+    }
+  };
+
+  const handleKeyDown = (event) => {
+    // Ignore events from children of `Chip`.
+    if (event.currentTarget === event.target && isDeleteKeyboardEvent(event)) {
+      // Will be handled in keyUp, otherwise some browsers
+      // might init navigation
+      event.preventDefault();
+    }
+
+    if (onKeyDown) {
+      onKeyDown(event);
+    }
+  };
+
+  const handleKeyUp = (event) => {
+    // Ignore events from children of `Chip`.
+    if (event.currentTarget === event.target) {
+      if (onDelete && isDeleteKeyboardEvent(event)) {
+        onDelete(event);
+      } else if (event.key === 'Escape' && chipRef.current) {
+        chipRef.current.blur();
+      }
+    }
+
+    if (onKeyUp) {
+      onKeyUp(event);
+    }
+  };
+
+  const clickable = clickableProp !== false && onClick ? true : clickableProp;
+
+  const component = clickable || onDelete ? ButtonBase : ComponentProp || 'div';
+
+  const ownerState = {
+    ...props,
+    component,
+    disabled,
+    size,
+    color,
+    iconColor: React.isValidElement(iconProp) ? iconProp.props.color || color : color,
+    onDelete: !!onDelete,
+    clickable,
+    variant,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  const moreProps =
+    component === ButtonBase
+      ? {
+          component: ComponentProp || 'div',
+          focusVisibleClassName: classes.focusVisible,
+          ...(onDelete && { disableRipple: true }),
+        }
+      : {};
+
+  let deleteIcon = null;
+  if (onDelete) {
+    deleteIcon =
+      deleteIconProp && React.isValidElement(deleteIconProp) ? (
+        React.cloneElement(deleteIconProp, {
+          className: clsx(deleteIconProp.props.className, classes.deleteIcon),
+          onClick: handleDeleteIconClick,
+        })
+      ) : (
+        <CancelIcon className={clsx(classes.deleteIcon)} onClick={handleDeleteIconClick} />
+      );
+  }
+
+  let avatar = null;
+  if (avatarProp && React.isValidElement(avatarProp)) {
+    avatar = React.cloneElement(avatarProp, {
+      className: clsx(classes.avatar, avatarProp.props.className),
+    });
+  }
+
+  let icon = null;
+  if (iconProp && React.isValidElement(iconProp)) {
+    icon = React.cloneElement(iconProp, {
+      className: clsx(classes.icon, iconProp.props.className),
+    });
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (avatar && icon) {
+      console.error(
+        'MUI: The Chip component can not handle the avatar ' +
+          'and the icon prop at the same time. Pick one.',
+      );
+    }
+  }
+
+  return (
+    <ChipRoot
+      as={component}
+      className={clsx(classes.root, className)}
+      disabled={clickable && disabled ? true : undefined}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      onKeyUp={handleKeyUp}
+      ref={handleRef}
+      tabIndex={skipFocusWhenDisabled && disabled ? -1 : tabIndex}
+      ownerState={ownerState}
+      {...moreProps}
+      {...other}
+    >
+      {avatar || icon}
+      <ChipLabel className={clsx(classes.label)} ownerState={ownerState}>
+        {label}
+      </ChipLabel>
+      {deleteIcon}
+    </ChipRoot>
+  );
+});
+
+Chip.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * The Avatar element to display.
+   */
+  avatar: PropTypes.element,
+  /**
+   * This prop isn't supported.
+   * Use the `component` prop if you need to change the children structure.
+   */
+  children: unsupportedProp,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, the chip will appear clickable, and will raise when pressed,
+   * even if the onClick prop is not defined.
+   * If `false`, the chip will not appear clickable, even if onClick prop is defined.
+   * This can be used, for example,
+   * along with the component prop to indicate an anchor Chip is clickable.
+   * Note: this controls the UI and does not affect the onClick event.
+   */
+  clickable: PropTypes.bool,
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#adding-new-colors).
+   * @default 'default'
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['default', 'primary', 'secondary', 'error', 'info', 'success', 'warning']),
+    PropTypes.string,
+  ]),
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * Override the default delete icon element. Shown only if `onDelete` is set.
+   */
+  deleteIcon: PropTypes.element,
+  /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Icon element.
+   */
+  icon: PropTypes.element,
+  /**
+   * The content of the component.
+   */
+  label: PropTypes.node,
+  /**
+   * @ignore
+   */
+  onClick: PropTypes.func,
+  /**
+   * Callback fired when the delete icon is clicked.
+   * If set, the delete icon will be shown.
+   */
+  onDelete: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onKeyDown: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onKeyUp: PropTypes.func,
+  /**
+   * The size of the component.
+   * @default 'medium'
+   */
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['medium', 'small']),
+    PropTypes.string,
+  ]),
+  /**
+   * If `true`, allows the disabled chip to escape focus.
+   * If `false`, allows the disabled chip to receive focus.
+   * @default false
+   */
+  skipFocusWhenDisabled: PropTypes.bool,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * @ignore
+   */
+  tabIndex: PropTypes.number,
+  /**
+   * The variant to use.
+   * @default 'filled'
+   */
+  variant: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['filled', 'outlined']),
+    PropTypes.string,
+  ]),
+};
+
+export default Chip;

--- a/packages/mui-material-next/src/Chip/Chip.test.js
+++ b/packages/mui-material-next/src/Chip/Chip.test.js
@@ -1,0 +1,754 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy, stub } from 'sinon';
+import {
+  describeConformance,
+  act,
+  createRenderer,
+  fireEvent,
+  focusVisible,
+  simulatePointerDevice,
+  programmaticFocusTriggersFocusVisible,
+} from 'test/utils';
+import { hexToRgb } from '@mui/system';
+import Chip, { chipClasses as classes } from '@mui/material-next/Chip';
+import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
+import { createTheme } from '@mui/material/styles';
+import Avatar from '@mui/material/Avatar';
+import CheckBox from '../internal/svg-icons/CheckBox';
+
+// TODO: remove after implementing Material You Chip's style
+const MaterialV5DefaultTheme = createTheme();
+
+describe('<Chip />', () => {
+  let originalMatchmedia;
+
+  beforeEach(() => {
+    originalMatchmedia = window.matchMedia;
+    window.matchMedia = () => ({
+      addListener: () => {},
+      removeListener: () => {},
+    });
+  });
+  afterEach(() => {
+    window.matchMedia = originalMatchmedia;
+  });
+
+  const { render } = createRenderer();
+
+  describeConformance(<Chip />, () => ({
+    ThemeProvider: CssVarsProvider,
+    createTheme: extendTheme,
+    classes,
+    inheritComponent: 'div',
+    render,
+    muiName: 'MuiChip',
+    testDeepOverrides: { slotName: 'label', slotClassName: classes.label },
+    testVariantProps: { variant: 'outlined' },
+    testStatOverrides: { prop: 'size', value: 'small', styleKey: 'sizeSmall' },
+    refInstanceof: window.HTMLDivElement,
+    testComponentPropWith: 'span',
+    skip: ['slots', 'componentsProp'],
+  }));
+
+  describe('text only', () => {
+    it('is not in tab order', () => {
+      const { container } = render(<Chip label="My text Chip" />);
+
+      expect(container.querySelectorAll('[tabindex]')).to.have.length(0);
+    });
+
+    it('should renders certain classes and contains a label', () => {
+      const { container } = render(<Chip label="My text Chip" />);
+
+      const chip = container.querySelector(`.${classes.root}`);
+      const label = container.querySelector(`.${classes.label}`);
+
+      expect(label).to.have.tagName('span');
+      expect(label).to.have.text('My text Chip');
+
+      expect(chip).to.have.class(classes.root);
+      expect(chip).not.to.have.class(classes.colorPrimary);
+      expect(chip).not.to.have.class(classes.colorSecondary);
+      expect(chip).not.to.have.class(classes.clickable);
+      expect(chip).not.to.have.class(classes.clickableColorPrimary);
+      expect(chip).not.to.have.class(classes.clickableColorSecondary);
+      expect(chip).not.to.have.class(classes.deletable);
+      expect(chip).not.to.have.class(classes.deletableColorPrimary);
+      expect(chip).not.to.have.class(classes.deletableColorSecondary);
+    });
+
+    it('should render with the color class name based on the color prop', () => {
+      const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
+
+      ['primary', 'secondary', 'info', 'error', 'warning', 'success'].forEach((color) => {
+        const { container } = render(<Chip color={color} />);
+        const chip = container.querySelector(`.${classes.root}`);
+        expect(chip).to.have.class(classes[`color${capitalize(color)}`]);
+      });
+    });
+  });
+
+  describe('clickable chip', () => {
+    it('renders as a button in taborder with the label as the accessible name', () => {
+      const { getByRole } = render(<Chip label="My Chip" onClick={() => {}} />);
+
+      const button = getByRole('button');
+      expect(button).to.have.property('tabIndex', 0);
+      expect(button).toHaveAccessibleName('My Chip');
+    });
+
+    it('should render link with the button base', () => {
+      const { container } = render(<Chip component="a" clickable label="My text Chip" />);
+
+      expect(container.firstChild).to.have.class('MuiButtonBase-root');
+      expect(container.firstChild).to.have.tagName('a');
+      expect(container.firstChild.querySelector('.MuiTouchRipple-root')).not.to.equal(null);
+    });
+
+    it('should disable ripple when MuiButtonBase has disableRipple in theme', () => {
+      const theme = extendTheme({
+        components: {
+          MuiButtonBase: {
+            defaultProps: {
+              disableRipple: true,
+            },
+          },
+        },
+      });
+
+      const { container } = render(
+        <CssVarsProvider theme={theme}>
+          <Chip clickable label="My Chip" />
+        </CssVarsProvider>,
+      );
+
+      expect(container.firstChild).to.have.class('MuiButtonBase-root');
+      expect(container.firstChild.querySelector('.MuiTouchRipple-root')).to.equal(null);
+    });
+
+    it('should apply user value of tabIndex', () => {
+      const { getByRole } = render(<Chip label="My Chip" onClick={() => {}} tabIndex={5} />);
+
+      expect(getByRole('button')).to.have.property('tabIndex', 5);
+    });
+
+    it('should render with the root and clickable class', () => {
+      const { container } = render(<Chip label="My Chip" onClick={() => {}} />);
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.root);
+      expect(chip).to.have.class(classes.clickable);
+    });
+
+    it('should render with the root and clickable primary class', () => {
+      const { getByRole } = render(<Chip label="My Chip" onClick={() => {}} color="primary" />);
+
+      const button = getByRole('button');
+      expect(button).to.have.class(classes.root);
+      expect(button).to.have.class(classes.colorPrimary);
+      expect(button).to.have.class(classes.clickable);
+      expect(button).to.have.class(classes.clickableColorPrimary);
+    });
+
+    it('should render with the root and outlined clickable primary class', () => {
+      const { container } = render(
+        <Chip color="primary" label="My Chip" onClick={() => {}} variant="outlined" />,
+      );
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.root);
+      expect(chip).to.have.class(classes.colorPrimary);
+      expect(chip).to.have.class(classes.clickable);
+      expect(chip).to.have.class(classes.clickableColorPrimary);
+      expect(chip).to.have.class(classes.outlined);
+      expect(chip).to.have.class(classes.outlinedPrimary);
+    });
+
+    it('should render with the root and outlined clickable secondary class', () => {
+      const { getByRole } = render(
+        <Chip color="secondary" label="My Chip" onClick={() => {}} variant="outlined" />,
+      );
+
+      const button = getByRole('button');
+      expect(button).to.have.class(classes.root);
+      expect(button).to.have.class(classes.colorSecondary);
+      expect(button).to.have.class(classes.clickable);
+      expect(button).to.have.class(classes.clickableColorSecondary);
+      expect(button).to.have.class(classes.outlined);
+      expect(button).to.have.class(classes.outlinedSecondary);
+    });
+
+    it('should render with the root and filled clickable primary class', () => {
+      const { getByRole } = render(
+        <Chip color="primary" label="My Chip" onClick={() => {}} variant="filled" />,
+      );
+
+      const chip = getByRole('button');
+      expect(chip).to.have.class(classes.root);
+      expect(chip).to.have.class(classes.colorPrimary);
+      expect(chip).to.have.class(classes.clickable);
+      expect(chip).to.have.class(classes.clickableColorPrimary);
+      expect(chip).to.have.class(classes.filled);
+      expect(chip).to.have.class(classes.filledPrimary);
+    });
+
+    it('should not be focused when a deletable chip is disabled and skipFocusWhenDisabled is true', () => {
+      const { getByTestId } = render(
+        <Chip
+          label="My Chip"
+          disabled
+          data-testid="chip"
+          skipFocusWhenDisabled
+          onDelete={() => {}}
+        />,
+      );
+
+      const chip = getByTestId('chip');
+
+      simulatePointerDevice();
+      act(() => {
+        fireEvent.keyDown(document.body, { key: 'Tab' });
+      });
+
+      expect(chip).to.have.class(classes.root);
+      expect(chip).to.have.property('tabIndex', -1);
+      expect(chip).not.to.have.class(classes.focusVisible);
+    });
+
+    it('should render with the root and filled clickable secondary class', () => {
+      const { getByRole } = render(
+        <Chip color="secondary" label="My Chip" onClick={() => {}} variant="filled" />,
+      );
+
+      const chip = getByRole('button');
+      expect(chip).to.have.class(classes.root);
+      expect(chip).to.have.class(classes.colorSecondary);
+      expect(chip).to.have.class(classes.clickable);
+      expect(chip).to.have.class(classes.clickableColorSecondary);
+      expect(chip).to.have.class(classes.filled);
+      expect(chip).to.have.class(classes.filledSecondary);
+    });
+  });
+
+  describe('deletable Avatar chip', () => {
+    it('should render a button in tab order with the avatar', () => {
+      const { container, getByRole } = render(
+        <Chip
+          avatar={<Avatar id="avatar">MB</Avatar>}
+          label="Text Avatar Chip"
+          onDelete={() => {}}
+        />,
+      );
+
+      expect(getByRole('button')).to.have.property('tabIndex', 0);
+      expect(container.querySelector('#avatar')).not.to.equal(null);
+    });
+
+    it('should not create ripples', () => {
+      const { container } = render(
+        <Chip avatar={<Avatar id="avatar">MB</Avatar>} onDelete={() => {}} />,
+      );
+
+      expect(container.firstChild.querySelector('.MuiTouchRipple-root')).to.equal(null);
+    });
+
+    it('should apply user value of tabIndex', () => {
+      const { container, getByRole } = render(
+        <Chip
+          avatar={<Avatar id="avatar">MB</Avatar>}
+          label="Text Avatar Chip"
+          onDelete={() => {}}
+          tabIndex={5}
+        />,
+      );
+
+      expect(getByRole('button')).to.have.property('tabIndex', 5);
+      const elementsInTabOrder = Array.from(container.querySelectorAll('[tabIndex]')).filter(
+        (element) => element.tabIndex >= 0,
+      );
+      expect(elementsInTabOrder).to.have.length(1);
+    });
+
+    it('fires onDelete when clicking the delete icon', () => {
+      const handleDelete = spy();
+      const { getByTestId } = render(
+        <Chip
+          avatar={<Avatar id="avatar">MB</Avatar>}
+          label="Text Avatar Chip"
+          onDelete={handleDelete}
+          deleteIcon={<div data-testid="delete-icon" />}
+        />,
+      );
+      const deleteIcon = getByTestId('delete-icon');
+
+      fireEvent.click(deleteIcon);
+
+      expect(handleDelete.callCount).to.equal(1);
+    });
+
+    it('should stop propagation when clicking the delete icon', () => {
+      const handleClick = spy();
+      const { getByTestId } = render(
+        <Chip
+          avatar={<Avatar id="avatar">MB</Avatar>}
+          label="Text Avatar Chip"
+          onClick={handleClick}
+          onDelete={() => {}}
+          deleteIcon={<div data-testid="delete-icon" />}
+        />,
+      );
+      const deleteIcon = getByTestId('delete-icon');
+
+      fireEvent.click(deleteIcon);
+
+      expect(handleClick.callCount).to.equal(0);
+    });
+
+    it('should render with the root, deletable classes', () => {
+      const { container } = render(
+        <Chip
+          avatar={<Avatar id="avatar">MB</Avatar>}
+          label="Text Avatar Chip"
+          onDelete={() => {}}
+        />,
+      );
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.deletable);
+    });
+
+    it('should render with the root, deletable and avatar primary classes', () => {
+      const { container } = render(
+        <Chip
+          avatar={<Avatar className="my-Avatar">MB</Avatar>}
+          label="Text Avatar Chip"
+          onDelete={() => {}}
+          color="primary"
+        />,
+      );
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.colorPrimary);
+      expect(chip).to.have.class(classes.deletable);
+      expect(chip).to.have.class(classes.deletableColorPrimary);
+      const avatar = container.querySelector(`.${classes.avatar}`);
+      expect(avatar).to.have.class(classes.avatarColorPrimary);
+    });
+
+    it('should render with the root, deletable and avatar secondary classes', () => {
+      const { container } = render(
+        <Chip
+          avatar={<Avatar>MB</Avatar>}
+          label="Text Avatar Chip"
+          onDelete={() => {}}
+          color="secondary"
+        />,
+      );
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.colorSecondary);
+      expect(chip).to.have.class(classes.deletable);
+      expect(chip).to.have.class(classes.deletableColorSecondary);
+      const avatar = container.querySelector(`.${classes.avatar}`);
+      expect(avatar).to.have.class(classes.avatarColorSecondary);
+    });
+  });
+
+  describe('prop: deleteIcon', () => {
+    it('should render a default icon with the root, deletable and deleteIcon classes', () => {
+      const { getByRole, getByTestId } = render(
+        <Chip label="Custom delete icon Chip" onDelete={() => {}} />,
+      );
+
+      const chip = getByRole('button');
+      const icon = getByTestId('CancelIcon');
+
+      expect(chip).to.have.class(classes.deletable);
+      expect(chip).to.contain(icon);
+      expect(icon).to.have.class(classes.deleteIcon);
+    });
+
+    it('should render default icon with the root, deletable and deleteIcon primary class', () => {
+      const { container, getByTestId } = render(
+        <Chip label="Custom delete icon Chip" onDelete={() => {}} color="primary" />,
+      );
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.colorPrimary);
+      expect(chip).to.have.class(classes.deletable);
+      expect(chip).to.have.class(classes.deletableColorPrimary);
+      const icon = getByTestId('CancelIcon');
+      expect(icon).to.have.class(classes.deleteIcon);
+      expect(icon).to.have.class(classes.deleteIconColorPrimary);
+    });
+
+    it('should render a default icon with the root, deletable, deleteIcon secondary class', () => {
+      const { container, getByTestId } = render(
+        <Chip label="Custom delete icon Chip" onDelete={() => {}} color="secondary" />,
+      );
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.colorSecondary);
+      expect(chip).to.have.class(classes.deletable);
+      expect(chip).to.have.class(classes.deletableColorSecondary);
+      const icon = getByTestId('CancelIcon');
+      expect(icon).to.have.class(classes.deleteIcon);
+      expect(icon).to.have.class(classes.deleteIconColorSecondary);
+    });
+
+    it('should render default icon with the root, deletable, deleteIcon primary class and deleteIcon filled primary class', () => {
+      const { container, getByTestId } = render(
+        <Chip
+          label="Custom delete icon Chip"
+          onDelete={() => {}}
+          color="primary"
+          variant="filled"
+        />,
+      );
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.colorPrimary);
+      expect(chip).to.have.class(classes.deletable);
+      expect(chip).to.have.class(classes.deletableColorPrimary);
+      const icon = getByTestId('CancelIcon');
+      expect(icon).to.have.class(classes.deleteIcon);
+      expect(icon).to.have.class(classes.deleteIconColorPrimary);
+      expect(icon).to.have.class(classes.deleteIconFilledColorPrimary);
+    });
+
+    it('should render default icon with the root, deletable, deleteIcon primary class and deleteIcon outlined primary class', () => {
+      const { container, getByTestId } = render(
+        <Chip
+          label="Custom delete icon Chip"
+          onDelete={() => {}}
+          color="primary"
+          variant="outlined"
+        />,
+      );
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.colorPrimary);
+      expect(chip).to.have.class(classes.deletable);
+      expect(chip).to.have.class(classes.deletableColorPrimary);
+      const icon = getByTestId('CancelIcon');
+      expect(icon).to.have.class(classes.deleteIcon);
+      expect(icon).to.have.class(classes.deleteIconColorPrimary);
+      expect(icon).to.have.class(classes.deleteIconOutlinedColorPrimary);
+    });
+
+    it('accepts a custom icon', () => {
+      const handleDelete = spy();
+      const { getByTestId } = render(
+        <Chip label="Custom delete icon Chip" onDelete={handleDelete} deleteIcon={<CheckBox />} />,
+      );
+
+      fireEvent.click(getByTestId('CheckBoxIcon'));
+
+      expect(handleDelete.callCount).to.equal(1);
+    });
+  });
+
+  describe('reacts to keyboard chip', () => {
+    it('should call onKeyDown when a key is pressed', () => {
+      const handleKeydown = stub().callsFake((event) => event.key);
+      const { getByRole } = render(<Chip onClick={() => {}} onKeyDown={handleKeydown} />);
+      const chip = getByRole('button');
+      act(() => {
+        chip.focus();
+      });
+
+      fireEvent.keyDown(chip, { key: 'p' });
+
+      expect(handleKeydown.callCount).to.equal(1);
+      expect(handleKeydown.firstCall.returnValue).to.equal('p');
+    });
+
+    it('should unfocus when a esc key is pressed', () => {
+      const handleBlur = spy();
+      const { getByRole } = render(<Chip onBlur={handleBlur} onClick={() => {}} />);
+      const chip = getByRole('button');
+      act(() => {
+        chip.focus();
+      });
+
+      fireEvent.keyUp(chip, { key: 'Escape' });
+
+      expect(handleBlur.callCount).to.equal(1);
+      expect(chip).not.toHaveFocus();
+    });
+
+    it('should call onClick when `space` is released ', () => {
+      const handleClick = spy();
+      const { getByRole } = render(<Chip onClick={handleClick} />);
+      const chip = getByRole('button');
+      act(() => {
+        chip.focus();
+      });
+
+      fireEvent.keyUp(chip, { key: ' ' });
+
+      expect(handleClick.callCount).to.equal(1);
+    });
+
+    it('should call onClick when `enter` is pressed ', () => {
+      const handleClick = spy();
+      const { getByRole } = render(<Chip onClick={handleClick} />);
+      const chip = getByRole('button');
+      act(() => {
+        chip.focus();
+      });
+
+      fireEvent.keyDown(chip, { key: 'Enter' });
+
+      expect(handleClick.callCount).to.equal(1);
+    });
+
+    describe('prop: onDelete', () => {
+      ['Backspace', 'Delete'].forEach((key) => {
+        it(`should call onDelete '${key}' is released`, () => {
+          const handleDelete = spy();
+          const handleKeyDown = spy();
+          const { getAllByRole } = render(
+            <Chip onClick={() => {}} onKeyDown={handleKeyDown} onDelete={handleDelete} />,
+          );
+          const chip = getAllByRole('button')[0];
+          act(() => {
+            chip.focus();
+          });
+
+          fireEvent.keyDown(chip, { key });
+
+          // defaultPrevented?
+          expect(handleKeyDown.callCount).to.equal(1);
+          expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', true);
+          expect(handleDelete.callCount).to.equal(0);
+
+          fireEvent.keyUp(chip, { key });
+
+          expect(handleDelete.callCount).to.equal(1);
+        });
+      });
+
+      it('should not prevent default on input', () => {
+        const handleKeyDown = spy();
+        const { container } = render(<Chip label={<input />} onKeyDown={handleKeyDown} />);
+        const input = container.querySelector('input');
+
+        act(() => {
+          input.focus();
+        });
+        fireEvent.keyDown(input, { key: 'Backspace' });
+
+        expect(handleKeyDown.callCount).to.equal(1);
+        expect(handleKeyDown.firstCall.args[0]).to.have.property('defaultPrevented', false);
+      });
+    });
+
+    describe('with children that generate events', () => {
+      ['Backspace', 'Delete'].forEach((key) => {
+        it(`should not call onDelete for child keyup event when '${key}' is released`, () => {
+          const handleDelete = spy();
+          const handleKeyUp = spy();
+          render(
+            <Chip
+              onDelete={handleDelete}
+              label={<input autoFocus className="child-input" onKeyUp={handleKeyUp} />}
+            />,
+          );
+
+          fireEvent.keyUp(document.querySelector('input'), { key });
+
+          expect(handleKeyUp.callCount).to.equal(1);
+          expect(handleDelete.callCount).to.equal(0);
+        });
+      });
+
+      it(`should not call onClick for child keyup event when 'Space' is released`, () => {
+        const handleClick = spy();
+        const handleKeyUp = spy();
+        render(
+          <Chip
+            onClick={handleClick}
+            label={<input autoFocus className="child-input" onKeyUp={handleKeyUp} />}
+          />,
+        );
+
+        fireEvent.keyUp(document.querySelector('input'), { key: ' ' });
+        expect(handleKeyUp.callCount).to.equal(1);
+        expect(handleClick.callCount).to.equal(0);
+      });
+
+      it(`should not call onClick for child keydown event when 'Enter' is pressed`, () => {
+        const handleClick = spy();
+        const handleKeyDown = spy();
+        render(
+          <Chip
+            onClick={handleClick}
+            label={<input autoFocus className="child-input" onKeyDown={handleKeyDown} />}
+          />,
+        );
+
+        fireEvent.keyDown(document.querySelector('input'), { key: 'Enter' });
+        expect(handleKeyDown.callCount).to.equal(1);
+        expect(handleClick.callCount).to.equal(0);
+      });
+
+      it('should not call onClick for child event when `space` is released', () => {
+        const handleClick = spy();
+        const handleKeyUp = spy();
+        render(
+          <Chip
+            onClick={handleClick}
+            label={<input autoFocus className="child-input" onKeyUp={handleKeyUp} />}
+          />,
+        );
+
+        fireEvent.keyUp(document.querySelector('input'), { key: ' ' });
+
+        expect(handleClick.callCount).to.equal(0);
+        expect(handleKeyUp.callCount).to.equal(1);
+      });
+
+      it('should not call onClick for child event when `enter` is pressed', () => {
+        const handleClick = spy();
+        const handleKeyDown = spy();
+        render(
+          <Chip
+            onClick={handleClick}
+            label={<input autoFocus className="child-input" onKeyDown={handleKeyDown} />}
+          />,
+        );
+
+        fireEvent.keyDown(document.querySelector('input'), { key: 'Enter' });
+
+        expect(handleClick.callCount).to.equal(0);
+        expect(handleKeyDown.callCount).to.equal(1);
+      });
+    });
+  });
+
+  describe('prop: icon', () => {
+    it('should render the icon', () => {
+      const { getByTestId } = render(<Chip icon={<span data-testid="test-icon" />} />);
+
+      expect(getByTestId('test-icon')).to.have.class(classes.icon);
+    });
+
+    it("should not override the icon's custom color", () => {
+      const { getByTestId } = render(
+        <React.Fragment>
+          <Chip icon={<CheckBox data-testid="test-icon" color="success" />} />,
+          <Chip icon={<CheckBox data-testid="test-icon2" color="success" />} color="error" />,
+        </React.Fragment>,
+      );
+
+      expect(getByTestId('test-icon')).to.have.class('MuiChip-iconColorSuccess');
+      expect(getByTestId('test-icon2')).to.have.class('MuiChip-iconColorSuccess');
+      expect(getByTestId('test-icon')).toHaveComputedStyle({
+        color: hexToRgb(MaterialV5DefaultTheme.palette.success.main),
+      });
+      expect(getByTestId('test-icon2')).toHaveComputedStyle({
+        color: hexToRgb(MaterialV5DefaultTheme.palette.success.main),
+      });
+    });
+  });
+
+  describe('prop: size', () => {
+    it('should render with the sizeSmall class', () => {
+      const { container } = render(<Chip size="small" />);
+
+      const chip = container.querySelector(`.${classes.root}`);
+      expect(chip).to.have.class(classes.sizeSmall);
+    });
+
+    it('should render the label with the labelSmall class', () => {
+      const { container } = render(<Chip size="small" label="small chip" />);
+
+      const label = container.querySelector(`.${classes.label}`);
+      expect(label).to.have.class(classes.labelSmall);
+    });
+
+    it('should render an avatar with the avatarSmall class', () => {
+      const { container } = render(
+        <Chip size="small" avatar={<Avatar className="my-Avatar">MB</Avatar>} />,
+      );
+
+      const avatar = container.querySelector('.my-Avatar');
+      expect(avatar).to.have.class(classes.avatar);
+      expect(avatar).to.have.class(classes.avatarSmall);
+    });
+
+    it('should render an icon with the icon and iconSmall classes', () => {
+      const { container } = render(<Chip size="small" icon={<span id="test-icon" />} />);
+
+      const icon = container.querySelector('#test-icon');
+      expect(icon).to.have.class(classes.icon);
+      expect(icon).to.have.class(classes.iconSmall);
+    });
+
+    it('should render the delete icon with the deleteIcon and deleteIconSmall classes', () => {
+      const { getByTestId } = render(<Chip size="small" onDelete={() => {}} />);
+
+      const icon = getByTestId('CancelIcon');
+      expect(icon).to.have.class(classes.deleteIcon);
+      expect(icon).to.have.class(classes.deleteIconSmall);
+    });
+  });
+
+  describe('event: focus', () => {
+    it('has a focus-visible polyfill', () => {
+      const { container } = render(<Chip label="Test Chip" onClick={() => {}} />);
+      const chip = container.querySelector(`.${classes.root}`);
+      simulatePointerDevice();
+
+      expect(chip).not.to.have.class(classes.focusVisible);
+
+      act(() => {
+        chip.focus();
+      });
+
+      if (programmaticFocusTriggersFocusVisible()) {
+        expect(chip).to.have.class(classes.focusVisible);
+      } else {
+        expect(chip).not.to.have.class(classes.focusVisible);
+      }
+
+      focusVisible(chip);
+
+      expect(chip).to.have.class(classes.focusVisible);
+    });
+
+    it('should reset the focused state', () => {
+      const { container, setProps } = render(<Chip label="Test Chip" onClick={() => {}} />);
+      const chip = container.querySelector(`.${classes.root}`);
+
+      simulatePointerDevice();
+      focusVisible(chip);
+
+      expect(chip).to.have.class(classes.focusVisible);
+
+      setProps({ disabled: true });
+
+      expect(chip).not.to.have.class(classes.focusVisible);
+    });
+  });
+
+  describe('CSS vars', () => {
+    it('should not throw when there is theme value is CSS variable', () => {
+      const theme = extendTheme();
+      theme.palette = theme.colorSchemes.light.palette;
+      theme.palette.text = {
+        ...theme.palette.text,
+        primary: 'var(--mui-palette-grey-900)',
+      };
+      expect(() =>
+        render(
+          <CssVarsProvider theme={theme}>
+            <Chip label="Test Chip" />
+          </CssVarsProvider>,
+        ),
+      ).not.to.throw();
+    });
+  });
+});

--- a/packages/mui-material-next/src/Chip/chipClasses.ts
+++ b/packages/mui-material-next/src/Chip/chipClasses.ts
@@ -1,0 +1,153 @@
+import {
+  unstable_generateUtilityClasses as generateUtilityClasses,
+  unstable_generateUtilityClass as generateUtilityClass,
+} from '@mui/utils';
+
+export interface ChipClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `size="small"`. */
+  sizeSmall: string;
+  /** Styles applied to the root element if `size="medium"`. */
+  sizeMedium: string;
+  /** Styles applied to the root element if `color="error"`. */
+  colorError: string;
+  /** Styles applied to the root element if `color="info"`. */
+  colorInfo: string;
+  /** Styles applied to the root element if `color="primary"`. */
+  colorPrimary: string;
+  /** Styles applied to the root element if `color="secondary"`. */
+  colorSecondary: string;
+  /** Styles applied to the root element if `color="success"`. */
+  colorSuccess: string;
+  /** Styles applied to the root element if `color="warning"`. */
+  colorWarning: string;
+  /** State class applied to the root element if `disabled={true}`. */
+  disabled: string;
+  /** Styles applied to the root element if `onClick` is defined or `clickable={true}`. */
+  clickable: string;
+  /** Styles applied to the root element if `onClick` and `color="primary"` is defined or `clickable={true}`. */
+  clickableColorPrimary: string;
+  /** Styles applied to the root element if `onClick` and `color="secondary"` is defined or `clickable={true}`. */
+  clickableColorSecondary: string;
+  /** Styles applied to the root element if `onDelete` is defined. */
+  deletable: string;
+  /** Styles applied to the root element if `onDelete` and `color="primary"` is defined. */
+  deletableColorPrimary: string;
+  /** Styles applied to the root element if `onDelete` and `color="secondary"` is defined. */
+  deletableColorSecondary: string;
+  /** Styles applied to the root element if `variant="outlined"`. */
+  outlined: string;
+  /** Styles applied to the root element if `variant="filled"`. */
+  filled: string;
+  /** Styles applied to the root element if `variant="outlined"` and `color="primary"`. */
+  outlinedPrimary: string;
+  /** Styles applied to the root element if `variant="outlined"` and `color="secondary"`. */
+  outlinedSecondary: string;
+  /** Styles applied to the root element if `variant="filled"` and `color="primary"`. */
+  filledPrimary: string;
+  /** Styles applied to the root element if `variant="filled"` and `color="secondary"`. */
+  filledSecondary: string;
+  /** Styles applied to the avatar element. */
+  avatar: string;
+  /** Styles applied to the avatar element if `size="small"`. */
+  avatarSmall: string;
+  /** Styles applied to the avatar element if `size="medium"`. */
+  avatarMedium: string;
+  /** Styles applied to the avatar element if `color="primary"`. */
+  avatarColorPrimary: string;
+  /** Styles applied to the avatar element if `color="secondary"`. */
+  avatarColorSecondary: string;
+  /** Styles applied to the icon element. */
+  icon: string;
+  /** Styles applied to the icon element if `size="small"`. */
+  iconSmall: string;
+  /** Styles applied to the icon element if `size="medium"`. */
+  iconMedium: string;
+  /** Styles applied to the icon element if `color="primary"`. */
+  iconColorPrimary: string;
+  /** Styles applied to the icon element if `color="secondary"`. */
+  iconColorSecondary: string;
+  /** Styles applied to the label `span` element. */
+  label: string;
+  /** Styles applied to the label `span` element if `size="small"`. */
+  labelSmall: string;
+  /** Styles applied to the label `span` element if `size="medium"`. */
+  labelMedium: string;
+  /** Styles applied to the deleteIcon element. */
+  deleteIcon: string;
+  /** Styles applied to the deleteIcon element if `size="small"`. */
+  deleteIconSmall: string;
+  /** Styles applied to the deleteIcon element if `size="medium"`. */
+  deleteIconMedium: string;
+  /** Styles applied to the deleteIcon element if `color="primary"` and `variant="filled"`. */
+  deleteIconColorPrimary: string;
+  /** Styles applied to the deleteIcon element if `color="secondary"` and `variant="filled"`. */
+  deleteIconColorSecondary: string;
+  /** Styles applied to the deleteIcon element if `color="primary"` and `variant="outlined"`. */
+  deleteIconOutlinedColorPrimary: string;
+  /** Styles applied to the deleteIcon element if `color="secondary"` and `variant="outlined"`. */
+  deleteIconOutlinedColorSecondary: string;
+  /** Styles applied to the deleteIcon element if `color="primary"` and `variant="filled"`. */
+  deleteIconFilledColorPrimary: string;
+  /** Styles applied to the deleteIcon element if `color="secondary"` and `variant="filled"`. */
+  deleteIconFilledColorSecondary: string;
+  /** State class applied to the root element if keyboard focused. */
+  focusVisible: string;
+}
+
+export type ChipClassKey = keyof ChipClasses;
+
+export function getChipUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiChip', slot);
+}
+
+const chipClasses: ChipClasses = generateUtilityClasses('MuiChip', [
+  'root',
+  'sizeSmall',
+  'sizeMedium',
+  'colorError',
+  'colorInfo',
+  'colorPrimary',
+  'colorSecondary',
+  'colorSuccess',
+  'colorWarning',
+  'disabled',
+  'clickable',
+  'clickableColorPrimary',
+  'clickableColorSecondary',
+  'deletable',
+  'deletableColorPrimary',
+  'deletableColorSecondary',
+  'outlined',
+  'filled',
+  'outlinedPrimary',
+  'outlinedSecondary',
+  'filledPrimary',
+  'filledSecondary',
+  'avatar',
+  'avatarSmall',
+  'avatarMedium',
+  'avatarColorPrimary',
+  'avatarColorSecondary',
+  'icon',
+  'iconSmall',
+  'iconMedium',
+  'iconColorPrimary',
+  'iconColorSecondary',
+  'label',
+  'labelSmall',
+  'labelMedium',
+  'deleteIcon',
+  'deleteIconSmall',
+  'deleteIconMedium',
+  'deleteIconColorPrimary',
+  'deleteIconColorSecondary',
+  'deleteIconOutlinedColorPrimary',
+  'deleteIconOutlinedColorSecondary',
+  'deleteIconFilledColorPrimary',
+  'deleteIconFilledColorSecondary',
+  'focusVisible',
+]);
+
+export default chipClasses;

--- a/packages/mui-material-next/src/Chip/index.d.ts
+++ b/packages/mui-material-next/src/Chip/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './Chip';
+export * from './Chip';
+
+export { default as chipClasses } from './chipClasses';
+export * from './chipClasses';

--- a/packages/mui-material-next/src/Chip/index.js
+++ b/packages/mui-material-next/src/Chip/index.js
@@ -1,0 +1,5 @@
+'use client';
+export { default } from './Chip';
+
+export { default as chipClasses } from './chipClasses';
+export * from './chipClasses';

--- a/packages/mui-material-next/src/index.ts
+++ b/packages/mui-material-next/src/index.ts
@@ -2,6 +2,9 @@
 export { default as Button } from './Button';
 export * from './Button';
 
+export { default as Chip } from './Chip';
+export * from './Chip';
+
 export { default as Input } from './Input';
 
 export { default as Slider } from './Slider';

--- a/packages/mui-material-next/src/internal/svg-icons/Cancel.js
+++ b/packages/mui-material-next/src/internal/svg-icons/Cancel.js
@@ -1,0 +1,11 @@
+'use client';
+import * as React from 'react';
+import createSvgIcon from '../../utils/createSvgIcon';
+
+/**
+ * @ignore - internal component.
+ */
+export default createSvgIcon(
+  <path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z" />,
+  'Cancel',
+);

--- a/packages/mui-material-next/src/internal/svg-icons/CheckBox.js
+++ b/packages/mui-material-next/src/internal/svg-icons/CheckBox.js
@@ -1,0 +1,11 @@
+'use client';
+import * as React from 'react';
+import createSvgIcon from '../../utils/createSvgIcon';
+
+/**
+ * @ignore - internal component.
+ */
+export default createSvgIcon(
+  <path d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />,
+  'CheckBox',
+);

--- a/packages/mui-material-next/src/styles/index.ts
+++ b/packages/mui-material-next/src/styles/index.ts
@@ -6,3 +6,4 @@ export { default as styled } from './styled';
 export { default as defaultTheme } from './defaultTheme';
 export { default as shouldSkipGeneratingVar } from './shouldSkipGeneratingVar';
 export * from './CssVarsProvider';
+export { default as useThemeProps } from './useThemeProps';

--- a/packages/mui-material-next/src/styles/styled.ts
+++ b/packages/mui-material-next/src/styles/styled.ts
@@ -1,8 +1,11 @@
-import { createStyled } from '@mui/system';
+import { createStyled, shouldForwardProp } from '@mui/system';
 import { THEME_ID } from '@mui/material/styles';
 import { Theme } from './Theme.types';
 import defaultTheme from './defaultTheme';
 
-const styled = createStyled<Theme>({ defaultTheme, themeId: THEME_ID });
+export const rootShouldForwardProp = (prop: PropertyKey) =>
+  shouldForwardProp(prop) && prop !== 'classes';
+
+const styled = createStyled<Theme>({ defaultTheme, themeId: THEME_ID, rootShouldForwardProp });
 
 export default styled;

--- a/packages/mui-material-next/src/utils/createSvgIcon.tsx
+++ b/packages/mui-material-next/src/utils/createSvgIcon.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import SvgIcon from '@mui/material/SvgIcon';
+
+/**
+ * Private module reserved for @mui packages.
+ */
+export default function createSvgIcon(path: React.ReactNode, displayName: string): typeof SvgIcon {
+  // @ts-ignore internal component
+  function Component(props, ref) {
+    return (
+      <SvgIcon data-testid={`${displayName}Icon`} ref={ref} {...props}>
+        {path}
+      </SvgIcon>
+    );
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    // Need to set `displayName` on the inner component for React.memo.
+    // React prior to 16.14 ignores `displayName` on the wrapper.
+    Component.displayName = `${displayName}Icon`;
+  }
+
+  // @ts-ignore internal component
+  Component.muiName = SvgIcon.muiName;
+
+  // @ts-ignore internal component
+  return React.memo(React.forwardRef(Component));
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**Chip issue:** #38024
**Material You umbrella issue**: #29345

This PR copies the `Chip` component and its related utils from the `material` package:

- Copy `Chip` files and update imports
- Copy `createSvgIcon` util
- Copy `Cancel` and `CheckBox` internal icons
- Stop forwarding `classes` prop for root slots

This is what's required to get the `Chip` component to work and tests to pass. There are some things not addressed in this PR that will be fixed later:

- `Chip.js` file imports `ButtonBase` from `material`, this will be removed when refactoring to use `useButton` from base (tracked by [#38024](https://github.com/mui/material-ui/issues/38024))
- `Chip.test.js` imports the `Avatar` component from `material`, this will be changed when the `Avatar` component is migrated to `material-next`
- `Chip.test.js` imports `createTheme` from `material` to get the material default theme for [this test](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Chip/Chip.test.js#L634-L639), this will be removed when implementing Material You styles (tracked by [#38024](https://github.com/mui/material-ui/issues/38024))
- `createSvgIcon.tsx` imports the `SvgIcon` component from `material`, this will be changed when the `SvgIcon` component is migrated to `material-next`

Besides all the remaining work in https://github.com/mui/material-ui/issues/38024

I prefer to do it this way to keep the PRs smaller in size and scope, easier to review, and more atomical changes in git versions history.