### PR TITLE
[docs][Select] Fix labeling issues in grouped select demo

### DIFF
--- a/docs/data/material/components/selects/GroupedSelect.js
+++ b/docs/data/material/components/selects/GroupedSelect.js
@@ -23,8 +23,17 @@ export default function GroupedSelect() {
         </Select>
       </FormControl>
       <FormControl sx={{ m: 1, minWidth: 120 }}>
-        <InputLabel htmlFor="grouped-select">Grouping</InputLabel>
-        <Select defaultValue="" id="grouped-select" label="Grouping">
+        <InputLabel id="grouped-select-label" htmlFor="grouped-select">
+          Grouping
+        </InputLabel>
+        <Select
+          defaultValue=""
+          id="grouped-select"
+          label="Grouping"
+          SelectDisplayProps={{
+            'aria-labelledby': 'grouped-select-label',
+          }}
+        >
           <MenuItem value="">
             <em>None</em>
           </MenuItem>

--- a/docs/data/material/components/selects/GroupedSelect.tsx
+++ b/docs/data/material/components/selects/GroupedSelect.tsx
@@ -23,8 +23,17 @@ export default function GroupedSelect() {
         </Select>
       </FormControl>
       <FormControl sx={{ m: 1, minWidth: 120 }}>
-        <InputLabel htmlFor="grouped-select">Grouping</InputLabel>
-        <Select defaultValue="" id="grouped-select" label="Grouping">
+        <InputLabel id="grouped-select-label" htmlFor="grouped-select">
+          Grouping
+        </InputLabel>
+        <Select
+          defaultValue=""
+          id="grouped-select"
+          label="Grouping"
+          SelectDisplayProps={{
+            'aria-labelledby': 'grouped-select-label',
+          }}
+        >
           <MenuItem value="">
             <em>None</em>
           </MenuItem>


### PR DESCRIPTION
Fixes this error reported by Lighthouse:

<img width="550" alt="Image" src="https://github.com/user-attachments/assets/a1f6f174-bccf-4b1d-aefe-89680cf1147c" />

The issue was that the element with `role="combobox"` wasn't associated with the `InputLabel`

Closes https://github.com/mui/material-ui/issues/46686

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
