### PR TITLE
[docs][Button] Add demo for disableFocusRipple prop

### DIFF
--- a/docs/data/material/components/buttons/DisableFocusRippleDemo.js
+++ b/docs/data/material/components/buttons/DisableFocusRippleDemo.js
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+
+export default function DisableFocusRippleDemo() {
+  return (
+    <Box>
+      <Button variant="contained" sx={{ mr: 1 }}>
+        Default
+      </Button>
+      <Button variant="contained" disableFocusRipple>
+        Focus Ripple Disabled
+      </Button>
+    </Box>
+  );
+}

--- a/docs/data/material/components/buttons/DisableFocusRippleDemo.tsx
+++ b/docs/data/material/components/buttons/DisableFocusRippleDemo.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+
+export default function DisableFocusRippleDemo() {
+  return (
+    <Box>
+      <Button variant="contained" sx={{ mr: 1 }}>
+        Default
+      </Button>
+      <Button variant="contained" disableFocusRipple>
+        Focus Ripple Disabled
+      </Button>
+    </Box>
+  );
+}

--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -27,6 +27,12 @@ The `Button` comes with three variants: text (default), contained, and outlined.
 
 {{"demo": "BasicButtons.js"}}
 
+## Disable focus ripple
+
+The `disableFocusRipple` prop removes the ripple effect that appears when the button is focused using the keyboard.
+
+<Demo file="buttons/DisableFocusRippleDemo.js" />
+
 ### Text button
 
 [Text buttons](https://m2.material.io/components/buttons#text-button)


### PR DESCRIPTION
This PR adds a new demo to the Button component page to demonstrate the usage and effect of the `disableFocusRipple` prop. This was a self-identified documentation gap as the prop was not shown in any examples.

Fixes #47303

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).