### PR TITLE
[material-ui][Rating] Fix the hover state when in a flex container

### DIFF
--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -89,6 +89,7 @@ const RatingRoot = styled('span', {
   color: '#faaf00',
   cursor: 'pointer',
   textAlign: 'left',
+  maxWidth: 'max-content',
   WebkitTapHighlightColor: 'transparent',
   [`&.${ratingClasses.disabled}`]: {
     opacity: (theme.vars || theme).palette.action.disabledOpacity,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

closes #40019

### Cause
Rating component has `display: "inline-flex"` but when it's wrapped with Stack or any other component with `display: "flex"` then it has `JustifyItems: "stretch"` by default which causes the Rating component to stretch over the parent component width.

### Change
I have provided the property `maxWidth: "max-content"` by default on RatingRoot.

#### Note:
This can also resolved by passing `alignSelf: "flex-start"` instead of `maxWidth: "max-content"` by default on RatingRoot but this may affect if the parent component has the display property "grid" or "flex" and wants to align items other then "start".
