### PR TITLE
[system] Fix unwanted attribute on DOM from InitColorSchemeScript `class` attribute

### DIFF
--- a/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.test.js
+++ b/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.test.js
@@ -52,6 +52,9 @@ describe('InitColorSchemeScript', () => {
     document.documentElement.classList.remove(...document.documentElement.classList);
 
     const { container } = render(<InitColorSchemeScript attribute="class" />);
+    expect(container.firstChild.textContent.replace(/\s/g, '')).not.to.include(
+      "setAttribute('.%s',colorScheme)",
+    );
     eval(container.firstChild.textContent);
     expect(document.documentElement.classList.value).to.equal('foo');
     document.documentElement.classList.remove('foo'); // cleanup

--- a/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.tsx
+++ b/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.tsx
@@ -79,7 +79,7 @@ export default function InitColorSchemeScript(options?: InitColorSchemeScriptPro
     }
     setter += `
       ${colorSchemeNode}.setAttribute('${attr}'.replace('%s', colorScheme), ${value ? `${value}.replace('%s', colorScheme)` : '""'});`;
-  } else {
+  } else if (attribute !== '.%s') {
     setter += `${colorSchemeNode}.setAttribute('${attribute}', colorScheme);`;
   }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Found this issue in my side project:

1. Open https://www.mui-treasury.com/
2. switch to "Dark" mode
3. inspect the html element
4. the `.%s="light"` is spread to DOM

<img width="553" height="58" alt="image" src="https://github.com/user-attachments/assets/54835919-5de0-4760-8f7d-6e4c82472336" />


---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
