### PR TITLE
[docs] Fix incorrect command for MCP Inspector in mcp.md

### DIFF
--- a/docs/data/material/getting-started/mcp/mcp.md
+++ b/docs/data/material/getting-started/mcp/mcp.md
@@ -99,7 +99,7 @@ Navigate to this URL in your browser and set the following paramters:
 
 - **Transport type: Stdio**
 - **Command:**`npx`
-- **Arguments:** `y @mui/mcp@latest`
+- **Arguments:** `-y @mui/mcp@latest`
 
 Click **Connect** and wait for the connection to be established.
 


### PR DESCRIPTION
This pull request corrects a small but critical typo in the documentation for the MUI Code Patcher (MCP) Inspector.

**Problem:**

The command provided in `mcp.md` for running the MCP Inspector is missing a hyphen before the `-y` flag.

The current documentation suggests:
```bash
npx y @mui/mcp@latest
```
When a user copies and runs this command, it fails because `y` is not a valid `npx` command. This can cause confusion for developers trying to use this new and powerful feature for the first time.

**Solution:**

This PR adds the required hyphen to the command, correcting it to the functional version:
```bash
npx -y @mui/mcp@latest
```

This ensures that the instructions work as expected out of the box, providing a smooth developer experience.

Here is the specific change:
```diff
- npx y @mui/mcp@latest
+ npx -y @mui/mcp@latest
```

---

-   [x] I have read the [contributing guidelines](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md) of this project.