### PR TITLE
[material-next][Option] Add Option component

### DIFF
--- a/packages/mui-material-next/src/Option/Option.spec.tsx
+++ b/packages/mui-material-next/src/Option/Option.spec.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { expectType } from '@mui/types';
+import Option, { OptionProps } from '@mui/material-next/Option';
+import Link from '@mui/material/Link';
+
+const CustomComponent: React.FC<{ stringProp: string; numberProp: number }> =
+  function CustomComponent() {
+    return <div />;
+  };
+
+const props1: OptionProps<'div'> = {
+  component: 'div',
+  onChange: (event) => {
+    expectType<React.FormEvent<HTMLDivElement>, typeof event>(event);
+  },
+};
+
+const props2: OptionProps = {
+  onChange: (event) => {
+    expectType<React.FormEvent<HTMLLIElement>, typeof event>(event);
+  },
+};
+
+const props3: OptionProps<typeof CustomComponent> = {
+  component: CustomComponent,
+  stringProp: '2',
+  numberProp: 2,
+};
+
+const props4: OptionProps<typeof CustomComponent> = {
+  component: CustomComponent,
+  stringProp: '2',
+  numberProp: 2,
+  // @ts-expect-error CustomComponent does not accept incorrectProp
+  incorrectProp: 3,
+};
+
+// @ts-expect-error missing props
+const props5: OptionProps<typeof CustomComponent> = {
+  component: CustomComponent,
+};
+
+const TestComponent = () => {
+  return (
+    <React.Fragment>
+      <Option />
+      <Option component={'a'} href="/test" />
+
+      <Option component={CustomComponent} stringProp="s" numberProp={1} />
+      {
+        // @ts-expect-error missing props
+        <Option component={CustomComponent} />
+      }
+      <Option
+        onChange={(event) => {
+          expectType<React.FormEvent<HTMLLIElement>, typeof event>(event);
+        }}
+      />
+      <Option
+        component="span"
+        onChange={(event) => {
+          expectType<React.FormEvent<HTMLSpanElement>, typeof event>(event);
+        }}
+      />
+      <Option component={Link} />
+    </React.Fragment>
+  );
+};

