### PR TITLE
[code-infra] Remove `fs-extra` from `mui-icons-material`

### DIFF
--- a/packages/mui-icons-material/builder.mjs
+++ b/packages/mui-icons-material/builder.mjs
@@ -1,5 +1,5 @@
 import path from 'path';
-import fse from 'fs-extra';
+import fs from 'node:fs/promises';
 import yargs from 'yargs';
 import { rimrafSync } from 'rimraf';
 import Mustache from 'mustache';
@@ -49,7 +49,7 @@ async function generateIndex(options) {
     .sort()
     .join('');
 
-  await fse.writeFile(path.join(options.outputDir, 'index.js'), index);
+  await fs.writeFile(path.join(options.outputDir, 'index.js'), index);
 }
 
 // Noise introduced by Google by mistake
@@ -218,9 +218,9 @@ async function worker({ progress, svgPath, options, renameFilter, template }) {
   const destPath = renameFilter(svgPathObj, innerPath, options);
 
   const outputFileDir = path.dirname(path.join(options.outputDir, destPath));
-  await fse.ensureDir(outputFileDir);
+  await fs.mkdir(outputFileDir, { recursive: true });
 
-  const data = await fse.readFile(svgPath, { encoding: 'utf8' });
+  const data = await fs.readFile(svgPath, { encoding: 'utf8' });
   const paths = cleanPaths({ svgPath, data });
 
   const componentName = getComponentName(destPath);
@@ -231,7 +231,7 @@ async function worker({ progress, svgPath, options, renameFilter, template }) {
   });
 
   const absDestPath = path.join(options.outputDir, destPath);
-  await fse.writeFile(absDestPath, fileString);
+  await fs.writeFile(absDestPath, fileString);
 }
 
 export async function handler(options) {
@@ -247,11 +247,11 @@ export async function handler(options) {
   if (typeof renameFilter !== 'function') {
     throw new Error('renameFilter must be a function');
   }
-  await fse.ensureDir(options.outputDir);
+  await fs.mkdir(options.outputDir, { recursive: true });
 
   const [svgPaths, template] = await Promise.all([
     globAsync(normalizePath(path.join(options.svgDir, options.glob))),
-    fse.readFile(path.join(currentDirectory, 'templateSvgIcon.js'), {
+    fs.readFile(path.join(currentDirectory, 'templateSvgIcon.js'), {
       encoding: 'utf8',
     }),
   ]);
@@ -286,8 +286,8 @@ export async function handler(options) {
     );
   }
 
-  await fse.copy(path.join(currentDirectory, '/legacy'), options.outputDir);
-  await fse.copy(path.join(currentDirectory, '/custom'), options.outputDir);
+  await fs.cp(path.join(currentDirectory, '/legacy'), options.outputDir, { recursive: true });
+  await fs.cp(path.join(currentDirectory, '/custom'), options.outputDir, { recursive: true });
 
   await generateIndex(options);
 }

--- a/packages/mui-icons-material/builder.test.mjs
+++ b/packages/mui-icons-material/builder.test.mjs
@@ -3,7 +3,6 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import fse from 'fs-extra';
 import { RENAME_FILTER_MUI, RENAME_FILTER_DEFAULT, getComponentName, handler } from './builder.mjs';
 
 const currentDirectory = fileURLToPath(new URL('.', import.meta.url));
@@ -50,7 +49,7 @@ describe('builder', () => {
         'material-ui-icons-builder-test',
         this.currentTest.fullTitle(),
       );
-      await fse.emptyDir(options.outputDir);
+      await emptyDir(options.outputDir);
     });
 
     it('script outputs to directory', async () => {
@@ -77,7 +76,7 @@ describe('builder', () => {
         'material-ui-icons-builder-test',
         this.currentTest.fullTitle(),
       );
-      await fse.emptyDir(options.outputDir);
+      await emptyDir(options.outputDir);
     });
 
     it('script outputs to directory', async () => {
@@ -118,7 +117,7 @@ describe('builder', () => {
         'material-ui-icons-builder-test',
         this.currentTest.fullTitle(),
       );
-      await fse.emptyDir(options.outputDir);
+      await emptyDir(options.outputDir);
     });
 
     it('should produce the expected output', async () => {
@@ -154,3 +153,8 @@ describe('builder', () => {
     });
   });
 });
+
+async function emptyDir(dir) {
+  await fs.promises.rm(dir, { recursive: true, force: true });
+  await fs.promises.mkdir(dir, { recursive: true });
+}

--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -55,7 +55,6 @@
     "chalk": "^5.5.0",
     "cross-fetch": "^4.1.0",
     "fast-glob": "^3.3.3",
-    "fs-extra": "^11.3.1",
     "lodash": "^4.17.21",
     "mustache": "^4.2.0",
     "react": "^19.1.1",

--- a/packages/mui-icons-material/scripts/download.mjs
+++ b/packages/mui-icons-material/scripts/download.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import fetch from 'cross-fetch';
-import fse from 'fs-extra';
+import fs from 'node:fs/promises';
 import path from 'path';
 import yargs from 'yargs';
 import { fileURLToPath } from 'url';
@@ -139,7 +139,7 @@ function downloadIcon(icon) {
         throw new Error(`status ${response.status}`);
       }
       const SVG = await response.text();
-      await fse.writeFile(
+      await fs.writeFile(
         path.join(
           currentDirectory,
           `../material-icons/${icon.name}${themeFileMap[theme]}_24px.svg`,
@@ -156,7 +156,9 @@ async function run() {
       .usage('Download the SVG from material.io/resources/icons')
       .describe('start-after', 'Resume at the following index').argv;
     console.log('run', argv);
-    await fse.emptyDir(path.join(currentDirectory, '../material-icons'));
+    const iconDir = path.join(currentDirectory, '../material-icons');
+    await fs.rm(iconDir, { recursive: true, force: true });
+    await fs.mkdir(iconDir, { recursive: true });
     const response = await fetch(
       'https://fonts.google.com/metadata/icons?key=material_symbols&incomplete=true',
     );

--- a/packages/netlify-plugin-cache-docs/package.json
+++ b/packages/netlify-plugin-cache-docs/package.json
@@ -10,9 +10,6 @@
   },
   "license": "MIT",
   "scripts": {},
-  "dependencies": {
-    "fs-extra": "^11.3.1"
-  },
   "engines": {
     "node": ">=14.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1364,9 +1364,6 @@ importers:
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
-      fs-extra:
-        specifier: ^11.3.1
-        version: 11.3.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1975,11 +1972,7 @@ importers:
         version: 21.0.0
     publishDirectory: build
 
-  packages/netlify-plugin-cache-docs:
-    dependencies:
-      fs-extra:
-        specifier: ^11.3.1
-        version: 11.3.1
+  packages/netlify-plugin-cache-docs: {}
 
   packages/react-docgen-types:
     devDependencies:


### PR DESCRIPTION
Part of https://github.com/mui/mui-public/issues/481.

Remove `fs-extra` from `mui-icons-material`.

Also removed it from the dependencies of `netlify-plugin-cache-docs`, which I forgot to do in https://github.com/mui/material-ui/commit/38a35bb1739caf6add62fbbdeb0cd77ee8acdb6a.