### PR TITLE
 Add Loading Button Example to Documentation

### DIFF
--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -206,3 +206,32 @@ However:
 ```
 
 This has the advantage of supporting any element, for instance, a link `<a>` element.
+
+### Loading Button Example
+
+```jsx
+import * as React from 'react';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+
+export default function LoadingButtonExample() {
+  const [loading, setLoading] = React.useState(false);
+
+  const handleClick = () => {
+    setLoading(true);
+    setTimeout(() => setLoading(false), 1500);
+  };
+
+  return (
+    <Button
+      variant="contained"
+      disabled={loading}
+      onClick={handleClick}
+      startIcon={loading ? <CircularProgress size={18} /> : null}
+    >
+      {loading ? 'Loading...' : 'Click Me'}
+    </Button>
+  );
+}
+
+This example demonstrates how to build a simple loading state inside a Material UI Button using a spinner and temporary disabled state.


### PR DESCRIPTION
Added a simple example demonstrating how to implement a loading state using Button and Circular Progress.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
This PR adds a new example to the Button component documentation  
that demonstrates how to implement a loading state using Circular Progress.  
This improves the component examples by showing a common real-world usage  
pattern that was previously missing.