--- a/packages/mui-material-next/src/Option/Option.test.tsx
+++ b/packages/mui-material-next/src/Option/Option.test.tsx
@@ -1,0 +1,222 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import {
+  act,
+  describeConformance,
+  createRenderer,
+  fireEvent,
+  screen,
+} from '@mui-internal/test-utils';
+import { MenuProvider } from '@mui/base/useMenu';
+import Option, { optionClasses as classes } from '@mui/material-next/Option';
+import Menu from '@mui/material-next/Menu';
+import ButtonBase from '@mui/material-next/ButtonBase';
+
+const dummyGetItemState = () => ({
+  disabled: false,
+  highlighted: false,
+  selected: false,
+  index: 0,
+  focusable: true,
+});
+
+const testContext = {
+  dispatch: () => {},
+  getItemIndex: () => 0,
+  getItemProps: () => ({}),
+  getItemState: dummyGetItemState,
+  open: false,
+  registerHighlightChangeHandler: () => () => {},
+  registerItem: () => ({ id: '', deregister: () => {} }),
+  registerSelectionChangeHandler: () => () => {},
+  totalSubitemCount: 0,
+};
+
+describe('<Option />', () => {
+  const { render } = createRenderer({ clock: 'fake' });
+
+  // afterEach(() => {
+  //   document.getElementsByTagName('html')[0].innerHTML = '';
+  // });
+
+  describeConformance(<Option data-testid="option">1</Option>, () => ({
+    render: (node) => {
+      return render(<MenuProvider value={testContext}>{node}</MenuProvider>);
+    },
+    wrapMount: (mount) => (node) => mount(<MenuProvider value={testContext}>{node}</MenuProvider>),
+    classes,
+    inheritComponent: ButtonBase,
+    refInstanceof: window.HTMLLIElement,
+    testComponentPropWith: 'a',
+    muiName: 'MuiOption',
+    testVariantProps: { dense: true },
+    skip: ['componentsProp', 'reactTestRenderer'],
+  }));
+
+  const renderWithMenu = (node: React.ReactNode) => {
+    function Test() {
+      return (
+        <Menu anchorEl={document.createElement('div')} open>
+          {node}
+        </Menu>
+      );
+    }
+
+    return render(<Test />);
+  };
+
+  it('should render a focusable option', () => {
+    renderWithMenu(<Option />);
+    const option = screen.getByRole('option');
+
+    expect(option).to.have.property('tabIndex', 0);
+  });
+
+  it('has a ripple when clicked', () => {
+    renderWithMenu(<Option TouchRippleProps={{ classes: { rippleVisible: 'ripple-visible' } }} />);
+    const option = screen.getByRole('option');
+
+    // ripple starts on mousedown
+    fireEvent.mouseDown(option);
+
+    expect(option.querySelectorAll('.ripple-visible')).to.have.length(1);
+  });
+
+  it('should render with the selected class but not aria-selected when `selected`', () => {
+    renderWithMenu(<Option selected />);
+    const option = screen.getByRole('option');
+
+    expect(option).to.have.class(classes.selected);
+    expect(option).not.to.have.attribute('aria-selected');
+  });
+
+  it('can have a role of option', () => {
+    renderWithMenu(<Option role="option" aria-selected={false} />);
+
+    expect(screen.queryByRole('option')).not.to.equal(null);
+  });
+
+  describe('event callbacks', () => {
+    const events: Array<keyof typeof fireEvent> = [
+      'click',
+      'mouseDown',
+      'mouseEnter',
+      'mouseLeave',
+      'mouseUp',
+      'touchEnd',
+    ];
+
+    events.forEach((eventName) => {
+      it(`should fire ${eventName}`, () => {
+        const handlerName = `on${eventName[0].toUpperCase()}${eventName.slice(1)}`;
+        const handler = spy();
+        renderWithMenu(<Option {...{ [handlerName]: handler }} />);
+
+        fireEvent[eventName](screen.getByRole('option'));
+
+        expect(handler.callCount).to.equal(1);
+      });
+    });
+
+    it(`should fire focus, keydown, keyup and blur`, () => {
+      const handleFocus = spy();
+      const handleKeyDown = spy();
+      const handleKeyUp = spy();
+      const handleBlur = spy();
+      renderWithMenu(
+        <Option
+          onFocus={handleFocus}
+          onKeyDown={handleKeyDown}
+          onKeyUp={handleKeyUp}
+          onBlur={handleBlur}
+        />,
+      );
+      const option = screen.getByRole('option');
+
+      act(() => {
+        option.focus();
+      });
+
+      expect(handleFocus.callCount).to.equal(1);
+
+      fireEvent.keyDown(option);
+
+      expect(handleKeyDown.callCount).to.equal(1);
+
+      fireEvent.keyUp(option);
+
+      expect(handleKeyUp.callCount).to.equal(1);
+
+      expect(handleKeyDown.callCount).to.equal(1);
+    });
+
+    it('should fire onTouchStart', function touchStartTest() {
+      // only run in supported browsers
+      if (typeof Touch === 'undefined') {
+        this.skip();
+      }
+
+      const handleTouchStart = spy();
+      renderWithMenu(<Option onTouchStart={handleTouchStart} />);
+      const option = screen.getByRole('option');
+
+      const touch = new Touch({ identifier: 0, target: option, clientX: 0, clientY: 0 });
+      fireEvent.touchStart(option, { touches: [touch] });
+
+      expect(handleTouchStart.callCount).to.equal(1);
+    });
+  });
+
+  it('can be disabled', () => {
+    renderWithMenu(<Option disabled />);
+    const option = screen.getByRole('option');
+
+    expect(option).to.have.attribute('aria-disabled', 'true');
+  });
+
+  it('can be selected', () => {
+    renderWithMenu(<Option selected />);
+    const option = screen.getByRole('option');
+
+    expect(option).to.have.class(classes.selected);
+  });
+
+  it('prop: disableGutters', () => {
+    const { rerender } = render(
+      <Menu anchorEl={document.createElement('div')} open>
+        <Option />
+      </Menu>,
+    );
+    const option = screen.getByRole('option');
+
+    expect(option).to.have.class(classes.gutters);
+
+    rerender(
+      <Menu anchorEl={document.createElement('div')} open>
+        <Option disableGutters />
+      </Menu>,
+    );
+
+    expect(option).not.to.have.class(classes.gutters);
+  });
+
+  // TODO v6: Need to be re-structured now that we don't use the List component internally
+  // describe('context: dense', () => {
+  //   it.skip('should forward the context', () => {
+  //     let context = null;
+  //     const { setProps } = render(
+  //       <Option>
+  //         <ListContext.Consumer>
+  //           {(options) => {
+  //             context = options;
+  //           }}
+  //         </ListContext.Consumer>
+  //       </Option>,
+  //     );
+  //     expect(context).to.have.property('dense', false);
+  //     setProps({ dense: true });
+  //     expect(context).to.have.property('dense', true);
+  //   });
+  // });
+});

