### PR TITLE
[Skeleton] Apply the wave animation to the correct element

### DIFF
--- a/packages/mui-material/src/Skeleton/Skeleton.js
+++ b/packages/mui-material/src/Skeleton/Skeleton.js
@@ -192,8 +192,10 @@ const SkeletonRoot = styled('span', {
           props: {
             animation: 'wave',
           },
-          style: waveAnimation || {
-            animation: `${waveKeyframe} 2s linear 0.5s infinite`,
+          style: {
+            '&::after': waveAnimation || {
+              animation: `${waveKeyframe} 2s linear 0.5s infinite`,
+            },
           },
         },
       ],


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/43470. While migrating to the variants API, we forgot to add the selector for the ::after element when applying the wave animation, check [v5](https://github.com/mui/material-ui/blob/v5.x/packages/mui-material/src/Skeleton/Skeleton.js#L134) and instead we had it on the root element.

Tested that it works with both Emotion & Pigment CSS.

Broken behavior: https://mui.com/material-ui/react-skeleton/#animations
Fixed behavior: https://deploy-preview-43474--material-ui.netlify.app/material-ui/react-skeleton/#animations