### PR TITLE
[infra] Add emotion as external for bundle monitor

### DIFF
--- a/scripts/dangerFileContent.ts
+++ b/scripts/dangerFileContent.ts
@@ -29,14 +29,7 @@ async function reportBundleSize() {
   const circleciBuildNumber = process.env.CIRCLE_BUILD_NUM;
 
   markdownContent += await renderMarkdownReport(danger.github.pr, circleciBuildNumber, {
-    track: [
-      '@mui/material',
-      '@mui/lab',
-      '@mui/system',
-      '@mui/utils',
-      '@emotion/react',
-      '@emotion/styled',
-    ],
+    track: ['@mui/material', '@mui/lab', '@mui/system', '@mui/utils'],
   });
 
   // Use the markdown function to publish the report

--- a/test/bundle-size/bundle-size-checker.config.mjs
+++ b/test/bundle-size/bundle-size-checker.config.mjs
@@ -46,8 +46,6 @@ export default defineConfig(async () => {
       '@mui/material/useMediaQuery',
       '@mui/material/useScrollTrigger',
       '@mui/utils',
-      '@emotion/react',
-      '@emotion/styled',
     ],
     upload: !!process.env.CI,
   };


### PR DESCRIPTION
Wanted to do this change separately as to not distort the results during the migration.

Take emotion into account as an external as it's a peer dependency the user has installed anyway, we don't control the version