--- a/packages/mui-material-next/src/Option/Option.tsx
+++ b/packages/mui-material-next/src/Option/Option.tsx
@@ -1,0 +1,321 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { OverridableComponent } from '@mui/types';
+import { alpha } from '@mui/system';
+import {
+  unstable_useEnhancedEffect as useEnhancedEffect,
+  unstable_useForkRef as useForkRef,
+} from '@mui/utils';
+import { useSlotProps } from '@mui/base/utils';
+import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
+import { useMenuItem } from '@mui/base/useMenuItem';
+// TODO v6: Replace with @mui/material-next when the List components are available
+import ListContext from '@mui/material/List/ListContext';
+import { listItemIconClasses } from '@mui/material/ListItemIcon';
+import { listItemTextClasses } from '@mui/material/ListItemText';
+import { styled, useThemeProps, rootShouldForwardProp } from '../styles';
+import ButtonBase from '../ButtonBase';
+import { dividerClasses } from '../Divider';
+import { OptionProps, OptionOwnerState, OptionTypeMap } from './Option.types';
+import optionClasses, { getOptionUtilityClass } from './optionClasses';
+
+const overridesResolver = (props: OptionProps & { ownerState: OptionOwnerState }, styles: any) => {
+  const { ownerState } = props;
+
+  return [
+    styles.root,
+    ownerState.dense && styles.dense,
+    ownerState.divider && styles.divider,
+    !ownerState.disableGutters && styles.gutters,
+  ];
+};
+
+const useUtilityClasses = (ownerState: OptionOwnerState) => {
+  const { disabled, dense, divider, disableGutters, selected, classes } = ownerState;
+  const slots = {
+    root: [
+      'root',
+      dense && 'dense',
+      disabled && 'disabled',
+      !disableGutters && 'gutters',
+      divider && 'divider',
+      selected && 'selected',
+    ],
+  };
+
+  const composedClasses = composeClasses(slots, getOptionUtilityClass, classes);
+
+  return {
+    ...classes,
+    ...composedClasses,
+  };
+};
+
+const OptionRoot = styled(ButtonBase, {
+  shouldForwardProp: (prop: string) => rootShouldForwardProp(prop) || prop === 'classes',
+  name: 'MuiOption',
+  slot: 'Root',
+  overridesResolver,
+})<{ ownerState: OptionOwnerState }>(({ theme, ownerState }) => ({
+  ...theme.typography.body1,
+  display: 'flex',
+  justifyContent: 'flex-start',
+  alignItems: 'center',
+  position: 'relative',
+  textDecoration: 'none',
+  minHeight: 48,
+  paddingTop: 6,
+  paddingBottom: 6,
+  boxSizing: 'border-box',
+  whiteSpace: 'nowrap',
+  ...(!ownerState.disableGutters && {
+    paddingLeft: 16,
+    paddingRight: 16,
+  }),
+  ...(ownerState.divider && {
+    borderBottom: `1px solid ${(theme.vars || theme).palette.divider}`,
+    backgroundClip: 'padding-box',
+  }),
+  '&:hover': {
+    textDecoration: 'none',
+    backgroundColor: (theme.vars || theme).palette.action.hover,
+    // Reset on touch devices, it doesn't add specificity
+    '@media (hover: none)': {
+      backgroundColor: 'transparent',
+    },
+  },
+  [`&.${optionClasses.selected}`]: {
+    backgroundColor: theme.vars
+      ? `rgba(${theme.vars.palette.primary.mainChannel} / ${theme.vars.palette.action.selectedOpacity})`
+      : alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
+    [`&.${optionClasses.focusVisible}`]: {
+      backgroundColor: theme.vars
+        ? `rgba(${theme.vars.palette.primary.mainChannel} / calc(${theme.vars.palette.action.selectedOpacity} + ${theme.vars.palette.action.focusOpacity}))`
+        : alpha(
+            theme.palette.primary.main,
+            theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
+          ),
+    },
+  },
+  [`&.${optionClasses.selected}:hover`]: {
+    backgroundColor: theme.vars
+      ? `rgba(${theme.vars.palette.primary.mainChannel} / calc(${theme.vars.palette.action.selectedOpacity} + ${theme.vars.palette.action.hoverOpacity}))`
+      : alpha(
+          theme.palette.primary.main,
+          theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
+        ),
+    // Reset on touch devices, it doesn't add specificity
+    '@media (hover: none)': {
+      backgroundColor: theme.vars
+        ? `rgba(${theme.vars.palette.primary.mainChannel} / ${theme.vars.palette.action.selectedOpacity})`
+        : alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
+    },
+  },
+  [`&.${optionClasses.focusVisible}`]: {
+    backgroundColor: (theme.vars || theme).palette.action.focus,
+  },
+  [`&.${optionClasses.disabled}`]: {
+    opacity: (theme.vars || theme).palette.action.disabledOpacity,
+  },
+  [`& + .${dividerClasses.root}`]: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  },
+  [`& + .${dividerClasses.inset}`]: {
+    marginLeft: 52,
+  },
+  [`& .${listItemTextClasses.root}`]: {
+    marginTop: 0,
+    marginBottom: 0,
+  },
+  [`& .${listItemTextClasses.inset}`]: {
+    paddingLeft: 36,
+  },
+  [`& .${listItemIconClasses.root}`]: {
+    minWidth: 36,
+  },
+  ...(!ownerState.dense && {
+    [theme.breakpoints.up('sm')]: {
+      minHeight: 'auto',
+    },
+  }),
+  ...(ownerState.dense && {
+    minHeight: 32, // https://m2.material.io/components/menus#specs > Dense
+    paddingTop: 4,
+    paddingBottom: 4,
+    ...theme.typography.body2,
+    [`& .${listItemIconClasses.root} svg`]: {
+      fontSize: '1.25rem',
+    },
+  }),
+}));
+
+const Option = React.forwardRef(function Option<RootComponentType extends React.ElementType>(
+  inProps: OptionProps<RootComponentType>,
+  ref: React.ForwardedRef<Element>,
+) {
+  const props = useThemeProps({ props: inProps, name: 'MuiOption' });
+  const {
+    autoFocus = false,
+    component = 'li',
+    dense = false,
+    divider = false,
+    disableGutters = false,
+    focusVisibleClassName,
+    role = 'option',
+    className,
+    disabled: disabledProp,
+    label: labelProp,
+    ...other
+  } = props;
+
+  const context = React.useContext(ListContext);
+  const childContext = React.useMemo(
+    () => ({
+      dense: dense || context.dense || false,
+      disableGutters,
+    }),
+    [context.dense, dense, disableGutters],
+  );
+
+  const optionRef = React.useRef<HTMLElement | null>(null);
+  const handleRef = useForkRef(optionRef, ref);
+
+  const { getRootProps, disabled, focusVisible, highlighted } = useMenuItem({
+    disabled: disabledProp,
+    rootRef: handleRef,
+    label: labelProp,
+  });
+
+  useEnhancedEffect(() => {
+    if (autoFocus) {
+      if (optionRef.current) {
+        optionRef.current.focus();
+      } else if (process.env.NODE_ENV !== 'production') {
+        console.error(
+          'MUI: Unable to set focus to an Option whose component has not been rendered.',
+        );
+      }
+    }
+  }, [autoFocus]);
+
+  const ownerState = {
+    ...props,
+    dense: childContext.dense,
+    divider,
+    disableGutters,
+    disabled,
+    focusVisible,
+    highlighted,
+  };
+
+  const classes = useUtilityClasses(props);
+
+  const Root = /* slots.root ?? */ OptionRoot;
+  const rootProps = useSlotProps({
+    elementType: Root,
+    getSlotProps: getRootProps,
+    // TODO v6: Add support for slotProps.root
+    externalSlotProps: {},
+    externalForwardedProps: other,
+    additionalProps: {
+      role,
+      component,
+      focusVisibleClassName: clsx(classes.focusVisible, focusVisibleClassName),
+      classes,
+    },
+    className: clsx(classes.root, className),
+    ownerState,
+  });
+  return (
+    <ListContext.Provider value={childContext}>
+      <OptionRoot {...rootProps} />
+    </ListContext.Provider>
+  );
+}) as OverridableComponent<OptionTypeMap>;
+
+Option.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * If `true`, the list item is focused during the first mount.
+   * Focus will also be triggered if the value changes from false to true.
+   * @default false
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * The content of the component.
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * If `true`, compact vertical padding designed for keyboard and mouse input is used.
+   * The prop defaults to the value inherited from the parent Select component.
+   * @default false
+   */
+  dense: PropTypes.bool,
+  /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * If `true`, the left and right padding is removed.
+   * @default false
+   */
+  disableGutters: PropTypes.bool,
+  /**
+   * If `true`, a 1px light border is added to the bottom of the option.
+   * @default false
+   */
+  divider: PropTypes.bool,
+  /**
+   * This prop can help identify which element has keyboard focus.
+   * The class name will be applied when the element gains the focus through keyboard interaction.
+   * It's a polyfill for the [CSS :focus-visible selector](https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo).
+   * The rationale for using this feature [is explained here](https://github.com/WICG/focus-visible/blob/HEAD/explainer.md).
+   * A [polyfill can be used](https://github.com/WICG/focus-visible) to apply a `focus-visible` class to other components
+   * if needed.
+   */
+  focusVisibleClassName: PropTypes.string,
+  /**
+   * A text representation of the option's content.
+   * Used for keyboard text navigation matching.
+   */
+  label: PropTypes.string,
+  /**
+   * @ignore
+   */
+  role: PropTypes /* @typescript-to-proptypes-ignore */.string,
+  /**
+   * If `true`, the component is selected.
+   * @default false
+   */
+  selected: PropTypes.bool,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+} as any;
+
+export default Option;

