### PR TITLE
[Checkbox] adding error prop

### DIFF
--- a/docs/pages/material-ui/api/checkbox.json
+++ b/docs/pages/material-ui/api/checkbox.json
@@ -78,6 +78,12 @@
   ],
   "classes": [
     {
+      "key": "error",
+      "className": "Mui-error",
+      "description": "State class applied to the root element if `error={true}`.",
+      "isGlobal": true
+    },
+    {
       "key": "checked",
       "className": "Mui-checked",
       "description": "State class applied to the root element if `checked={true}`.",

--- a/packages/mui-material/src/Checkbox/Checkbox.d.ts
+++ b/packages/mui-material/src/Checkbox/Checkbox.d.ts
@@ -83,6 +83,11 @@ export interface CheckboxProps
    */
   disabled?: SwitchBaseProps['disabled'];
   /**
+   * If `true`, the component is displayed in an error state.
+   * @default false
+   */
+  error?: boolean;
+  /**
    * If `true`, the ripple effect is disabled.
    * @default false
    */

--- a/packages/mui-material/src/Checkbox/Checkbox.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.js
@@ -16,9 +16,11 @@ import createSimplePaletteValueFilter from '../utils/createSimplePaletteValueFil
 import { useDefaultProps } from '../DefaultPropsProvider';
 import { mergeSlotProps } from '../utils';
 import useSlot from '../utils/useSlot';
+import formControlState from '../FormControl/formControlState';
+import useFormControl from '../FormControl/useFormControl';
 
 const useUtilityClasses = (ownerState) => {
-  const { classes, indeterminate, color, size } = ownerState;
+  const { classes, indeterminate, color, size, error } = ownerState;
 
   const slots = {
     root: [
@@ -34,6 +36,7 @@ const useUtilityClasses = (ownerState) => {
   return {
     ...classes, // forward the disabled and checked classes to the SwitchBase
     ...composedClasses,
+    root: clsx(composedClasses.root, error && 'Mui-error'),
   };
 };
 
@@ -93,6 +96,18 @@ const CheckboxRoot = styled(SwitchBase, {
           },
         })),
       {
+        props: { error: true },
+        style: {
+          color: (theme.vars || theme).palette.error.main,
+          [`&.${checkboxClasses.checked}, &.${checkboxClasses.indeterminate}`]: {
+            color: (theme.vars || theme).palette.error.main,
+          },
+          [`&.${checkboxClasses.disabled}`]: {
+            color: (theme.vars || theme).palette.action.disabled,
+          },
+        },
+      },
+      {
         // Should be last to override other colors
         props: { disableRipple: false },
         style: {
@@ -126,11 +141,20 @@ const Checkbox = React.forwardRef(function Checkbox(inProps, ref) {
     className,
     slots = {},
     slotProps = {},
+    error: errorProp,
     ...other
   } = props;
 
   const icon = indeterminate ? indeterminateIconProp : iconProp;
   const indeterminateIcon = indeterminate ? indeterminateIconProp : checkedIcon;
+
+  const muiFormControl = useFormControl();
+  const fcs = formControlState({
+    props,
+    muiFormControl,
+    states: ['error'],
+  });
+  const error = fcs.error ?? errorProp ?? false;
 
   const ownerState = {
     ...props,
@@ -138,6 +162,7 @@ const Checkbox = React.forwardRef(function Checkbox(inProps, ref) {
     color,
     indeterminate,
     size,
+    error,
   };
 
   const classes = useUtilityClasses(ownerState);
@@ -172,6 +197,7 @@ const Checkbox = React.forwardRef(function Checkbox(inProps, ref) {
             : externalInputProps,
           {
             'data-indeterminate': indeterminate,
+            'aria-invalid': error || undefined,
           },
         ),
       },
@@ -222,6 +248,11 @@ Checkbox.propTypes /* remove-proptypes */ = {
    * @default false
    */
   disabled: PropTypes.bool,
+  /**
+   * If `true`, the component is displayed in an error state.
+   * @default false
+   */
+  error: PropTypes.bool,
   /**
    * If `true`, the ripple effect is disabled.
    * @default false

--- a/packages/mui-material/src/Checkbox/Checkbox.spec.tsx
+++ b/packages/mui-material/src/Checkbox/Checkbox.spec.tsx
@@ -30,3 +30,5 @@ import { expectType } from '@mui/types';
     },
   }}
 />;
+
+<Checkbox error />;

--- a/packages/mui-material/src/Checkbox/Checkbox.test.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.test.js
@@ -108,6 +108,42 @@ describe('<Checkbox />', () => {
     });
   });
 
+  describe('prop: error', () => {
+    it('adds the error class to the root element when `error` is true', () => {
+      render(<Checkbox error />);
+      const checkbox = screen.getByRole('checkbox');
+      const root = checkbox.parentElement;
+
+      expect(root).to.have.class('Mui-error');
+    });
+
+    it('adds the error class when provided by FormControl context', () => {
+      render(
+        <FormControl error>
+          <Checkbox />
+        </FormControl>,
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      const root = checkbox.parentElement;
+
+      expect(root).to.have.class('Mui-error');
+    });
+
+    it('allows the `error` prop to override FormControl context', () => {
+      render(
+        <FormControl error>
+          <Checkbox error={false} />
+        </FormControl>,
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      const root = checkbox.parentElement;
+
+      expect(root).not.to.have.class('Mui-error');
+    });
+  });
+
   describe('theme: customization', () => {
     it('should be customizable in the theme using the size prop.', function test() {
       if (window.navigator.userAgent.includes('jsdom')) {


### PR DESCRIPTION
### Summary

Add built-in error handling to Checkbox, wiring the new error prop into FormControl context, applying the global Mui-error class for styling, and documenting the updated API.