### PR TITLE
[docs][Popover] removed `id` prop from example

### DIFF
--- a/docs/data/material/components/popover/BasicPopover.js
+++ b/docs/data/material/components/popover/BasicPopover.js
@@ -15,15 +15,13 @@ export default function BasicPopover() {
   };
 
   const open = Boolean(anchorEl);
-  const id = open ? 'simple-popover' : undefined;
 
   return (
     <div>
-      <Button aria-describedby={id} variant="contained" onClick={handleClick}>
+      <Button variant="contained" onClick={handleClick}>
         Open Popover
       </Button>
       <Popover
-        id={id}
         open={open}
         anchorEl={anchorEl}
         onClose={handleClose}


### PR DESCRIPTION
Removed `id` prop from `<Popover>` [basic component example](https://mui.com/material-ui/react-popover/#basic-popover). 

This prop usage in the demo is confusing since it is not stated in the [API page of the `Popover`](https://mui.com/material-ui/api/popover/) but it still used, without any explanation. It is definitely not needed for the "Basic Popover" example.

Either the demo is using a pop which not part of the API or the [API page](https://mui.com/material-ui/api/popover/) is lacking proper documentation for the `id` prop

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
