### PR TITLE
[code-infra] Update vitest usage detection in `@mui/internal-test-utils`

### DIFF
--- a/packages-internal/test-utils/src/createRenderer.tsx
+++ b/packages-internal/test-utils/src/createRenderer.tsx
@@ -519,7 +519,7 @@ export function createRenderer(globalOptions: CreateRendererOptions = {}): Rende
     clockConfig,
     strict: globalStrict = true,
     strictEffects: globalStrictEffects = globalStrict,
-    vi = (globalThis as any).vi || {},
+    vi = (globalThis as any).vi,
     clockOptions,
   } = globalOptions;
   // save stack to re-use in test-hooks


### PR DESCRIPTION
Detect vitest usage by checking that the `vi` argument isn't `null` or `undefined`.

The current detection method broke in the upgrade to Vitest v4 in MUI X ([PR](https://github.com/mui/mui-x/pull/20102)). 

