### PR TITLE
[infra] Add support donation button

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -59,3 +59,9 @@ body:
           Output from `npx @mui/envinfo` goes here.
         ```
         </details>
+  - type: markdown
+    attributes:
+      value: |
+        ## :heart: Love Material UI?
+
+        Consider donating $ to sustain our open-source work and non-profit: [https://opencollective.com/mui-org](https://opencollective.com/mui-org).

--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -64,4 +64,4 @@ body:
       value: |
         ## :heart: Love Material UI?
 
-        Consider donating $ to sustain our open-source work and non-profit: [https://opencollective.com/mui-org](https://opencollective.com/mui-org).
+        Consider donating $10 to sustain our open-source work: [https://opencollective.com/mui-org](https://opencollective.com/mui-org).

--- a/.github/ISSUE_TEMPLATE/2.feature.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature.yml
@@ -32,3 +32,9 @@ body:
     attributes:
       label: Motivation
       description: What are you trying to accomplish? Providing context helps us come up with a solution that is more useful in the real world.
+  - type: markdown
+    attributes:
+      value: |
+        ## :heart: Love Material UI?
+
+        Consider donating $ to sustain our open-source work and non-profit: [https://opencollective.com/mui-org](https://opencollective.com/mui-org).

--- a/.github/ISSUE_TEMPLATE/2.feature.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature.yml
@@ -37,4 +37,4 @@ body:
       value: |
         ## :heart: Love Material UI?
 
-        Consider donating $ to sustain our open-source work and non-profit: [https://opencollective.com/mui-org](https://opencollective.com/mui-org).
+        Consider donating $10 to sustain our open-source work: [https://opencollective.com/mui-org](https://opencollective.com/mui-org).

--- a/.github/ISSUE_TEMPLATE/4.docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/4.docs-feedback.yml
@@ -47,4 +47,4 @@ body:
       value: |
         ## :heart: Love Material UI?
 
-        Consider donating $ to sustain our open-source work and non-profit: [https://opencollective.com/mui-org](https://opencollective.com/mui-org).
+        Consider donating $10 to sustain our open-source work: [https://opencollective.com/mui-org](https://opencollective.com/mui-org).

--- a/.github/ISSUE_TEMPLATE/4.docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/4.docs-feedback.yml
@@ -42,3 +42,9 @@ body:
     attributes:
       label: Context
       description: What are you trying to accomplish? Providing context helps us come up with a solution that is more useful in the real world.
+  - type: markdown
+    attributes:
+      value: |
+        ## :heart: Love Material UI?
+
+        Consider donating $ to sustain our open-source work and non-profit: [https://opencollective.com/mui-org](https://opencollective.com/mui-org).


### PR DESCRIPTION
I saw this from https://github.com/badges/shields/issues/new?assignees=&labels=service-badge&projects=&template=3_Badge_request.yml

<img width="927" alt="SCR-20240602-riur" src="https://github.com/mui/material-ui/assets/3165635/c1090a16-3db6-4350-8198-7ba0983fadd0">

I wonder if this would make sense in our context.

Preview: https://github.com/oliviertassinari/material-ui/blob/donation-footer/.github/ISSUE_TEMPLATE/1.bug.yml