### PR TITLE
[docs][Menu] Add missing ListItemIcon import in SimpleListMenu example

### DIFF
--- a/docs/data/material/components/menus/SimpleListMenu.tsx
+++ b/docs/data/material/components/menus/SimpleListMenu.tsx
@@ -4,6 +4,10 @@ import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
+import ListItemIcon from '@mui/material/ListItemIcon';
+
+
+
 
 const options = [
   'Show some love to MUI',


### PR DESCRIPTION
### Description
The SimpleListMenu documentation example uses `ListItemIcon`, but the component was not imported.  
This caused confusion when copying the example directly.

### Changes
- Added missing `ListItemIcon` import to `docs/data/material/components/menus/SimpleListMenu.tsx`.

### Testing
- Verified that the example compiles after adding the import.
- No additional changes were required.

### Impact
This improves clarity and prevents runtime errors for developers who copy the example directly from the documentation.
