### PR TITLE
Add bundle size optimization guide and ESLint rules for icons-material

### DIFF
--- a/.eslintrc.example.json
+++ b/.eslintrc.example.json
@@ -1,0 +1,16 @@
+{
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          {
+            "regex": "^@mui/[^/]+$",
+            "message": "Use path-based imports to avoid loading entire packages. Example: import Button from '@mui/material/Button' instead of import { Button } from '@mui/material'"
+          }
+        ]
+      }
+    ]
+  }
+}
+

--- a/BUNDLE_SIZE_OPTIMIZATION.md
+++ b/BUNDLE_SIZE_OPTIMIZATION.md
@@ -1,0 +1,122 @@
+# Bundle Size Optimization Guide
+
+## المشاكل الرئيسية في حجم المكتبة
+
+### 1. @mui/icons-material - المشكلة الأكبر ⚠️
+
+**المشكلة:**
+- أكثر من 20,000 ملف أيقونة
+- كل أيقونة لها 5 متغيرات (Outlined, Rounded, Sharp, TwoTone, Filled)
+- Barrel imports تحمل كل الملفات في التطوير
+
+**الحل:**
+```javascript
+// ❌ بطيء جداً - يحمل كل الأيقونات (أكثر من 20,000 ملف!)
+import { Delete, Add, Edit } from '@mui/icons-material';
+
+// ✅ سريع - يحمل فقط الأيقونة المطلوبة
+import Delete from '@mui/icons-material/Delete';
+import Add from '@mui/icons-material/Add';
+import Edit from '@mui/icons-material/Edit';
+```
+
+### 2. Barrel Imports من @mui/material
+
+**المشكلة:**
+- Barrel imports تحمل كل المكونات في التطوير
+- يسبب بطء في startup و rebuild times
+
+**الحل:**
+```javascript
+// ❌ بطيء في التطوير
+import { Button, TextField, Dialog } from '@mui/material';
+
+// ✅ أسرع في التطوير
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Dialog from '@mui/material/Dialog';
+```
+
+### 3. Emotion/Styled Engine
+
+**المشكلة:**
+- `@emotion/react` و `@emotion/styled` يضيفان ~50-70 KB (gzipped)
+- ضروري للتنسيق لكنه يزيد الحجم
+
+**الحل:**
+- استخدام Pigment CSS (تجريبي) بدلاً من Emotion
+- أو استخدام CSS modules
+
+## الحلول الموصى بها
+
+### 1. للأيقونات - استخدم الاستيراد المباشر دائماً
+
+```javascript
+// ✅ الصحيح
+import Delete from '@mui/icons-material/Delete';
+import Add from '@mui/icons-material/Add';
+```
+
+### 2. للمكونات - استخدم الاستيراد المباشر
+
+```javascript
+// ✅ الصحيح
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+```
+
+### 3. استخدام Codemod للتحويل التلقائي
+
+```bash
+npx @mui/codemod@latest v5.0.0/path-imports <path>
+```
+
+### 4. Next.js 13.5+ - استخدم optimizePackageImports
+
+```javascript
+// next.config.js
+experimental: {
+  optimizePackageImports: ['@mui/material', '@mui/icons-material']
+}
+```
+
+## ESLint Configuration
+
+أضف هذا إلى `.eslintrc` لمنع barrel imports:
+
+```json
+{
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          { "regex": "^@mui/[^/]+$" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## VS Code Configuration
+
+أضف هذا إلى `.vscode/settings.json` لمنع auto-import من barrel files:
+
+```json
+{
+  "typescript.preferences.autoImportSpecifierExcludeRegexes": ["^@mui/[^/]+$"]
+}
+```
+
+## ملاحظات مهمة
+
+1. **في الإنتاج**: Tree-shaking يعمل تلقائياً، لكن barrel imports تبقى بطيئة في التطوير
+2. **الأيقونات**: المشكلة الأكبر - استخدم path imports دائماً
+3. **المكونات**: استخدم path imports في التطوير لتحسين الأداء
+
+## المراجع
+
+- [Minimizing Bundle Size](https://mui.com/material-ui/guides/minimizing-bundle-size/)
+- [Path Imports Codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod/README.md#path-imports)
+

--- a/MAP.md
+++ b/MAP.md
@@ -1,0 +1,120 @@
+خطة شرح مكتبة Material-UI (MUI)
+1. نظرة عامة على المكتبة
+ما هي Material-UI؟
+مكتبة React مفتوحة المصدر تطبق Material Design من Google
+تحتوي على أكثر من 100 مكون جاهز للاستخدام
+تستخدم نظام monorepo مع Lerna لإدارة الحزم المتعددة
+الإصدار الحالي: 7.3.5
+البنية الأساسية للمكتبة
+الحزم الرئيسية (packages/):
+@mui/material - المكونات الأساسية (Button, TextField, Dialog, etc.)
+@mui/system - نظام CSS utilities للتصميم السريع
+@mui/joy - مكتبة تجريبية بتصميم Joy (في حالة تجميد)
+@mui/lab - مكونات تجريبية غير مستقرة
+@mui/icons-material - أيقونات Material Design
+@mui/utils - أدوات مساعدة
+@mui/styled-engine - محرك التنسيق (Emotion/Styled Components)
+2. هيكل المكونات
+بنية مجلد المكون (مثال: Button)
+Button/
+├── Button.js          # المكون الرئيسي
+├── Button.d.ts        # تعريفات TypeScript
+├── Button.spec.tsx    # اختبارات
+├── buttonClasses.ts   # فئات CSS utilities
+└── index.js           # نقطة التصدير
+كيفية عمل المكون:
+useUtilityClasses - إنشاء فئات CSS ديناميكية
+styled() - إنشاء مكونات مخصصة باستخدام zero-styled
+Theme Integration - دمج مع نظام الثيم
+Variants - دعم متغيرات مختلفة (contained, outlined, text)
+Props System - نظام props مرن مع TypeScript
+3. نظام الثيم (Theming)
+الملفات الرئيسية:
+createTheme.ts - إنشاء ثيم مخصص
+ThemeProvider.tsx - موفر الثيم
+createPalette.js - نظام الألوان
+createTypography.js - نظام الخطوط
+createTransitions.js - الانتقالات والحركات
+الميزات:
+دعم CSS Variables
+Dark Mode
+Responsive Design
+Customization عميق
+4. كيفية إضافة عنصر جديد
+الخطوات:
+إنشاء مجلد جديد في packages/mui-material/src/
+إنشاء الملفات الأساسية:
+ComponentName.js - المكون الرئيسي
+ComponentName.d.ts - TypeScript types
+componentNameClasses.ts - CSS classes
+index.js - Export
+إضافة التصدير في packages/mui-material/src/index.js
+إنشاء الاختبارات في ComponentName.test.js
+إضافة التوثيق في docs/
+مثال على بنية مكون جديد:
+// MyComponent.js
+import { styled } from '../zero-styled';
+import { useUtilityClasses } from './myComponentClasses';
+
+const MyComponentRoot = styled('div', {
+  name: 'MuiMyComponent',
+  // ... styles
+});
+
+export default function MyComponent(props) {
+  // ... implementation
+}
+5. كيفية استخدام المكتبة
+التثبيت:
+npm install @mui/material @emotion/react @emotion/styled
+الاستخدام الأساسي:
+import { Button, TextField, ThemeProvider, createTheme } from '@mui/material';
+
+const theme = createTheme();
+
+function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Button variant="contained">Click me</Button>
+    </ThemeProvider>
+  );
+}
+الميزات المتقدمة:
+Customization - تخصيص المكونات عبر sx prop
+Theming - إنشاء ثيمات مخصصة
+Composition - دمج المكونات
+Accessibility - دعم كامل للوصولية
+6. العيوب والقيود
+العيوب:
+حجم الحزمة الكبير - المكتبة كبيرة نسبياً
+اعتماد على Emotion - يتطلب @emotion/react و @emotion/styled
+منحنى التعلم - يحتاج وقت لفهم النظام بالكامل
+التخصيص المعقد - التخصيص العميق قد يكون معقداً
+Breaking Changes - تحديثات كبيرة بين الإصدارات
+Joy UI متجمد - Joy UI في حالة تجميد ولا يُنصح باستخدامه
+القيود:
+يتطلب React 17+ أو 18+ أو 19+
+يحتاج Node.js 14+ للبناء
+بعض المكونات في @mui/lab غير مستقرة
+Pigment CSS في مرحلة تجريبية
+7. البنية التقنية
+أدوات البناء:
+pnpm - مدير الحزم
+Lerna - إدارة Monorepo
+TypeScript - للأنواع
+Babel - للتحويل
+Mocha - للاختبارات
+نظام التصدير:
+ES Modules
+CommonJS
+TypeScript declarations
+8. التوثيق والمساهمة
+التوثيق:
+الموقع الرسمي: https://mui.com/material-ui/
+الكود في docs/ directory
+أمثلة في examples/ directory
+المساهمة:
+اتباع CONTRIBUTING.md
+إنشاء PR على GitHub
+اختبار التغييرات محلياً
+تحديث التوثيق

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,17 @@ const NO_RESTRICTED_IMPORTS_PATHS_TOP_LEVEL_PACKAGES = [
     name: '@mui/lab',
     message: OneLevelImportMessage,
   },
+<<<<<<< HEAD
+=======
+  {
+    name: '@mui/icons-material',
+    message: [
+      'Prefer path-based imports for icons to avoid loading all 20,000+ icon files in development.',
+      'Use: import Delete from "@mui/icons-material/Delete" instead of: import { Delete } from "@mui/icons-material"',
+      'See: https://mui.com/material-ui/guides/minimizing-bundle-size/#avoid-barrel-imports',
+    ].join('\n'),
+  },
+>>>>>>> e1f6824e81 (Add bundle size optimization guide and ESLint rules for icons-material)
 ];
 
 const NO_RESTRICTED_IMPORTS_PATTERNS_DEEPLY_NESTED = [


### PR DESCRIPTION
- Add BUNDLE_SIZE_OPTIMIZATION.md with comprehensive guide on reducing bundle size
- Add ESLint rule to prevent barrel imports from @mui/icons-material (20,000+ files issue)
- Add example VS Code settings to prevent auto-importing from barrel files
- Add example ESLint config for projects using Material-UI

This addresses the biggest bundle size issue: @mui/icons-material barrel imports which can be 6x slower in development.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
