### PR TITLE
[code-infra] Migrate versions page to getStaticProps

### DIFF
--- a/docs/pages/versions.js
+++ b/docs/pages/versions.js
@@ -35,7 +35,7 @@ async function getBranches() {
   return JSON.parse(text);
 }
 
-Page.getInitialProps = async () => {
+export async function getStaticProps() {
   const FILTERED_BRANCHES = ['latest', 'l10n', 'next', 'migration', 'material-ui.com'];
 
   const branches = await getBranches();
@@ -75,5 +75,5 @@ Page.getInitialProps = async () => {
     });
   }
 
-  return { versions: uniqBy(versions, (item) => item.version) };
-};
+  return { props: { versions: uniqBy(versions, (item) => item.version) } };
+}


### PR DESCRIPTION
Make sure this code can only run during the build. To keep the token out of the bundles.

Also using this as a canary to assess how difficult the migration could be. It probably wouldn't be difficult at all.

~Comparing lighthouse score locally against recent PR Seems to have a drastic effect:~

<details>
<summary>Hiding these results. Can't reproduce anymore</summary>

* Baseline: https://deploy-preview-47140--material-ui.netlify.app/versions/

    <img width="738" height="637" alt="Screenshot 2025-10-31 at 10 58 09" src="https://github.com/user-attachments/assets/3e217bf7-8ec5-4b13-809b-7946b60ce1e3" />

* This PR: https://deploy-preview-47151--material-ui.netlify.app/versions/

    <img width="717" height="650" alt="Screenshot 2025-10-31 at 10 58 01" src="https://github.com/user-attachments/assets/299873f3-200e-47a1-8f81-292e37d85157" />
</details>