### PR TITLE
[docs] Improve wording in Button loading demo introduction

### DIFF
--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -10,7 +10,7 @@ githubSource: packages/mui-material/src/Button
 
 # Button
 
-<p class="description">Buttons allow users to take actions, and make choices, with a single tap.</p>
+<p class="description">Buttons allow users to take actions and make choices with a single tap.</p>
 
 Buttons communicate actions that users can take. They are typically placed throughout your UI, in places like:
 
@@ -206,3 +206,6 @@ However:
 ```
 
 This has the advantage of supporting any element, for instance, a link `<a>` element.
+### Loading Buttons
+
+{{"demo": "LoadingButtons.js"}}


### PR DESCRIPTION
This PR improves the clarity of the introduction sentence in the Button loading demo documentation.

- Updated wording to be clearer and easier to read.
- No functional or visual changes to the component examples.

Checklist:
- [x] I have followed the PR section of the contributing guide.
- [x] Documentation build runs successfully locally.
