### PR TITLE
[Button] Apply default size styles

### DIFF
--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -215,7 +215,6 @@ const ButtonRoot = styled(ButtonBase, {
       {
         props: {
           size: 'small',
-          variant: 'text',
         },
         style: {
           padding: '4px 5px',
@@ -225,7 +224,6 @@ const ButtonRoot = styled(ButtonBase, {
       {
         props: {
           size: 'large',
-          variant: 'text',
         },
         style: {
           padding: '8px 11px',


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/32427

This PR applies the sizes for the default variant as a base style. This way adding custom variants won't break the size prop.