### PR TITLE
[chip] Remove unnecessary optional chaining from key event handlers

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -519,11 +519,11 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
       },
       onKeyDown: (event) => {
         handlers.onKeyDown?.(event);
-        handleKeyDown?.(event);
+        handleKeyDown(event);
       },
       onKeyUp: (event) => {
         handlers.onKeyUp?.(event);
-        handleKeyUp?.(event);
+        handleKeyUp(event);
       },
     }),
   });


### PR DESCRIPTION
In #46263, unnecessary optional chaining was added for `handleKeyDown` and `handleKeyUp`. These handlers are defined within the component. Optional chaining is only needed for the developer-provided `onClick`. We can keep the tests from #46263.