### PR TITLE
[docs][autocomplete] Fix Google Maps brand attribution

### DIFF
--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -97,7 +97,7 @@ const fetch = debounce(async (request, callback) => {
       }),
     );
   } catch (err) {
-    if (err.message === 'Quota exceeded for quota') {
+    if (err.message.startsWith('Quota exceeded for quota')) {
       callback(request.input.length === 1 ? fakeAnswer.p : fakeAnswer.paris);
     }
 
@@ -193,7 +193,6 @@ export default function GoogleMaps() {
       includeInputInList
       filterSelectedOptions
       value={value}
-      open
       noOptionsText="No locations"
       onChange={(event, newValue) => {
         setOptions(newValue ? [newValue, ...options] : options);

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -110,7 +110,7 @@ const fetch = debounce(
         }),
       );
     } catch (err: any) {
-      if (err.message === 'Quota exceeded for quota') {
+      if (err.message.startsWith('Quota exceeded for quota')) {
         callback(request.input.length === 1 ? fakeAnswer.p : fakeAnswer.paris);
       }
 
@@ -211,7 +211,6 @@ export default function GoogleMaps() {
       includeInputInList
       filterSelectedOptions
       value={value}
-      open
       noOptionsText="No locations"
       onChange={(event: any, newValue: PlaceType | null) => {
         setOptions(newValue ? [newValue, ...options] : options);


### PR DESCRIPTION
The brand changed: https://developers.google.com/maps/documentation/javascript/policies

<img width="334" height="423" alt="SCR-20250823-owzl" src="https://github.com/user-attachments/assets/a6cd160f-195b-4770-9746-41ab5692812e" />
<img width="328" height="428" alt="SCR-20250823-owxd" src="https://github.com/user-attachments/assets/8482c05d-b917-4880-afd2-a812e0829c1c" />

A quick follow-up on #46793.

It's not too far off from their official implementation: https://developers.google.com/maps/documentation/javascript/examples/place-autocomplete-map

<img width="569" height="395" alt="SCR-20250823-oznn" src="https://github.com/user-attachments/assets/0ff1630c-7920-47e7-b81c-8c301fa349a5" />

Preview: https://deploy-preview-46803--material-ui.netlify.app/material-ui/react-autocomplete/#google-maps-place