### PR TITLE
[fix] mui-stylis-plugin-rtl not wrapping css with @layer bug fixed wi…

### DIFF
--- a/packages/mui-stylis-plugin-rtl/src/index.ts
+++ b/packages/mui-stylis-plugin-rtl/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 // @ts-nocheck
-import cssjanus from 'cssjanus';
+import cssjanus from "cssjanus";
 import {
   COMMENT,
   compile,
@@ -20,14 +20,14 @@ import {
   MEDIA,
   SUPPORTS,
   LAYER,
-} from 'stylis';
+} from "stylis";
 
 type MiddlewareParams = Parameters<Middleware>;
 
 function stringifyPreserveComments(
   element: MiddlewareParams[0],
   index: MiddlewareParams[1],
-  children: MiddlewareParams[2],
+  children: MiddlewareParams[2]
 ): string {
   switch (element.type) {
     case IMPORT:
@@ -35,7 +35,9 @@ function stringifyPreserveComments(
     case COMMENT:
       return (element.return = element.return || element.value);
     case RULESET: {
-      element.value = Array.isArray(element.props) ? element.props.join(',') : element.props;
+      element.value = Array.isArray(element.props)
+        ? element.props.join(",")
+        : element.props;
 
       if (Array.isArray(element.children)) {
         element.children.forEach((x) => {
@@ -47,39 +49,62 @@ function stringifyPreserveComments(
 
   const serializedChildren = serialize(
     Array.prototype.concat(element.children),
-    stringifyPreserveComments,
+    stringifyPreserveComments
   );
 
   return strlen(serializedChildren)
-    ? (element.return = element.value + '{' + serializedChildren + '}')
-    : '';
+    ? (element.return = element.value + "{" + serializedChildren + "}")
+    : "";
 }
 
-function stylisRTLPlugin(
-  element: MiddlewareParams[0],
-  index: MiddlewareParams[1],
-  children: MiddlewareParams[2],
-  callback: MiddlewareParams[3],
-): string | void {
-  if (
-    element.type === KEYFRAMES ||
-    element.type === SUPPORTS ||
-    (element.type === RULESET &&
-      (!element.parent ||
-        element.parent.type === MEDIA ||
-        element.parent.type === RULESET ||
-        element.parent.type === LAYER))
-  ) {
-    const stringified = cssjanus.transform(stringifyPreserveComments(element, index, children));
+export function stylisRTLPluginFactory(layer?: string) {
+  const stylisRTLPlugin = (
+    element: MiddlewareParams[0],
+    index: MiddlewareParams[1],
+    children: MiddlewareParams[2],
+    callback: MiddlewareParams[3]
+  ): string | void => {
+    if (layer && layer.trim().length > 0 && !element.root) {
+      const child = { ...element, parent: element, root: element };
 
-    element.children = stringified ? compile(stringified)[0].children : [];
+      Object.assign(element, {
+        children: [child],
+        length: 6,
+        parent: null,
+        props: [layer],
+        return: "",
+        root: null,
+        type: "@layer",
+        value: `@layer ${layer}`,
+      });
+    }
 
-    element.return = '';
-  }
+    if (
+      element.type === KEYFRAMES ||
+      element.type === SUPPORTS ||
+      (element.type === RULESET &&
+        (!element.parent ||
+          element.parent.type === MEDIA ||
+          element.parent.type === RULESET ||
+          element.parent.type === LAYER))
+    ) {
+      const stringified = cssjanus.transform(
+        stringifyPreserveComments(element, index, children)
+      );
+
+      element.children = stringified ? compile(stringified)[0].children : [];
+
+      element.return = "";
+    }
+  };
+
+  return stylisRTLPlugin;
 }
+
+const stylisRTLPlugin = stylisRTLPluginFactory();
 
 // stable identifier that will not be dropped by minification unless the whole module
 // is unused
-Object.defineProperty(stylisRTLPlugin, 'name', { value: 'stylisRTLPlugin' });
+Object.defineProperty(stylisRTLPlugin, "name", { value: "stylisRTLPlugin" });
 
 export default stylisRTLPlugin;


### PR DESCRIPTION
Working on a Next.js app router and MUI project using tailwindcss for customizations. I found that when changing to `RTL` the rtl cache provider does not wrap CSS with `@layer mui` even though `enableCssLayer` is set to `true`. This ruins the tailwindcss integration because the layer ordering is not properly applied. So based on these two issues <https://github.com/mui/material-ui/issues/44700> - <https://github.com/emotion-js/emotion/issues/3134#issuecomment-1939309240>. I refactored the `mui-stylis-plugin-rtl` to export a plugin factory that accepts an optinal layer name. If provided the output CSS will be wrapped with an `@layer <layer-name>` and if not the output will be as is.

If this pull request is merged I'm willing to update both tests and the documentation website ASAP, which isn't possible for now since there's a major change in tests which happen to use the installed version of the plugin, so updating tests isn't possible before updating the package.

```ts
import { compile, middleware, serialize, stringify } from "stylis";

import { stylisRTLPluginFactory } from "./plugin"; // * local diretory

const css = serialize(
  compile(`
    h1{all:unset}

    @media (width > 768px) {
      h2 { display: none }
    }
    `),
  middleware([stylisRTLPluginFactory('mui'), stringify])
);

console.log(css);
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
