### PR TITLE
[website] Add missing autoComplete='email'

### DIFF
--- a/docs/src/components/footer/EmailSubscribe.tsx
+++ b/docs/src/components/footer/EmailSubscribe.tsx
@@ -100,6 +100,7 @@ export default function EmailSubscribe({ sx }: { sx?: SxProps<Theme> }) {
           name="email"
           type="email"
           placeholder="example@email.com"
+          autoComplete="email"
           value={form.email}
           onChange={(event) => setForm({ email: event.target.value, status: 'initial' })}
           inputProps={{ required: true }}


### PR DESCRIPTION
Fix https://mui.com/

<img width="1012" height="395" alt="SCR-20250811-cxpk" src="https://github.com/user-attachments/assets/1a776a41-7812-4955-8231-caf3a34f0514" />

---

After: https://deploy-preview-46710--material-ui.netlify.app/