### PR TITLE
[chip][material] Fix base cursor style to be "auto" not "default"

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -92,8 +92,6 @@ const ChipRoot = styled('div', {
       borderRadius: 32 / 2,
       whiteSpace: 'nowrap',
       transition: theme.transitions.create(['background-color', 'box-shadow']),
-      // label will inherit this from root, then `clickable` class overrides this for both
-      cursor: 'default',
       // We disable the focus ring for mouse, touch and keyboard users.
       outline: 0,
       textDecoration: 'none',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Found in: https://github.com/mui/material-ui/pull/38025

Following up on this comment: https://github.com/mui/material-ui/pull/38025#pullrequestreview-1536085015, update the Chip's `cursor` to be `auto` (which is the default value for the `cursor` property), that way the cursor type is determined given the chip's context. It will still be [set to `pointer` if `clickable` is true](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Chip/Chip.js#L202).

This brings it closer to Joy's implementation as well.

