### PR TITLE
[alert][Breadcrumbs] Fix inheritance message in docs

### DIFF
--- a/docs/pages/material-ui/api/alert-title.json
+++ b/docs/pages/material-ui/api/alert-title.json
@@ -21,7 +21,7 @@
   "muiName": "MuiAlertTitle",
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/AlertTitle/AlertTitle.js",
-  "inheritance": null,
+  "inheritance": { "component": "Typography", "pathname": "/material-ui/api/typography/" },
   "demos": "<ul><li><a href=\"/material-ui/react-alert/\">Alert</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/pages/material-ui/api/breadcrumbs.json
+++ b/docs/pages/material-ui/api/breadcrumbs.json
@@ -45,7 +45,7 @@
   "muiName": "MuiBreadcrumbs",
   "forwardsRefTo": "HTMLElement",
   "filename": "/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js",
-  "inheritance": null,
+  "inheritance": { "component": "Typography", "pathname": "/material-ui/api/typography/" },
   "demos": "<ul><li><a href=\"/material-ui/react-breadcrumbs/\">Breadcrumbs</a></li></ul>",
   "cssComponent": false
 }

--- a/packages/mui-material/src/AlertTitle/AlertTitle.d.ts
+++ b/packages/mui-material/src/AlertTitle/AlertTitle.d.ts
@@ -27,5 +27,6 @@ export interface AlertTitleProps extends StandardProps<React.HTMLAttributes<HTML
  * API:
  *
  * - [AlertTitle API](https://mui.com/material-ui/api/alert-title/)
+ * - inherits [Typography API](https://mui.com/material-ui/api/typography/)
  */
 export default function AlertTitle(props: AlertTitleProps): JSX.Element;

--- a/packages/mui-material/src/AlertTitle/AlertTitle.test.js
+++ b/packages/mui-material/src/AlertTitle/AlertTitle.test.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { createRenderer, describeConformance } from 'test/utils';
 import AlertTitle, { alertTitleClasses as classes } from '@mui/material/AlertTitle';
+import Typography from '@mui/material/Typography';
 
 describe('<AlertTitle />', () => {
   const { render } = createRenderer();
 
   describeConformance(<AlertTitle />, () => ({
     classes,
-    inheritComponent: 'div',
+    inheritComponent: Typography,
     render,
     muiName: 'MuiAlertTitle',
     refInstanceof: window.HTMLDivElement,

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.d.ts
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.d.ts
@@ -96,6 +96,7 @@ export interface BreadcrumbsTypeMap<
  * API:
  *
  * - [Breadcrumbs API](https://mui.com/material-ui/api/breadcrumbs/)
+ * - inherits [Typography API](https://mui.com/material-ui/api/typography/)
  */
 declare const Breadcrumbs: OverridableComponent<BreadcrumbsTypeMap>;
 

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.test.js
@@ -8,6 +8,7 @@ import {
   strictModeDoubleLoggingSuppressed,
 } from 'test/utils';
 import Breadcrumbs, { breadcrumbsClasses as classes } from '@mui/material/Breadcrumbs';
+import Typography from '@mui/material/Typography';
 import FirstPageIcon from '../internal/svg-icons/FirstPage';
 
 describe('<Breadcrumbs />', () => {
@@ -15,7 +16,7 @@ describe('<Breadcrumbs />', () => {
 
   describeConformance(<Breadcrumbs>Conformance?</Breadcrumbs>, () => ({
     classes,
-    inheritComponent: 'nav',
+    inheritComponent: Typography,
     render,
     muiName: 'MuiBreadcrumbs',
     refInstanceof: window.HTMLElement,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## This PR fixes following issues

`AlertTitle` is extended from `Typography` [here](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/AlertTitle/AlertTitle.js#L21) but docs doesn't mention that

`Breadcrumbs` is extended from `Typography` [here](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js#L27) but docs doesn't mention that

### Docs After fix
AlertTitle: https://deploy-preview-38876--material-ui.netlify.app/material-ui/api/alert-title/#props
Breadcrumbs: https://deploy-preview-38876--material-ui.netlify.app/material-ui/api/breadcrumbs/#props

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
