### PR TITLE
[code-infra] Exact match for renovate file name

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,8 +70,9 @@
       "enabled": false
     },
     {
-      "groupName": "codemode tests",
-      "matchFileNames": ["packages/mui-codemod"],
+      "groupName": "codemod tests",
+      "description": "Prevent renovate from renaming @material-ui/core to @mui/material in the codemod tests.",
+      "matchFileNames": ["packages/mui-codemod/package.json"],
       "matchPackageNames": ["@material-ui/core"],
       "enabled": false
     }


### PR DESCRIPTION
Looks like we need to fully specify the path or a glob, matching folders doesn't seem to work