### PR TITLE
[docs][Chip] Clarify default size in documentation

### DIFF
--- a/docs/data/material/components/chips/chips.md
+++ b/docs/data/material/components/chips/chips.md
@@ -74,7 +74,7 @@ You can use the `color` prop to define a color from theme palette.
 
 ## Sizes chip
 
-You can use the `size` prop to define a small Chip.
+You can use the `size` prop to choose between `medium` (default) and `small`.
 
 {{"demo": "SizesChips.js"}}
 


### PR DESCRIPTION
## Fix: Correct default value of Chip `size` in documentation

### The problem
The Chip documentation listed the wrong default value for the `size` prop.

- **Documented default:** `"small"` (incorrect)
- **Actual default in implementation:** `"medium"`

### The solution
Updated the docs to show the correct default value for the `size` prop.

### What changed
- Fixed the default value of `size` in the Chip docs.

### Result
- Documentation now reflects the actual behavior of the component.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).