### PR TITLE
[code-infra] Fix github actions check for continuous release

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -18,6 +18,11 @@ on:
 permissions: {}
 
 jobs:
+  continuous-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No continuous release required"'
+
   test-dev:
     if: ${{ github.actor != 'l10nbot' }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Need to do the same as ci-check for job that doesn't run on pull request that only touches docs.

We should probably just consider removing this weird optimization for docs only changes. Or split this into two files, because now for docs only PRs, the packages in stackblitz/codesandbox don't exist