### PR TITLE
[docs][joy-ui] Add missing ComponentLinkHeader components

### DIFF
--- a/docs/data/joy/components/accordion/accordion.md
+++ b/docs/data/joy/components/accordion/accordion.md
@@ -10,6 +10,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/accordion/
 
 <p class="description">Accordions let users show and hide sections of related content on a page.</p>
 
+{{"component": "@mui/docs/ComponentLinkHeader"}}
+
 ## Introduction
 
 Joy UI provides four accordion-related components:

--- a/docs/data/joy/components/aspect-ratio/aspect-ratio.md
+++ b/docs/data/joy/components/aspect-ratio/aspect-ratio.md
@@ -8,6 +8,8 @@ components: AspectRatio
 
 <p class="description">The Aspect Ratio component resizes its contents to match the desired ratio.</p>
 
+{{"component": "@mui/docs/ComponentLinkHeader"}}
+
 ## Introduction
 
 Aspect Ratio is a wrapper component for quickly resizing content to conform to your preferred ratio of width to height.

--- a/docs/data/joy/components/card/card.md
+++ b/docs/data/joy/components/card/card.md
@@ -9,6 +9,8 @@ githubLabel: 'component: card'
 
 <p class="description">A card is a generic container for grouping related UI elements and content.</p>
 
+{{"component": "@mui/docs/ComponentLinkHeader"}}
+
 ## Introduction
 
 The Joy UI Card component includes several complementary utility components to handle various use cases:

--- a/docs/data/joy/components/drawer/drawer.md
+++ b/docs/data/joy/components/drawer/drawer.md
@@ -9,6 +9,8 @@ githubLabel: 'component: drawer'
 
 <p class="description">Navigation drawers provide quick access to other areas of an app without taking the user away from their current location.</p>
 
+{{"component": "@mui/docs/ComponentLinkHeader"}}
+
 ## Introduction
 
 Drawers are commonly used as menus for desktop navigation, and as dialogs on mobile devices (similar to [Apple's sheets](https://developer.apple.com/design/human-interface-guidelines/sheets)).

--- a/docs/data/joy/components/grid/grid.md
+++ b/docs/data/joy/components/grid/grid.md
@@ -9,6 +9,8 @@ githubLabel: 'component: Grid'
 
 <p class="description">Grid acts as a generic container, wrapping around the elements to be arranged.</p>
 
+{{"component": "@mui/docs/ComponentLinkHeader"}}
+
 ## Introduction
 
 The Grid component, based on a 12-column grid layout, creates visual consistency between layouts while allowing flexibility across a wide variety of designs.

--- a/docs/data/joy/components/list/list.md
+++ b/docs/data/joy/components/list/list.md
@@ -9,6 +9,8 @@ githubLabel: 'component: list'
 
 <p class="description">Lists are organizational tools that enhance the readability and organization of content.</p>
 
+{{"component": "@mui/docs/ComponentLinkHeader"}}
+
 ## Introduction
 
 Lists present information in a concise, easy-to-follow format through a continuous, vertical index of text or images.

--- a/docs/data/joy/components/menu/menu.md
+++ b/docs/data/joy/components/menu/menu.md
@@ -11,6 +11,8 @@ unstyled: /base-ui/react-menu/
 
 <p class="description">Menus display a list of choices on temporary surfaces.</p>
 
+{{"component": "@mui/docs/ComponentLinkHeader"}}
+
 ## Introduction
 
 Joy UI provides five menu-related components:

--- a/docs/data/joy/components/skeleton/skeleton.md
+++ b/docs/data/joy/components/skeleton/skeleton.md
@@ -9,6 +9,8 @@ components: Skeleton, AspectRatio, Avatar, Typography
 
 <p class="description">Skeletons are preview placeholders for components that haven't loaded yet, reducing load-time frustration.</p>
 
+{{"component": "@mui/docs/ComponentLinkHeader"}}
+
 ## Introduction
 
 Skeletons provide users an expectation of what the UI looks like while data loads.

--- a/docs/data/joy/components/stepper/stepper.md
+++ b/docs/data/joy/components/stepper/stepper.md
@@ -10,6 +10,8 @@ materialDesign: https://m1.material.io/components/steppers.html
 
 <p class="description">Steppers convey progress through numbered steps. It provides a wizard-like workflow.</p>
 
+{{"component": "@mui/docs/ComponentLinkHeader"}}
+
 ## Introduction
 
 Stepper displays progress through a sequence of logical and numbered steps. It support horizontal and vertical orientation for desktop and mobile viewports.

--- a/docs/data/joy/components/toggle-button-group/toggle-button-group.md
+++ b/docs/data/joy/components/toggle-button-group/toggle-button-group.md
@@ -9,6 +9,8 @@ components: ToggleButtonGroup, Button, IconButton
 
 <p class="description">A group of mutually exclusive buttons.</p>
 
+{{"component": "@mui/docs/ComponentLinkHeader"}}
+
 ## Introduction
 
 Toggle Button Group provides a way to get mutually exclusive actions closer together by sharing a common container.

--- a/docs/data/joy/components/typography/typography.md
+++ b/docs/data/joy/components/typography/typography.md
@@ -9,6 +9,8 @@ githubLabel: 'component: Typography'
 
 <p class="description">The Typography component helps present design and content clearly and efficiently.</p>
 
+{{"component": "@mui/docs/ComponentLinkHeader"}}
+
 ## Introduction
 
 The Typography component helps maintain a consistent design by providing a limited set of values to choose from and convenient props for building common designs faster.


### PR DESCRIPTION
From the backlog of docs tasks - the problem appears to be isolated to Joy UI docs. https://www.notion.so/mui-org/docs-Add-ComponentLinkHeader-on-all-pages-de4a6859ad4f46fcbbd0b9c9cdd2abc7?pvs=4
