### PR TITLE
[code-infra] Fix package.json repo info for publishing

### DIFF
--- a/packages-internal/test-utils/package.json
+++ b/packages-internal/test-utils/package.json
@@ -4,6 +4,11 @@
   "author": "MUI Team",
   "description": "Utilities for MUI tests. This is an internal package not meant for general use.",
   "main": "./build/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mui/material-ui.git",
+    "directory": "packages-internal/test-utils"
+  },
   "exports": {
     ".": "./build/index.js",
     "./createDescribe": "./build/createDescribe.js",

--- a/packages/api-docs-builder-core/package.json
+++ b/packages/api-docs-builder-core/package.json
@@ -8,6 +8,11 @@
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/api-docs-builder/**/*.test.?(c|m)[jt]s?(x)'",
     "typescript": "tsc -p tsconfig.json"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mui/material-ui.git",
+    "directory": "packages/api-docs-builder-core"
+  },
   "dependencies": {
     "@mui-internal/api-docs-builder": "workspace:^",
     "@mui/internal-markdown": "workspace:^",

--- a/packages/api-docs-builder/package.json
+++ b/packages/api-docs-builder/package.json
@@ -7,6 +7,11 @@
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/api-docs-builder/**/*.test.?(c|m)[jt]s?(x)'",
     "typescript": "tsc -p tsconfig.json"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mui/material-ui.git",
+    "directory": "packages/api-docs-builder"
+  },
   "dependencies": {
     "@babel/core": "^7.28.4",
     "@babel/preset-typescript": "^7.27.1",


### PR DESCRIPTION
When publishing, we see this error:
```
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@mui%2finternal-test-utils - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/mui/material-ui" from provenance
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
