### PR TITLE
[docs] Fix pigment-css.md syntax error

### DIFF
--- a/docs/data/material/experimental-api/pigment-css/pigment-css.md
+++ b/docs/data/material/experimental-api/pigment-css/pigment-css.md
@@ -62,7 +62,7 @@ Next, head over to your config file and import the `withPigment` plugin:
 // next.config.js
 import { withPigment } from '@pigment-css/nextjs-plugin';
 
-export default withPigment({ nextConfig });
+export default withPigment(nextConfig);
 ```
 
 ```ts Vite


### PR DESCRIPTION
While going through the Getting Started documentation, I came across a syntax error. [#247](https://github.com/mui/pigment-css/issues/247)