### PR TITLE
[docs] Add @mui/styles to list of packages that can have their versio…

### DIFF
--- a/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
+++ b/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
@@ -30,6 +30,7 @@ If you're using any of these packages, you can also change their version to `"6.
 - `@mui/lab`
 - `@mui/material-nextjs`
 - `@mui/styled-engine-sc`
+- `@mui/styles`
 - `@mui/utils`
 
 Note that MUI X packages _do not_ follow the same versioning strategy as Material UI.


### PR DESCRIPTION
During my upgrade from v5 to v6, I noticed that the documentation doesn't clearly address the status of @mui/styles. This package is marked as legacy (https://mui.com/system/styles/basics/) but its handling during the upgrade process isn't explicitly mentioned. Thanks!

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
