### PR TITLE
[code-infra] Fix benchmark package regression

### DIFF
--- a/benchmark/browser/webpack.config.js
+++ b/benchmark/browser/webpack.config.js
@@ -8,7 +8,7 @@ process.env.NODE_ENV = 'production';
 
 module.exports = {
   context: workspaceRoot,
-  entry: 'benchmark/browser/index.js',
+  entry: './benchmark/browser/index.js',
   mode: 'production',
   output: {
     path: path.join(__dirname, 'dist'),

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -11,6 +11,7 @@
     "server:system": "cd ../ && cross-env NODE_ENV=production BABEL_ENV=benchmark babel-node benchmark/server/scenarios/system.js --inspect=0.0.0.0:9229 --extensions \".tsx,.ts,.js\""
   },
   "dependencies": {
+    "@babel/runtime": "^7.24.6",
     "@chakra-ui/system": "^2.6.2",
     "@emotion/react": "^11.11.4",
     "@emotion/server": "^11.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,6 +469,9 @@ importers:
 
   benchmark:
     dependencies:
+      '@babel/runtime':
+        specifier: ^7.24.6
+        version: 7.24.6
       '@chakra-ui/system':
         specifier: ^2.6.2
         version: 2.6.2(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(react@18.2.0)


### PR DESCRIPTION
The benchmark command threw errors, the entry point must be a relative url or it will be treated as a bare module specifier. It also couldn't resolve the babel helpers. Likely introduced by the pnpm migration.