### PR TITLE
[docs-infra] Restrict legacy env vars to server only

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -32,7 +32,7 @@ module.exports = {
         'process.env': {
           COMMIT_REF: JSON.stringify(process.env.COMMIT_REF),
           ENABLE_AD: JSON.stringify(process.env.ENABLE_AD),
-          GITHUB_AUTH: JSON.stringify(process.env.GITHUB_AUTH),
+          ...(options.isServer ? { GITHUB_AUTH: JSON.stringify(process.env.GITHUB_AUTH) } : {}),
           LIB_VERSION: JSON.stringify(pkg.version),
           PULL_REQUEST: JSON.stringify(process.env.PULL_REQUEST === 'true'),
           REACT_MODE: JSON.stringify(reactMode),


### PR DESCRIPTION
Restrict some vars to server bundles only
