### PR TITLE
[docs-infra] Exclude a few pages from llms-txt

### DIFF
--- a/scripts/buildLlmsDocs/index.ts
+++ b/scripts/buildLlmsDocs/index.ts
@@ -254,8 +254,8 @@ function findNonComponentMarkdownFiles(
 
     const ignoredPaths = [
       '/material-ui/experimental-api/',
-      '/material/migration/migrating-to-pigment-css',
-      '/material/about-the-lab',
+      '/material-ui/migration/migrating-to-pigment-css',
+      '/material-ui/about-the-lab',
     ];
 
     // Filter out external links and special patterns


### PR DESCRIPTION
While pigment is not stable yet, we can avoid confusion in LLMs for the time being.
