### PR TITLE
fix: allow data structures for formHelperText slot

### DIFF
--- a/packages/mui-material/src/TextField/TextField.d.ts
+++ b/packages/mui-material/src/TextField/TextField.d.ts
@@ -77,7 +77,7 @@ export type TextFieldSlotsAndSlotProps<InputPropsType> = CreateSlotsAndSlotProps
      * Props forwarded to the form helper text slot.
      * By default, the available props are based on the [FormHelperText](https://mui.com/material-ui/api/form-helper-text/#props) component.
      */
-    formHelperText: SlotProps<React.ElementType<FormHelperTextProps>, {}, TextFieldOwnerState>;
+    formHelperText: SlotProps<React.ElementType<FormHelperTextProps>,Record<string, any>,TextFieldOwnerState>;
     /**
      * Props forwarded to the select slot.
      * By default, the available props are based on the [Select](https://mui.com/material-ui/api/select/#props) component.


### PR DESCRIPTION
### Summary
This PR fixes the typings for the `formHelperText` slot in the TextField component by allowing data attributes and other standard HTML props, similar to the other slot props.

### What kind of change does this PR introduce?
- Fixes an incorrect or missing TypeScript type definition.

### Additional context
This change ensures consistency with the other slot props (`htmlInput`, `select`) and aligns with the expected behavior described in Issue #47230.

### Checklist
- [x] I have followed the contributing guidelines.
- [x] I added only the required change.
- [x] The fix builds successfully locally.

