### PR TITLE
[examples] Add missing .gitignore to NextJS App Router example

### DIFF
--- a/examples/material-ui-nextjs/.gitignore
+++ b/examples/material-ui-nextjs/.gitignore
@@ -1,0 +1,18 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Next.js
+/.next


### PR DESCRIPTION
Add missing .gitignore file to the NextJS App Router javascript example in examples/material-ui-nextjs.

I copied the .gitignore file found in the Pages Router equivalent for this. If further changes are to be made to the gitignore file contents, let me know!

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