--- a/packages/mui-material-next/src/Option/Option.types.ts
+++ b/packages/mui-material-next/src/Option/Option.types.ts
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { OverrideProps } from '@mui/types';
+import { SxProps } from '@mui/system';
+import { ExtendButtonBaseTypeMap } from '@mui/material/ButtonBase';
+import { Theme } from '@mui/material/styles';
+import { OptionClasses } from './optionClasses';
+
+export interface OptionOwnProps {
+  /**
+   * If `true`, the list item is focused during the first mount.
+   * Focus will also be triggered if the value changes from false to true.
+   * @default false
+   */
+  autoFocus?: boolean;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<OptionClasses>;
+  /**
+   * If `true`, compact vertical padding designed for keyboard and mouse input is used.
+   * The prop defaults to the value inherited from the parent Select component.
+   * @default false
+   */
+  dense?: boolean;
+  /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * If `true`, the left and right padding is removed.
+   * @default false
+   */
+  disableGutters?: boolean;
+  /**
+   * If `true`, a 1px light border is added to the bottom of the option.
+   * @default false
+   */
+  divider?: boolean;
+  /**
+   * A text representation of the option's content.
+   * Used for keyboard text navigation matching.
+   */
+  label?: string;
+  /**
+   * If `true`, the component is selected.
+   * @default false
+   */
+  selected?: boolean;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+}
+
+export type OptionTypeMap<
+  AdditionalProps = {},
+  RootComponent extends React.ElementType = 'li',
+> = ExtendButtonBaseTypeMap<{
+  props: AdditionalProps & OptionOwnProps;
+  defaultComponent: RootComponent;
+}>;
+
+export type OptionProps<
+  RootComponent extends React.ElementType = OptionTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<OptionTypeMap<AdditionalProps, RootComponent>, RootComponent> & {
+  component?: React.ElementType;
+};
+
+export interface OptionOwnerState extends OptionProps {}

