### PR TITLE
POC: Transition compatibility hooks

### DIFF
--- a/packages/mui-utils/src/CompatTransitionManager/CompatTransitionManager.ts
+++ b/packages/mui-utils/src/CompatTransitionManager/CompatTransitionManager.ts
@@ -1,0 +1,119 @@
+import * as ReactDOM from 'react-dom';
+import * as React from 'react';
+
+export type Callback = () => void;
+export type BatchCallback = (batch: Batch) => void;
+
+interface Batch {
+  queue: Set<Callback>;
+}
+
+let ACTIVE_BATCH: Batch | null = null;
+let PENDING_FLUSH: number = 0;
+const PENDING_BATCHES: Set<Batch> = new Set();
+
+/**
+ * Executes the given function inside of a batch.
+ *
+ * If a batch doesn't already exist, a new one will be created, and the given
+ * callback will be executed when it ends.
+ */
+export function runWithBatch<T>(fn: () => T, batchCallback: BatchCallback): T {
+  return ReactDOM.unstable_batchedUpdates(() => {
+    const prevBatch = ACTIVE_BATCH;
+    const batch = prevBatch == null ? ({ queue: new Set() } as Batch) : prevBatch;
+    let result: T;
+
+    try {
+      ACTIVE_BATCH = batch;
+      result = fn();
+    } finally {
+      ACTIVE_BATCH = prevBatch;
+    }
+
+    if (batch !== prevBatch) {
+      batchCallback(batch);
+    }
+    return result;
+  });
+}
+
+/**
+ * A batch callback that immediately executes all of the updates
+ * in every batch (the current one, and any pending). Assumes it's
+ * called in a ReactDOM batch.
+ */
+export function blockingBatchCallback(batch: Batch) {
+  flushPendingBatches();
+  batch.queue.forEach((callback) => callback());
+}
+
+/**
+ * A batch callback that executes every update in a future macro
+ * task. Assumes it's called in a ReactDOM batch.
+ */
+export function nonBlockingBatchCallback(batch: Batch) {
+  // Apply the pending batches with a timeout so that they
+  // are executed in a future macrotask, *after* the blocking
+  // changes have been painted.
+  //
+  // The timeout is a bit arbitrary. One of benefits of transitions are
+  // that they enable a kind of debouncing. With a non-zero timeout, we can
+  // get some of that benefit in React 17 by allowing non-blocking updates
+  // from e.g. keystrokes to cancel our previous timeout and further delay
+  // our deferred work instead of blocking the UI, with the trade-off of an
+  // increased latency to when the deferred work will be shown.
+  //
+  // The value should be something high enough that e.g. actively typing into
+  // a search box remains responsive, but not so high that the application
+  // feels slow to respond when you stop typing.
+  PENDING_BATCHES.add(batch);
+  window.clearTimeout(PENDING_FLUSH);
+  PENDING_FLUSH = window.setTimeout(() => {
+    ReactDOM.unstable_batchedUpdates(flushPendingBatches);
+  }, 375);
+}
+
+/**
+ * Creates a batch callback that executes every update in the given
+ * `startTransition` function.
+ */
+export function createPassthroughBatchCallback(startTransition: (callback: Callback) => void) {
+  return (batch: Batch) => {
+    startTransition(() => {
+      batch.queue.forEach((callback) => callback());
+    });
+  };
+}
+
+/**
+ * Attempt to enqueue the given state update.
+ *
+ * If there is an existing batch, the update will be added to it and
+ * run later. Otherwise, it will be run immediately, without batching.
+ */
+export function enqueueStateUpdate<T>(fn: Callback): Callback {
+  const queue = ACTIVE_BATCH?.queue;
+  if (queue) {
+    queue.add(fn);
+    return () => {
+      queue.delete(fn);
+    };
+  } else {
+    fn();
+    return () => {};
+  }
+}
+
+/**
+ * Flush any pending batches. Assumes it's called within a ReactDOM batch.
+ */
+function flushPendingBatches() {
+  window.clearTimeout(PENDING_FLUSH);
+  PENDING_FLUSH = 0;
+
+  PENDING_BATCHES.forEach((batch) => {
+    batch.queue.forEach((callback) => callback());
+  });
+  PENDING_BATCHES.clear();
+}

--- a/packages/mui-utils/src/CompatTransitionManager/index.ts
+++ b/packages/mui-utils/src/CompatTransitionManager/index.ts
@@ -1,0 +1,1 @@
+export * from './CompatTransitionManager';

--- a/packages/mui-utils/src/index.ts
+++ b/packages/mui-utils/src/index.ts
@@ -48,4 +48,8 @@ export { default as unstable_resolveComponentProps } from './resolveComponentPro
 export { default as unstable_extractEventHandlers } from './extractEventHandlers';
 export { default as unstable_getReactNodeRef } from './getReactNodeRef';
 export { default as unstable_getReactElementRef } from './getReactElementRef';
