### PR TITLE
Update theme object exploration instructions

### DIFF
--- a/docs/data/material/customization/default-theme/default-theme.md
+++ b/docs/data/material/customization/default-theme/default-theme.md
@@ -5,8 +5,9 @@
 If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createTheme.ts`](https://github.com/mui/material-ui/blob/-/packages/mui-material/src/styles/createTheme.ts),
 and the related imports which `createTheme()` uses.
 
-You can play with the documentation theme object in your browser console,
-as the `theme` variable is exposed on all the documentation pages.
+:::info
+You can explore the documentation `theme` object by opening the browser's developer console on this page. The `theme` variable is available in the console context of the documentation preview iframes.
+:::
 
 :::warning
 Please note that **the documentation site is using a custom theme** (the MUI's organization branding).


### PR DESCRIPTION
Fixes #46580

Updated the documentation tip in `docs/data/material/customization/default-theme/default-theme.md` to clarify how to access the theme object in the browser console.

**Changes:**
- Replaced misleading text suggesting the `theme` variable is directly exposed in the main browser console
- Added clear instructions explaining that the `theme` variable is available in the console context of the documentation preview iframes
- Formatted the tip using the :::info admonition for better visibility

**Why:**
The previous instruction could confuse users who try to access `theme` in their main browser console, where it's not available. The theme object is only accessible in the iframe console context where the documentation previews run.