--- a/packages/mui-material-next/src/Option/index.ts
+++ b/packages/mui-material-next/src/Option/index.ts
@@ -1,0 +1,7 @@
+'use client';
+export { default } from './Option';
+
+export * from './Option.types';
+
+export * from './optionClasses';
+export { default as optionClasses } from './optionClasses';

--- a/packages/mui-material-next/src/Option/optionClasses.ts
+++ b/packages/mui-material-next/src/Option/optionClasses.ts
@@ -26,7 +26,7 @@ export function getOptionUtilityClass(slot: string): string {
   return generateUtilityClass('MuiOption', slot);
 }
 
-const menuItemClasses: OptionClasses = generateUtilityClasses('MuiOption', [
+const optionClasses: OptionClasses = generateUtilityClasses('MuiOption', [
   'root',
   'focusVisible',
   'dense',
@@ -36,4 +36,4 @@ const menuItemClasses: OptionClasses = generateUtilityClasses('MuiOption', [
   'selected',
 ]);
 
-export default menuItemClasses;
+export default optionClasses;

--- a/packages/mui-material-next/src/Option/optionClasses.ts
+++ b/packages/mui-material-next/src/Option/optionClasses.ts
@@ -1,0 +1,39 @@
+import {
+  unstable_generateUtilityClasses as generateUtilityClasses,
+  unstable_generateUtilityClass as generateUtilityClass,
+} from '@mui/utils';
+
+export interface OptionClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** State class applied to the root element if keyboard focused. */
+  focusVisible: string;
+  /** Styles applied to the root element if dense. */
+  dense: string;
+  /** State class applied to the root element if `disabled={true}`. */
+  disabled: string;
+  /** Styles applied to the root element if `divider={true}`. */
+  divider: string;
+  /** Styles applied to the inner `component` element unless `disableGutters={true}`. */
+  gutters: string;
+  /** State class applied to the root element if `selected={true}`. */
+  selected: string;
+}
+
+export type OptionClassKey = keyof OptionClasses;
+
+export function getOptionUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiOption', slot);
+}
+
+const menuItemClasses: OptionClasses = generateUtilityClasses('MuiOption', [
+  'root',
+  'focusVisible',
+  'dense',
+  'disabled',
+  'divider',
+  'gutters',
+  'selected',
+]);
+
+export default menuItemClasses;

--- a/packages/mui-material-next/src/index.ts
+++ b/packages/mui-material-next/src/index.ts
@@ -44,6 +44,9 @@ export * from './Menu';
 export { default as MenuItem } from './MenuItem';
 export * from './MenuItem';
 
+export { default as Option } from './Option';
+export * from './Option';
+
 export { default as OutlinedInput } from './OutlinedInput';
 export * from './OutlinedInput';
 


### PR DESCRIPTION
Add the `Option` component, copied from `MenuItem`. This PR only copies the component and does minimal changes to get tests passing. The changes required to make it work with `Select` will be included on #40210. This PR's purpose is that #40210 diff is more significant and easier to review.
