### PR TITLE
[code-infra] Update node group in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -92,7 +92,7 @@
     },
     {
       "groupName": "node",
-      "matchPackageNames": ["node"],
+      "matchPackageNames": ["node", "cimg/node", "actions/setup-node"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Expanded the 'node' group in renovate.json to include 'cimg/node' and 'actions/setup-node' in matchPackageNames. This ensures these packages are grouped together for dependency updates.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
