### PR TITLE
[Text Field] Add For Helpe Text Slot Props Overrides for data attributes

### DIFF
--- a/packages/mui-material/src/TextField/TextField.d.ts
+++ b/packages/mui-material/src/TextField/TextField.d.ts
@@ -17,6 +17,7 @@ import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
 export interface TextFieldPropsColorOverrides {}
 export interface TextFieldPropsSizeOverrides {}
 
+
 export interface TextFieldSlots {
   /**
    * The component that renders the root.
@@ -77,7 +78,7 @@ export type TextFieldSlotsAndSlotProps<InputPropsType> = CreateSlotsAndSlotProps
      * Props forwarded to the form helper text slot.
      * By default, the available props are based on the [FormHelperText](https://mui.com/material-ui/api/form-helper-text/#props) component.
      */
-    formHelperText: SlotProps<React.ElementType<FormHelperTextProps>, {}, TextFieldOwnerState>;
+    formHelperText: SlotProps<React.ElementType<FormHelperTextProps>, TextFieldFormHelperTextSlotPropsOverrides, TextFieldOwnerState>;
     /**
      * Props forwarded to the select slot.
      * By default, the available props are based on the [Select](https://mui.com/material-ui/api/select/#props) component.


### PR DESCRIPTION
Fixes #47230

Adds TextFieldFormHelperTextSlotPropsOverrides interface to allow developers to augment the formHelperText slot props with custom data-* attributes using module augmentation.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
