### PR TITLE
[docs][Dialog] Fix Form dialog demo's actions button padding

### DIFF
--- a/docs/data/material/components/dialogs/FormDialog.js
+++ b/docs/data/material/components/dialogs/FormDialog.js
@@ -34,7 +34,7 @@ export default function FormDialog() {
       </Button>
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>Subscribe</DialogTitle>
-        <DialogContent sx={{ paddingBottom: 0 }}>
+        <DialogContent>
           <DialogContentText>
             To subscribe to this website, please enter your email address here. We
             will send updates occasionally.

--- a/docs/data/material/components/dialogs/FormDialog.tsx
+++ b/docs/data/material/components/dialogs/FormDialog.tsx
@@ -34,7 +34,7 @@ export default function FormDialog() {
       </Button>
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>Subscribe</DialogTitle>
-        <DialogContent sx={{ paddingBottom: 0 }}>
+        <DialogContent>
           <DialogContentText>
             To subscribe to this website, please enter your email address here. We
             will send updates occasionally.


### PR DESCRIPTION
Fixes #46478

This PR updates the Dialog demo to address the extra bottom padding that appears after the DialogActions component when used with the default spacing.

### What was changed
- Reduced spacing/margin in the Dialog demo where `DialogActions` (Form Dialog) had too much bottom padding.

### Screenshot
**Before**
<img width="614" height="235" alt="before_dialog" src="https://github.com/user-attachments/assets/7570ddac-fce8-4bae-9f43-d4b2bd6d2788" />

**After**
<img width="614" height="236" alt="after_dialog" src="https://github.com/user-attachments/assets/90b2a01c-3feb-4625-87f0-58721144346e" />

Let me know if any adjustments are needed. Thank you!

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
