### PR TITLE
[docs] Remove "To be continued" section from v0 –> v1 migration guide

### DIFF
--- a/docs/data/material/migration/migration-v0x/migration-v0x.md
+++ b/docs/data/material/migration/migration-v0x/migration-v0x.md
@@ -187,8 +187,3 @@ RaisedButton upgrade path:
 -<DropDownMenu></DropDownMenu>
 +<Select value={this.state.value}></Select>
 ```
-
-### To be continued…
-
-Have you successfully migrated your app, and wish to help the community?
-There is an open issue in order to finish this migration guide [#7195](https://github.com/mui/material-ui/issues/7195). Any pull request is welcomed 😊.


### PR DESCRIPTION
from the backlog of docs tasks: https://www.notion.so/mui-org/docs-v1-migration-outdated-guide-86b8c52d5de349f08b29be926c086429