### PR TITLE
[chip] Explicitly define line-height

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -90,6 +90,7 @@ const ChipRoot = styled('div', {
       alignItems: 'center',
       justifyContent: 'center',
       height: 32,
+      lineHeight: 1.5,
       color: (theme.vars || theme).palette.text.primary,
       backgroundColor: (theme.vars || theme).palette.action.selected,
       borderRadius: 32 / 2,


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/issues/45097

The gist of it is explicitly defining line-height so it's not unexpectedly overriden from context.

Before: https://stackblitz.com/edit/qqzpax9d-uenxkstz?file=src%2FApp.jsx
After: https://stackblitz.com/edit/qqzpax9d?file=src%2FApp.jsx

The [original PR](https://github.com/mui/material-ui/pull/45101) got stuck in a Github update 😅 You can check the discussion there.