+export { default as useDeferredValue } from './useDeferredValue';
+export { default as useStateWithTransitions } from './useStateWithTransitions';
+export { default as useReducerWithTransitions } from './useReducerWithTransitions';
+export { default as useTransition } from './useTransition';
 export * from './types';

--- a/packages/mui-utils/src/useDeferredValue/index.ts
+++ b/packages/mui-utils/src/useDeferredValue/index.ts
@@ -1,0 +1,2 @@
+'use client';
+export { default } from './useDeferredValue';

--- a/packages/mui-utils/src/useDeferredValue/useDeferredValue.ts
+++ b/packages/mui-utils/src/useDeferredValue/useDeferredValue.ts
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import {
+  nonBlockingBatchCallback,
+  enqueueStateUpdate,
+  runWithBatch,
+} from '../CompatTransitionManager';
+
+function useDeferredValue17<T>(value: T): T {
+  // React 17 doesn't support concurrent rendering. We simulate the behavior
+  // by only updating to the current value when the previous one is committed.
+  const [currentValue, setCurrentValue] = React.useState(value);
+
+  React.useEffect(() => {
+    if (value !== currentValue) {
+      return runWithBatch(
+        () => enqueueStateUpdate(() => setCurrentValue(value)),
+        nonBlockingBatchCallback,
+      );
+    }
+  }, [value, currentValue]);
+
+  return currentValue;
+}
+
+// See https://github.com/mui/material-ui/issues/41190#issuecomment-2040873379 for why
+const safeReact = { ...React };
+const maybeReactUseDeferredValue: undefined | typeof React.useDeferredValue =
+  safeReact.useDeferredValue;
+
+const useDeferredValue =
+  typeof maybeReactUseDeferredValue === 'undefined'
+    ? useDeferredValue17
+    : maybeReactUseDeferredValue;
+
+export default useDeferredValue;

--- a/packages/mui-utils/src/useReducerWithTransitions/index.ts
+++ b/packages/mui-utils/src/useReducerWithTransitions/index.ts
@@ -1,0 +1,2 @@
+'use client';
+export { default } from './useReducerWithTransitions';

--- a/packages/mui-utils/src/useReducerWithTransitions/useReducerWithTransitions.ts
+++ b/packages/mui-utils/src/useReducerWithTransitions/useReducerWithTransitions.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import {
+  runWithBatch,
+  blockingBatchCallback,
+  enqueueStateUpdate,
+} from '../CompatTransitionManager';
+
+/**
+ * Like `useReducer`, but for use with the compatibility version of `useTransition`.
+ * TODO: Improve typing.
+ */
+export default function useReducerWithTransitions<T>(
+  reducer: any,
+  initializerArg: any,
+  initializer?: any,
+) {
+  const [state, dispatch] = React.useReducer(reducer, initializerArg, initializer);
+  const enqueueDispatch = React.useCallback(
+    (value: any) => {
+      runWithBatch(() => {
+        enqueueStateUpdate(() => (dispatch as any)(value));
+      }, blockingBatchCallback);
+    },
+    [dispatch],
+  );
+
+  return [state, enqueueDispatch];
+}

--- a/packages/mui-utils/src/useStateWithTransitions/index.ts
+++ b/packages/mui-utils/src/useStateWithTransitions/index.ts
@@ -1,0 +1,2 @@
+'use client';
+export { default } from './useStateWithTransitions';

--- a/packages/mui-utils/src/useStateWithTransitions/useStateWithTransitions.ts
+++ b/packages/mui-utils/src/useStateWithTransitions/useStateWithTransitions.ts
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import {
+  runWithBatch,
+  blockingBatchCallback,
+  enqueueStateUpdate,
+} from '../CompatTransitionManager';
+
+type StateUpdateFn<T> = (prevState: T) => T;
+type SetStateInput<T> = T | StateUpdateFn<T>;
+type SetStateFn<T> = (value: SetStateInput<T>) => void;
+
+/**
+ * Like `useState`, but for use with the compatibility version of `useTransition`.
+ */
+export default function useStateWithTransitions<T>(
+  initialValue: T | (() => T),
+): [T, SetStateFn<T>] {
+  const [state, setState] = React.useState(initialValue);
+  const enqueueSetState = React.useCallback(
+    (value: SetStateInput<T>) => {
+      runWithBatch(() => {
+        enqueueStateUpdate(() => setState(value));
+      }, blockingBatchCallback);
+    },
+    [setState],
+  );
+
+  return [state, enqueueSetState];
+}

