### PR TITLE
[chip][material-ui] Add cursor CSS property reset

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -92,6 +92,8 @@ const ChipRoot = styled('div', {
       borderRadius: 32 / 2,
       whiteSpace: 'nowrap',
       transition: theme.transitions.create(['background-color', 'box-shadow']),
+      // reset cursor explicitly in case ButtonBase is used
+      cursor: 'unset',
       // We disable the focus ring for mouse, touch and keyboard users.
       outline: 0,
       textDecoration: 'none',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/mui/material-ui/issues/38958

The `cursor: "default"` style was removed in https://github.com/mui/material-ui/pull/38076. This introduced https://github.com/mui/material-ui/issues/38958.

When `ButtonBase` is used (on clickable and deletable chips), this component's `cursor: "pointer"` is added. We must explicitly reset the `cursor` CSS property using the [`auto`](https://developer.mozilla.org/en-US/docs/Web/CSS/unset) keyword. This will set the property to its initial value while allowing it to be inherited from the parent, maintaining https://github.com/mui/material-ui/pull/38076 's original goal.

(`cursor: "pointer"` is [added back for clickable chips](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Chip/Chip.js#L200))
