### PR TITLE
[code-infra] Fix React@next tests

### DIFF
--- a/packages/mui-utils/src/elementTypeAcceptingRef/elementTypeAcceptingRef.ts
+++ b/packages/mui-utils/src/elementTypeAcceptingRef/elementTypeAcceptingRef.ts
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import * as React from 'react';
 import chainPropTypes from '../chainPropTypes';
 
 function isClassComponent(elementType: Function) {
@@ -42,6 +43,10 @@ function elementTypeAcceptingRef(
    */
   if (typeof propValue === 'function' && !isClassComponent(propValue)) {
     warningHint = 'Did you accidentally provide a plain function component instead?';
+  }
+
+  if (propValue === React.Fragment) {
+    warningHint = 'Did you accidentally provide React.Fragment instead?';
   }
 
   if (warningHint !== undefined) {


### PR DESCRIPTION
Under the newest version `prop-types` recognizes Fragment component as an elementType. Technically it accepts a ref now, but it won't be compatible with existing usage of this function