### PR TITLE
[docs-infra] Fix warning redirects

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -264,14 +264,5 @@ export default withDocsInfra({
             { source: `/static/x/:rest*`, destination: 'http://0.0.0.0:3001/static/x/:rest*' },
           ];
         },
-        redirects: async () => {
-          return [
-            {
-              source: '/base-ui/',
-              destination: 'https://base-ui.com',
-              permanent: true,
-            },
-          ];
-        },
       }),
 } satisfies NextConfig);

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -249,15 +249,6 @@ export default withDocsInfra({
 
     return map;
   },
-  redirects: async () => {
-    return [
-      {
-        source: '/base-ui/',
-        destination: 'https://base-ui.com',
-        permanent: true,
-      },
-    ];
-  },
   // Used to signal we run pnpm build
   ...(process.env.NODE_ENV === 'production'
     ? {
@@ -271,6 +262,15 @@ export default withDocsInfra({
             // Make sure to include the trailing slash if `trailingSlash` option is set
             { source: '/api/:rest*/', destination: '/api-docs/:rest*/' },
             { source: `/static/x/:rest*`, destination: 'http://0.0.0.0:3001/static/x/:rest*' },
+          ];
+        },
+        redirects: async () => {
+          return [
+            {
+              source: '/base-ui/',
+              destination: 'https://base-ui.com',
+              permanent: true,
+            },
           ];
         },
       }),


### PR DESCRIPTION
This was added in #45083, which led to warnings like: 

<img width="1006" height="125" alt="SCR-20250921-nmkl" src="https://github.com/user-attachments/assets/487c886d-d232-4cde-9bf5-6e8f54d8f6d0" />

https://app.netlify.com/projects/material-ui/deploys/68cff7a09818140007510c16

I noticed it looking at something else, I was annoyed by it.