### PR TITLE
[docs-infra] Add alias to package.json files to some of the packages

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -91,6 +91,10 @@ export default withDocsInfra({
           ...config.resolve.alias,
 
           // for 3rd party packages with dependencies in this repository
+          '@mui/material/package.json': path.resolve(
+            workspaceRoot,
+            'packages/mui-material/package.json',
+          ),
           '@mui/material$': path.resolve(workspaceRoot, 'packages/mui-material/src/index.js'),
           '@mui/material': path.resolve(workspaceRoot, 'packages/mui-material/src'),
 
@@ -102,10 +106,15 @@ export default withDocsInfra({
           '@mui/icons-material': path.resolve(workspaceRoot, 'packages/mui-icons-material/lib/esm'),
           '@mui/lab': path.resolve(workspaceRoot, 'packages/mui-lab/src'),
           '@mui/styled-engine': path.resolve(workspaceRoot, 'packages/mui-styled-engine/src'),
+          '@mui/system/package.json': path.resolve(
+            workspaceRoot,
+            'packages/mui-system/package.json',
+          ),
           '@mui/system': path.resolve(workspaceRoot, 'packages/mui-system/src'),
           '@mui/private-theming': path.resolve(workspaceRoot, 'packages/mui-private-theming/src'),
           '@mui/utils': path.resolve(workspaceRoot, 'packages/mui-utils/src'),
           '@mui/material-nextjs': path.resolve(workspaceRoot, 'packages/mui-material-nextjs/src'),
+          '@mui/joy/package.json': path.resolve(workspaceRoot, 'packages/mui-joy/package.json'),
           '@mui/joy': path.resolve(workspaceRoot, 'packages/mui-joy/src'),
         },
         extensions: [


### PR DESCRIPTION
Currently, the docs build is failing stating that the modules, like `@mui/material/package.json`, are not found.

Example [build](https://app.netlify.com/projects/material-ui/deploys/68e5716cd05bd600084ee7bf).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