--- a/packages/mui-utils/src/useTransition/index.ts
+++ b/packages/mui-utils/src/useTransition/index.ts
@@ -1,0 +1,2 @@
+'use client';
+export { default } from './useTransition';

--- a/packages/mui-utils/src/useTransition/useTransition.ts
+++ b/packages/mui-utils/src/useTransition/useTransition.ts
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import {
+  nonBlockingBatchCallback,
+  BatchCallback,
+  createPassthroughBatchCallback,
+  enqueueStateUpdate,
+  runWithBatch,
+} from '../CompatTransitionManager';
+
+export type TransitionFunction = () => void | PromiseLike<void>;
+export interface StartTransitionFunction {
+  (callback: TransitionFunction): void;
+}
+
+interface TransitionStatePending {
+  status: 'PENDING';
+}
+interface TransitionStateResolved {
+  status: 'RESOLVED';
+}
+interface TransitionStateRejected {
+  status: 'REJECTED';
+  reason: any;
+}
+type TransitionState = TransitionStatePending | TransitionStateResolved | TransitionStateRejected;
+
+/**
+ * Shared implementation logic for the `useTransition` hooks.
+ */
+function useTransitionImpl(batchCallback: BatchCallback): [boolean, StartTransitionFunction] {
+  const pendingPromise = React.useRef<PromiseLike<void> | null>(null);
+  const [state, setState] = React.useState<TransitionState>({ status: 'RESOLVED' });
+
+  const onTransitionThen = (promise: PromiseLike<void> | null) => {
+    if (pendingPromise.current === promise) {
+      pendingPromise.current = null;
+      runWithBatch(() => {
+        enqueueStateUpdate(() => setState({ status: 'RESOLVED' }));
+      }, batchCallback);
+    }
+  };
+  const onTransitionCatch = (promise: PromiseLike<void> | null, reason: any) => {
+    if (pendingPromise.current === promise) {
+      pendingPromise.current = null;
+      runWithBatch(() => {
+        enqueueStateUpdate(() => setState({ status: 'REJECTED', reason }));
+      }, batchCallback);
+    }
+  };
+
+  const startTransition = React.useCallback(
+    (callback: TransitionFunction) => {
+      enqueueStateUpdate(() => setState({ status: 'PENDING' }));
+      runWithBatch(() => {
+        try {
+          const res = callback();
+          if (res != null && typeof res.then === 'function') {
+            pendingPromise.current = res;
+            res.then(onTransitionThen.bind(null, res), onTransitionCatch.bind(null, res));
+          } else {
+            pendingPromise.current = null;
+            onTransitionThen(null);
+          }
+        } catch (error) {
+          pendingPromise.current = null;
+          onTransitionCatch(null, error);
+        }
+      }, batchCallback);
+    },
+    [setState, batchCallback],
+  );
+
+  if (state.status === 'REJECTED') {
+    throw state.reason;
+  } else {
+    return [state.status === 'PENDING', startTransition];
+  }
+}
+
+function useTransition18(): [boolean, StartTransitionFunction] {
+  // To ease the upgrade process, we implement the same semantics in
+  // React 18 as React 17, i.e. only updates to `useStateWithTransitions`
+  // and `useReducerWithTransitions` are marked as non-blocking.
+  const [isPendingInternal, startTransitionInternal] = maybeReactUseTransition!();
+  const batchCallback = React.useMemo(
+    () => createPassthroughBatchCallback(startTransitionInternal),
+    [startTransitionInternal],
+  );
+  const [isPending, startTransition] = useTransitionImpl(batchCallback);
+  // React 18 applications might adopt suspense, so we should be pending
+  // as long as an async action is pending or the subsequent transition is.
+  return [isPending || isPendingInternal, startTransition];
+}
+
+function useTransition17(): [boolean, StartTransitionFunction] {
+  return useTransitionImpl(nonBlockingBatchCallback);
+}
+
+// See https://github.com/mui/material-ui/issues/41190#issuecomment-2040873379 for why
+const safeReact = { ...React };
+const maybeReactUseTransition: undefined | typeof React.useTransition = safeReact.useTransition;
+
+/**
+ * The `startTransition` callback in the compatibility hook works a little differently from the built-in hook.
+ * Even in React 18, only updates to `useStateWithTransitions` and `useReducerWithTransitions` are marked as
+ * non-blocking.
+ */
+const useTransition: () => [boolean, StartTransitionFunction] =
+  typeof maybeReactUseTransition === 'undefined' ? useTransition17 : useTransition18;
+
+export default useTransition;


