### PR TITLE
[docs][material-ui] Update the basic Grid section copy

### DIFF
--- a/docs/data/material/components/grid/grid.md
+++ b/docs/data/material/components/grid/grid.md
@@ -40,7 +40,8 @@ Fluid grids use columns that scale and resize content. A fluid grid's layout can
 
 Column widths are integer values between 1 and 12; they apply at any breakpoint and indicate how many columns are occupied by the component.
 
-A value given to a breakpoint applies to all the other breakpoints wider than it (unless overridden, as you can read later in this page). For example, `xs={12}` sizes a component to occupy the full width of it's parent container width regardless of viewport size.
+A value passed to any given breakpoint also applies to all wider breakpoints (if they have no values explicitly defined).
+For example, `xs={12}` sizes a component to occupy the full width of its parent container, regardless of the viewport size.
 
 {{"demo": "BasicGrid.js", "bg": true}}
 


### PR DESCRIPTION
Current explanation is not correct and it's mixing actual browser window viewport term with the width of the parent grid container. Correct wording would be that `xs={12}`, when added on a Grid element, would cause it to take 12 spaces of it's parent. We do not and cannot assume that the parent Grid element has width set to `100vw`. If the parent Grid has width set to 300px, for example, setting xs={12} on it's child would mean that that child occupies full width of the parent. In this case, given that parent Grid doesn't have any paddings and margins, would mean that the Grid has a width of 300px.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
