### PR TITLE
[docs][Menu] Add missing ListItemIcon import in SimpleListMenu example

### DIFF
--- a/docs/data/material/components/menus/SimpleListMenu.tsx
+++ b/docs/data/material/components/menus/SimpleListMenu.tsx
@@ -4,6 +4,10 @@ import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
+import ListItemIcon from '@mui/material/ListItemIcon';
+
+
+
 
 const options = [
   'Show some love to MUI',


### PR DESCRIPTION
### Problem
The SimpleListMenu documentation example uses `ListItemIcon`, but the component was not imported.  
This caused confusion for readers and resulted in a reference error if copied directly.

### Fix
Added the missing import:

import ListItemIcon from '@mui/material/ListItemIcon';

### Impact
This makes the example accurate, prevents runtime errors, and improves documentation clarity.
