### PR TITLE
[docs][LinearProgress] Fix buffer demo

### DIFF
--- a/docs/data/material/components/progress/LinearBuffer.js
+++ b/docs/data/material/components/progress/LinearBuffer.js
@@ -6,16 +6,6 @@ export default function LinearBuffer() {
   const [progress, setProgress] = React.useState(0);
   const [buffer, setBuffer] = React.useState(10);
 
-  const bufferRef = React.useRef(() => {});
-  React.useEffect(() => {
-    bufferRef.current = () => {
-      if (buffer < 100) {
-        const newBuffer = buffer + 1 + Math.random() * 10;
-        setBuffer(newBuffer > 100 ? 100 : newBuffer);
-      }
-    };
-  });
-
   const progressRef = React.useRef(() => {});
   React.useEffect(() => {
     progressRef.current = () => {
@@ -24,19 +14,13 @@ export default function LinearBuffer() {
         setBuffer(10);
       } else {
         setProgress(progress + 1);
+        if (buffer < 100 && progress % 5 === 0) {
+          const newBuffer = buffer + 1 + Math.random() * 10;
+          setBuffer(newBuffer > 100 ? 100 : newBuffer);
+        }
       }
     };
   });
-
-  React.useEffect(() => {
-    const timer = setInterval(() => {
-      bufferRef.current();
-    }, 500);
-
-    return () => {
-      clearInterval(timer);
-    };
-  }, []);
 
   React.useEffect(() => {
     const timer = setInterval(() => {

--- a/docs/data/material/components/progress/LinearBuffer.tsx
+++ b/docs/data/material/components/progress/LinearBuffer.tsx
@@ -6,16 +6,6 @@ export default function LinearBuffer() {
   const [progress, setProgress] = React.useState(0);
   const [buffer, setBuffer] = React.useState(10);
 
-  const bufferRef = React.useRef(() => {});
-  React.useEffect(() => {
-    bufferRef.current = () => {
-      if (buffer < 100) {
-        const newBuffer = buffer + 1 + Math.random() * 10;
-        setBuffer(newBuffer > 100 ? 100 : newBuffer);
-      }
-    };
-  });
-
   const progressRef = React.useRef(() => {});
   React.useEffect(() => {
     progressRef.current = () => {
@@ -24,19 +14,13 @@ export default function LinearBuffer() {
         setBuffer(10);
       } else {
         setProgress(progress + 1);
+        if (buffer < 100 && progress % 5 === 0) {
+          const newBuffer = buffer + 1 + Math.random() * 10;
+          setBuffer(newBuffer > 100 ? 100 : newBuffer);
+        }
       }
     };
   });
-
-  React.useEffect(() => {
-    const timer = setInterval(() => {
-      bufferRef.current();
-    }, 500);
-
-    return () => {
-      clearInterval(timer);
-    };
-  }, []);
 
   React.useEffect(() => {
     const timer = setInterval(() => {


### PR DESCRIPTION
During [this internal discussion](https://mui-org.slack.com/archives/C02P87NQLJC/p1720199430192089?thread_ts=1720106797.509159&cid=C02P87NQLJC) I noticed that the LinearProgress buffer demo doesn't behave how one might expect (steady progress, erratic buffering), so this fixes that, and a couple of bugs where values can go out of range.

There's an argument (see above discussion) that it shouldn't be a progress indicator to begin with, and that the animated track is ugly and distracting, and no longer to spec, but those are separate issues altogether.

As it's just scratching an itch, I've added the "priority: low" label, but it shouldn't be more than five minutes of someone's time to review.

https://deploy-preview-42858--material-ui.netlify.app/material-ui/react-progress/#linear-buffer