### PR TITLE
[core][material-ui] Prevent scrolling when restoring after FocusTrap

### DIFF
--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -201,7 +201,7 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
         // Once IE11 support is dropped the focus() call can be unconditional.
         if (nodeToRestore.current && (nodeToRestore.current as HTMLElement).focus) {
           ignoreNextEnforceFocus.current = true;
-          (nodeToRestore.current as HTMLElement).focus();
+          (nodeToRestore.current as HTMLElement).focus({ preventScroll: true });
         }
 
         nodeToRestore.current = null;

--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
@@ -193,7 +193,7 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
         // Once IE11 support is dropped the focus() call can be unconditional.
         if (nodeToRestore.current && (nodeToRestore.current as HTMLElement).focus) {
           ignoreNextEnforceFocus.current = true;
-          (nodeToRestore.current as HTMLElement).focus();
+          (nodeToRestore.current as HTMLElement).focus({ preventScroll: true });
         }
 
         nodeToRestore.current = null;


### PR DESCRIPTION
Fixes #43299

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
