### PR TITLE
[docs][Menu] Replace `TransitionComponent` with `slots.transition` in demo

### DIFF
--- a/docs/data/material/components/menus/FadeMenu.js
+++ b/docs/data/material/components/menus/FadeMenu.js
@@ -32,10 +32,10 @@ export default function FadeMenu() {
             'aria-labelledby': 'fade-button',
           },
         }}
+        slots={{ transition: Fade }}
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}
-        TransitionComponent={Fade}
       >
         <MenuItem onClick={handleClose}>Profile</MenuItem>
         <MenuItem onClick={handleClose}>My account</MenuItem>

--- a/docs/data/material/components/menus/FadeMenu.tsx
+++ b/docs/data/material/components/menus/FadeMenu.tsx
@@ -32,10 +32,10 @@ export default function FadeMenu() {
             'aria-labelledby': 'fade-button',
           },
         }}
+        slots={{ transition: Fade }}
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}
-        TransitionComponent={Fade}
       >
         <MenuItem onClick={handleClose}>Profile</MenuItem>
         <MenuItem onClick={handleClose}>My account</MenuItem>


### PR DESCRIPTION
This PR replaces TransitionComponent with slots.transition in demos

preview: https://deploy-preview-46661--material-ui.netlify.app/material-ui/react-menu/#change-transition