### PR TITLE
[autocomplete] Add note in JSDoc for non-TextField components in `renderInput`

### DIFF
--- a/docs/translations/api-docs/autocomplete/autocomplete.json
+++ b/docs/translations/api-docs/autocomplete/autocomplete.json
@@ -166,7 +166,9 @@
       "description": "Render the group.",
       "typeDescriptions": { "params": "The group to render." }
     },
-    "renderInput": { "description": "Render the input." },
+    "renderInput": {
+      "description": "Render the input.<br><strong>Note:</strong> The <code>renderInput</code> prop must return a <code>TextField</code> component or a compatible custom component that correctly forwards <code>InputProps.ref</code> and spreads <code>inputProps</code>. This ensures proper integration with the Autocomplete&#39;s internal logic (e.g., focus management and keyboard navigation).<br>Avoid using components like <code>DatePicker</code> or <code>Select</code> directly, as they may not forward the required props, leading to runtime errors or unexpected behavior."
+    },
     "renderOption": {
       "description": "Render the option, use <code>getOptionLabel</code> by default.",
       "typeDescriptions": {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
@@ -334,14 +334,17 @@ export interface AutocompleteProps<
   renderGroup?: (params: AutocompleteRenderGroupParams) => React.ReactNode;
   /**
    * Render the input.
-   * 
-   *Note: The `renderInput` prop must return a `TextField` component or a component that correctly handles `inputRef` and `inputProps`.
-   *Using components like `DatePicker` or `Select` directly here may cause runtime errors and unexpected behavior.
+   *
+   * **Note:** The `renderInput` prop must return a `TextField` component or a compatible custom component
+   * that correctly forwards `InputProps.ref` and spreads `inputProps`. This ensures proper integration
+   * with the Autocomplete's internal logic (e.g., focus management and keyboard navigation).
+   *
+   * Avoid using components like `DatePicker` or `Select` directly, as they may not forward the required props,
+   * leading to runtime errors or unexpected behavior.
    *
    * @param {object} params
    * @returns {ReactNode}
    */
-
   renderInput: (params: AutocompleteRenderInputParams) => React.ReactNode;
   /**
    * Render the option, use `getOptionLabel` by default.

--- a/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
@@ -334,10 +334,14 @@ export interface AutocompleteProps<
   renderGroup?: (params: AutocompleteRenderGroupParams) => React.ReactNode;
   /**
    * Render the input.
+   * 
+   *Note: The `renderInput` prop must return a `TextField` component or a component that correctly handles `inputRef` and `inputProps`.
+   *Using components like `DatePicker` or `Select` directly here may cause runtime errors and unexpected behavior.
    *
    * @param {object} params
    * @returns {ReactNode}
    */
+
   renderInput: (params: AutocompleteRenderInputParams) => React.ReactNode;
   /**
    * Render the option, use `getOptionLabel` by default.

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -1148,6 +1148,13 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   /**
    * Render the input.
    *
+   * **Note:** The `renderInput` prop must return a `TextField` component or a compatible custom component
+   * that correctly forwards `InputProps.ref` and spreads `inputProps`. This ensures proper integration
+   * with the Autocomplete's internal logic (e.g., focus management and keyboard navigation).
+   *
+   * Avoid using components like `DatePicker` or `Select` directly, as they may not forward the required props,
+   * leading to runtime errors or unexpected behavior.
+   *
    * @param {object} params
    * @returns {ReactNode}
    */


### PR DESCRIPTION
This PR improves the documentation of the Autocomplete component by adding a warning to the renderInput prop's JSDoc. It clarifies that developers should not return non-TextField components (e.g. DatePicker, Select) directly inside renderInput. issue mui/mui-x#17832

I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-46141--material-ui.netlify.app/material-ui/api/autocomplete/#autocomplete-prop-renderInput