### PR TITLE
[fix] Allow coloured `svgIcon` to be hidden by loading indicator

### DIFF
--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -66,6 +66,9 @@ const LoadingButtonRoot = styled(Button, {
     [`&.${loadingButtonClasses.loading}`]: {
       color: 'transparent',
     },
+    [`& .${loadingButtonClasses.loading} .MuiButton-icon path`]: {
+    fill: 'transparent'
+  },
   }),
   ...(ownerState.loadingPosition === 'start' &&
     ownerState.fullWidth && {

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -67,8 +67,8 @@ const LoadingButtonRoot = styled(Button, {
       color: 'transparent',
     },
     [`& .${loadingButtonClasses.loading} .MuiButton-icon path`]: {
-    fill: 'transparent'
-  },
+      fill: 'transparent',
+    },
   }),
   ...(ownerState.loadingPosition === 'start' &&
     ownerState.fullWidth && {

--- a/packages/mui-material/src/Skeleton/Skeleton.js
+++ b/packages/mui-material/src/Skeleton/Skeleton.js
@@ -88,9 +88,9 @@ const SkeletonRoot = styled('span', {
         height: 'auto',
         transformOrigin: '0 55%',
         transform: 'scale(1, 0.60)',
-        borderRadius: `${radiusValue}${radiusUnit}/${
-          Math.round((radiusValue / 0.6) * 10) / 10
-        }${radiusUnit}`,
+        borderRadius: `${radiusValue}${radiusUnit}/${Math.round((radiusValue / 0.6) * 10) / 10}${
+          radiusUnit
+        }`,
         '&:empty:before': {
           content: '"\\00a0"',
         },

--- a/packages/mui-material/src/Skeleton/Skeleton.js
+++ b/packages/mui-material/src/Skeleton/Skeleton.js
@@ -88,9 +88,7 @@ const SkeletonRoot = styled('span', {
         height: 'auto',
         transformOrigin: '0 55%',
         transform: 'scale(1, 0.60)',
-        borderRadius: `${radiusValue}${radiusUnit}/${Math.round((radiusValue / 0.6) * 10) / 10}${
-          radiusUnit
-        }`,
+        borderRadius: `${radiusValue}${radiusUnit}/${Math.round((radiusValue / 0.6) * 10) / 10}${radiusUnit}`,
         '&:empty:before': {
           content: '"\\00a0"',
         },


### PR DESCRIPTION
The `fill: currentColor` on the `svg` element is unable to override the explicit `fill` property supplied in case of coloured icons.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/fcbb7177-61c3-4e19-b790-59ca3b99f9ed" /> | <video src="https://github.com/user-attachments/assets/21506796-c03b-421e-bb2d-324be7f9b343" /> |


