### PR TITLE
[material-ui][Modal] Add the `mountNode` prop

### DIFF
--- a/packages/mui-material/src/Modal/Modal.d.ts
+++ b/packages/mui-material/src/Modal/Modal.d.ts
@@ -151,6 +151,7 @@ export interface ModalOwnProps {
    * @default false
    */
   keepMounted?: boolean;
+  mountNode?: PortalProps['container'];
   /**
    * Callback fired when the backdrop is clicked.
    * @deprecated Use the `onClose` prop with the `reason` argument to handle the `backdropClick` events.

--- a/packages/mui-material/src/Modal/Modal.js
+++ b/packages/mui-material/src/Modal/Modal.js
@@ -89,6 +89,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
     disableScrollLock = false,
     hideBackdrop = false,
     keepMounted = false,
+    mountNode,
     onBackdropClick,
     onClose,
     onTransitionEnter,
@@ -196,7 +197,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
   }
 
   return (
-    <Portal ref={portalRef} container={container} disablePortal={disablePortal}>
+    <Portal ref={portalRef} container={mountNode ?? container} disablePortal={disablePortal}>
       {/*
        * Marking an element with the role presentation indicates to assistive technology
        * that this element should be ignored; it exists to support the web application and
@@ -356,6 +357,10 @@ Modal.propTypes /* remove-proptypes */ = {
    * @default false
    */
   keepMounted: PropTypes.bool,
+  mountNode: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    HTMLElementType,
+    PropTypes.func,
+  ]),
   /**
    * Callback fired when the backdrop is clicked.
    * @deprecated Use the `onClose` prop with the `reason` argument to handle the `backdropClick` events.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

fixes #39636 

_I want to know your thoughts about this approach before I add tests and docs._

Currently the [suggested way](https://mui.com/material-ui/guides/shadow-dom/) to add a Dialog inside a shadow root is to use `props.container`, but I'm thinking a new input is needed on Modal to fix #39636, something like `props.mountNode` to differentiate between
- the container where the Portal is created; and
- the container that is used in `ModalManager` to handle styling

Because a Dialog can be _inside a container or use `document.body`_, additionally it can be _inside a Shadow DOM or not_. These two properties are independent of each other and one cannot be inferred from the other.

To use this new prop to add a dialog in a Shadow DOM, follow the [MUI docs](https://mui.com/material-ui/guides/shadow-dom/) but instead of setting `container` set `mountNode`, this will keep using `container` (which is `document.body` by default) in `ModalManager` and `shadowRootElement` to create the Portal:
```ts
const theme = createTheme({
  components: {
    MuiModal: {
      defaultProps: {
        mountNode: shadowRootElement,
      },
    },
  },
});
```