### PR TITLE
[code-infra] Transpile `assertion-error` in karma tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,9 +278,6 @@ jobs:
       - run:
           name: Tests real browsers
           command: pnpm test:karma
-          environment:
-            # temporary, remove before merging
-            BROWSERSTACK_FORCE: 'true'
       - run:
           name: Check coverage generated
           command: |


### PR DESCRIPTION
mui/material-ui#46886 broke tests on browserstack - safari, https://app.circleci.com/pipelines/github/mui/material-ui/159803/workflows/1c9d0f8c-47ae-44ba-b00e-3b9c6d8eb013/jobs/853875

```
Safari 15.6.1 (Mac OS 10.15.7) ERROR
  SyntaxError: Unexpected token '{'
  at /tmp/_karma_webpack_100568/commons.js:48829:0
Safari 15.6.1 (Mac OS 10.15.7) ERROR
  SyntaxError: Unexpected token '{'
  at /tmp/_karma_webpack_100568/commons.js:48829:0
Safari 15.6.1 (Mac OS 10.15.7): Executed 0 of 0 ERROR (50.947 secs / 0 secs)
```


Inspecting the commons.js source locally yields:

```15.6.1, but not
// node_modules/assertion-error/index.js
48210 var canElideFrames = "captureStackTrace" in Error;
48211 var AssertionError = class _AssertionError extends Error {
48212   static {
48213     __name(this, "AssertionError");
48214   }
```

[static class fields](https://caniuse.com/mdn-javascript_classes_static_class_fields) are supported in Safari but not [static class initialization blocks](https://caniuse.com/mdn-javascript_classes_static_initialization_blocks), they are only available in 16.4


Proof that it worked: https://app.circleci.com/pipelines/github/mui/material-ui/159940/workflows/00e4b6ee-6dce-4233-984e-438b6f922efa/jobs/854498