### PR DESCRIPTION
Proof of concept of compatibility hooks enabling [transitions](https://react.dev/reference/react/useTransition#marking-a-state-update-as-a-non-blocking-transition) to be used in React 17 applications. There are a few key differences outlined below.

# Compatibility Hooks

## `unstable_useDeferredValueCompat(value)`

Implements `React.useDeferredValue`. Note that the React 19 `initialValue?` argument is not currently supported, as there are open questions as to shimming this behavior in React 18.

## `unstable_useTransitionCompat()`

Implements `React.useTransition`, including support for async actions. Note that the semantics for this hook differ slightly from React. Consider the following:

```typescript
const [isPending, startTransition] = useTransition();
const [state, dispatch] = useReducer((s, a) => [...s, a], []);

// ...

startTransition(() => {
  dispatch('foo');
});
dispatch('bar');
```

It's expected that the value of `state` will be `['foo', 'bar']`. That's because conceptually, state updates are _queued_, and even though the first update was scheduled non-blocking, the update still needs to be applied chronologically before the second update. Unfortunately, this type of queuing is not trivial to implement _generally_ (i.e. for all state) without brittle monkey patching of React.

Instead, the compatibility hook works a little differently. Instead of marking all state updates inside of `startTransition` as non-blocking, it marks everything as blocking by default -- **even in React 18 and higher**. To mark state updates as non-blocking with the compatibility hook, the state hook itself must use either `unstable_useStateCompat` or `unstable_useReducerCompat`. That means in order to reproduce the React 18 behavior, you need to write this instead:

```typescript
const [isPending, startTransition] = unstable_useTransitionCompat();
const [state, dispatch] = unstable_useReducerCompat((s, a) => [...s, a], []);

// ...

startTransition(() => {
  dispatch('foo');
});
dispatch('bar');
```

Once ready to adopt React 18, you would first migrate `unstable_useTransitionCompat` to `useTransition`, and then `unstable_useStateCompat`/`unstable_useReducerCompat` alternatives. 

## `unstable_useStateCompat`

Just like `useState`, but for use with `unstable_useTransitionCompat`. If you're not updating the value in a transition, you should just use `useState`.

## `unstable_useReducerCompat`

Just like `useReducer`, but for use with `unstable_useTransitionCompat`. If you're not updating the value in a transition, you should just use `useReducer`.

# How it works

The `CompatTransitionManager` maintains _batches_, queues of updates that should be applied together. The primary question is _when_ the batches should be applied:

1. Whenever a _blocking_ update is queued (i.e. outside of `startTransition` or `useDeferredValue`), all previous batches (even non-blocking) must be applied before the blocking update is. This is implemented by `blockingBatchCallback`

2. Whenever a _non-blocking_ update is queued, the update can be applied at some point in the future. This is implemented by `nonBlockingBatchCallback`, which simply uses `setTimeout` to apply the changes in a future macrotask, so blocking updates have a chance to be painted first.

3. Running the compatibility hooks in React 18 is a special case, as we want to preserve the same semantics for those upgrading from React 17. This is implemented by `createPassthroughBatchCallback`, which executes _only_ updates batched via the compatibility hooks inside the actual `startTransition`.

React has a much more sophisticated strategy than these compatibility hooks. However, without being able to interrupt or reprioritize rendering work, it just doesn't make much sense to be more complex than this. We accept that without incremental rendering, non-blocking rendering will inevitably make the UI less responsive (that's why it was marked as non-blocking in the first place: so it wouldn't make the UI less responsive), and so we just make sure we paint any pending states/loading indicators in a blocking update, and cram as much work as possible into the subsequent update.

# Why?

Transitions help make applications more responsive and improve Core Web Vitals like [INP](https://web.dev/articles/inp), especially on lower end devices like mobile. While the compatibility hooks aren't perfect, they can significantly improve the user experience.

Consider the `Autocomplete` component. Without transitions, running with 20x slowdown, you end up with something like this:

https://github.com/user-attachments/assets/ad3cb38c-8e90-4834-b444-1c26c69b1595

The UI simply freezes while the large list is being rendered. However, by using `useDeferredValue`, we can achieve this instead:

https://github.com/user-attachments/assets/9cc74622-7000-40aa-97b5-edc299791459

Even in React 17 via `unstable_useDeferredValue` we can achieve a significant improvement to INP (~800ms vs 2s). While the UI is unable to quickly respond to subsequent interactions while the dropdown content is rendering (due to the lack of time slicing/incremental rendering prior to React 18), we are still able to show our animation and a loading indicator to the user.

(Note: the changes to autocomplete are not implemented in this PR. In reality, we would likely want a browser controlled animation that only starts after e.g. a 400ms delay, so that users on faster devices don't see it).

Ideally, applications would just be able to use React 18 or higher. However, in cases where that's not feasible, they should still ideally use transition and [action](https://react.dev/blog/2024/04/25/react-19#by-convention-functions-that-use-async-transitions-are-called-actions) semantics and APIs.