### PR TITLE
[slider] Fix thumb lagging issue on low-end devices

### DIFF
--- a/packages/mui-material/src/Slider/useSlider.ts
+++ b/packages/mui-material/src/Slider/useSlider.ts
@@ -20,8 +20,6 @@ import {
 import { EventHandlers } from '../utils/types';
 import areArraysEqual from '../utils/areArraysEqual';
 
-
-
 function getNewValue(
   currentValue: number,
   step: number,
@@ -664,10 +662,10 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
 
       // Avoid text selection
       event.preventDefault();
-      
+
       // Set dragging immediately for better responsiveness
       setDragging(true);
-      
+
       const finger = trackFinger(event, touchId);
       if (finger !== false) {
         const { newValue, activeIndex } = getFingerNewValue({ finger });

--- a/packages/mui-material/src/Slider/useSlider.ts
+++ b/packages/mui-material/src/Slider/useSlider.ts
@@ -20,7 +20,7 @@ import {
 import { EventHandlers } from '../utils/types';
 import areArraysEqual from '../utils/areArraysEqual';
 
-const INTENTIONAL_DRAG_COUNT_THRESHOLD = 2;
+
 
 function getNewValue(
   currentValue: number,
@@ -554,10 +554,6 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
     focusThumb({ sliderRef, activeIndex, setActive });
     setValueState(newValue);
 
-    if (!dragging && moveCount.current > INTENTIONAL_DRAG_COUNT_THRESHOLD) {
-      setDragging(true);
-    }
-
     if (handleChange && !areValuesEqual(newValue, valueDerived)) {
       handleChange(nativeEvent, newValue, activeIndex);
     }
@@ -596,6 +592,9 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
     if (!doesSupportTouchActionNone()) {
       nativeEvent.preventDefault();
     }
+
+    // Set dragging immediately for better responsiveness
+    setDragging(true);
 
     const touch = nativeEvent.changedTouches[0];
     if (touch != null) {
@@ -665,6 +664,10 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
 
       // Avoid text selection
       event.preventDefault();
+      
+      // Set dragging immediately for better responsiveness
+      setDragging(true);
+      
       const finger = trackFinger(event, touchId);
       if (finger !== false) {
         const { newValue, activeIndex } = getFingerNewValue({ finger });


### PR DESCRIPTION
[Slider] Fix thumb lagging issue on low-end devices by improving drag responsiveness
- Remove INTENTIONAL_DRAG_COUNT_THRESHOLD logic that caused delayed drag state activation
- Set dragging state immediately on touch/mouse start for instant visual feedback
- Eliminate moveCount-based threshold that was causing thumb lag on slower devices
- Improve user experience by providing immediate responsiveness to drag interactions

The previous implementation used a moveCount threshold (2+ moves) before setting
dragging=true, which caused noticeable lag on low-end devices where move events
are processed slower. This change ensures the thumb responds immediately to
user interaction, providing consistent and responsive behavior across all device
performance levels.

Fixes: https://github.com/mui/material-ui/issues/44851 (thumb lagging on low-end devices)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
