### PR TITLE
[material-ui][docs] Fix SearchAppBar width on `sm` screens

### DIFF
--- a/docs/data/material/components/app-bar/SearchAppBar.js
+++ b/docs/data/material/components/app-bar/SearchAppBar.js
@@ -36,12 +36,12 @@ const SearchIconWrapper = styled('div')(({ theme }) => ({
 
 const StyledInputBase = styled(InputBase)(({ theme }) => ({
   color: 'inherit',
+  width: '100%',
   '& .MuiInputBase-input': {
     padding: theme.spacing(1, 1, 1, 0),
     // vertical padding + font size from searchIcon
     paddingLeft: `calc(1em + ${theme.spacing(4)})`,
     transition: theme.transitions.create('width'),
-    width: '100%',
     [theme.breakpoints.up('sm')]: {
       width: '12ch',
       '&:focus': {

--- a/docs/data/material/components/app-bar/SearchAppBar.tsx
+++ b/docs/data/material/components/app-bar/SearchAppBar.tsx
@@ -36,12 +36,12 @@ const SearchIconWrapper = styled('div')(({ theme }) => ({
 
 const StyledInputBase = styled(InputBase)(({ theme }) => ({
   color: 'inherit',
+  width: '100%',
   '& .MuiInputBase-input': {
     padding: theme.spacing(1, 1, 1, 0),
     // vertical padding + font size from searchIcon
     paddingLeft: `calc(1em + ${theme.spacing(4)})`,
     transition: theme.transitions.create('width'),
-    width: '100%',
     [theme.breakpoints.up('sm')]: {
       width: '12ch',
       '&:focus': {


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/40047.

`width: 100%` should be on the input root, not the input element. This makes it expand to the container, fixing https://github.com/mui/material-ui/issues/40047 (the input element will expand regardless as the input root is a flex container). In screens larger than `sm`, it doesn't expand as the parent's container's width is `auto`.

Before: https://mui.com/material-ui/react-app-bar/#app-bar-with-search-field
After: https://deploy-preview-40049--material-ui.netlify.app/material-ui/react-app-bar/#app-bar-with-search-field
