### PR TITLE
[autocomplete] Prevent shrink animation in controlled Autocomplete when initial `value` is provided

### DIFF
--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -146,7 +146,7 @@ function useAutocomplete(props) {
   const highlightedIndexRef = React.useRef(defaultHighlighted);
 
   // Calculate the initial inputValue on mount only.
-  // Using useRef since defaultValue doesn't need to update inputValue dynamically.
+  // useRef ensures it doesn't update dynamically with defaultValue or value props.
   const initialInputValue = React.useRef(
     getInputValue(defaultValue ?? valueProp, multiple, getOptionLabel),
   ).current;

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -148,7 +148,7 @@ function useAutocomplete(props) {
   // Calculate the initial inputValue on mount only.
   // Using useRef since defaultValue doesn't need to update inputValue dynamically.
   const initialInputValue = React.useRef(
-    getInputValue(defaultValue, multiple, getOptionLabel),
+    getInputValue(defaultValue ?? valueProp, multiple, getOptionLabel),
   ).current;
 
   const [value, setValueState] = useControlled({

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
@@ -415,4 +415,24 @@ describe('useAutocomplete', () => {
       expect(onInputChange.callCount).to.equal(0);
     });
   });
+
+  describe('prop: value', () => {
+    it('should not trigger onInputChange when value is provided', () => {
+      const onInputChange = spy();
+      const value = 'foo';
+
+      function Test() {
+        const { getInputProps } = useAutocomplete({
+          value,
+          onInputChange,
+          options: ['foo', 'bar'],
+        });
+
+        return <input {...getInputProps()} />;
+      }
+
+      render(<Test />);
+      expect(onInputChange.callCount).to.equal(0);
+    });
+  });
 });

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
@@ -419,11 +419,12 @@ describe('useAutocomplete', () => {
   describe('prop: value', () => {
     it('should not trigger onInputChange when value is provided', () => {
       const onInputChange = spy();
-      const value = 'foo';
 
       function Test() {
+        const [value, setValue] = React.useState('foo');
         const { getInputProps } = useAutocomplete({
           value,
+          onChange: (event, valueParam) => setValue(valueParam),
           onInputChange,
           options: ['foo', 'bar'],
         });


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

To address https://github.com/mui/material-ui/issues/45724, we can set `initialInputValue` on `useAutocomplete` to avoid shrinking its label when an initial value is already set.

Fixes #45724 

Before: https://stackblitz.com/edit/stackblitz-starters-bukupsze
After: https://codesandbox.io/p/sandbox/material-ui-cra-ts-forked-ct2y7y