### PR TITLE
[docs][AppBar] Document correct default values for elevation and square props

### DIFF
--- a/packages/mui-material/src/AppBar/AppBar.d.ts
+++ b/packages/mui-material/src/AppBar/AppBar.d.ts
@@ -10,6 +10,17 @@ export interface AppBarPropsColorOverrides {}
 
 export interface AppBarOwnProps {
   /**
+   * Shadow depth, corresponds to `dp` in the spec.
+   * It accepts values between 0 and 24 inclusive.
+   * @default 4
+   */
+  elevation?: number;
+  /**
+   * If `false`, rounded corners are enabled.
+   * @default true
+   */
+  square?: boolean;
+  /**
    * Override or extend the styles applied to the component.
    */
   classes?: Partial<AppBarClasses>;
@@ -49,7 +60,7 @@ export type AppBarTypeMap<
     props: AdditionalProps & AppBarOwnProps;
     defaultComponent: RootComponent;
   },
-  'position' | 'color' | 'classes'
+  'position' | 'color' | 'classes' | 'elevation' | 'square'
 >;
 
 /**


### PR DESCRIPTION
Fixes #47260.

- Documents correct default values for `elevation` (4) and `square` (true) on the AppBar component.
- Adds/adjusts JSDoc comments in the type definitions.
- Ensures correct display in API docs.
- Runs proptypes and docs:api scripts to update generated docs.

Verified changes render on local docs site.

<img width="484" height="235" alt="Screenshot From 2025-11-15 10-45-20" src="https://github.com/user-attachments/assets/d2abe18c-3234-4164-ae2b-fed6b2c59592" />
<img width="530" height="235" alt="Screenshot From 2025-11-15 10-45-32" src="https://github.com/user-attachments/assets/c77323d1-6b1d-456e-921e-76f0c7947142" />
<img width="906" height="977" alt="Screenshot From 2025-11-15 10-46-17" src="https://github.com/user-attachments/assets/a0918a34-1e3f-4a42-9996-83f72cd37be8" />
