### PR TITLE
[Joy]Fix:Exclude test files from final Typescript declaration Output.

### DIFF
--- a/packages/mui-joy/package.json
+++ b/packages/mui-joy/package.json
@@ -27,7 +27,8 @@
     "release": "pnpm build && pnpm publish",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-joy/**/*.test.?(c|m)[jt]s?(x)'",
     "typescript": "tsc -p tsconfig.json",
-    "typescript:module-augmentation": "node scripts/testModuleAugmentation.js"
+    "typescript:module-augmentation": "node scripts/testModuleAugmentation.js",
+    "build:types-only": "tsc -p tsconfigson"
   },
   "dependencies": {
     "@babel/runtime": "^7.28.4",
@@ -85,4 +86,5 @@
     ".": "./src/index.ts",
     "./*": "./src/*/index.ts"
   }
+
 }

--- a/packages/mui-joy/tsconfig.json
+++ b/packages/mui-joy/tsconfig.json
@@ -1,4 +1,34 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["src/**/*", "test/integration/**/*"]
-}
+  //1.Extend the root configuration for shared settings
+  "extends":"./tsconfig.json",
+  "compilerOptions":{
+    //2,REQUIRED for project references and incremental builds
+    "composite":true,
+    //3.Output Declaration(.d.ts)files
+    "declaration":true,
+    //4.Do NOT emit JavaScript(.js)files (Babel handles this)
+    "noEmit":false,
+    //5.Only generate declaration files,nothing else
+    "emitDeclarationOnly":true, 
+    //6.Specify where the compiled .d.ts files go
+    "outDir":"./build/esm",
+    //7.Root directory of source code
+    "rootDir":"./src"
+  },
+  //8.Explicitly INCLUDE only the source files that should be part of the build
+  "include":["./src/**/*.ts"],
+
+
+    //9.Explicitly EXCLUDE only the source files that should NOT be part of the build
+
+  "exclude":[ 
+    "node_modules",//Standard exclusion
+    "**/test",//Exclude the entire 'test' folder
+    "src/**/*.spec.ts",//Exclude files ending with .spec.ts
+    "src/**/*.test.ts",//Exclude files ending with .test.ts
+],
+  //10.List dependent projects for monorepo functionality
+  "references":[
+    {"path":"../../mui-system/tsconfig.build.json"}
+  ]
+ }


### PR DESCRIPTION
This PR updates tsconfig.json explicitily excludes *.test.ts files,preventing test type declarations from being included in the final package bundle.This was necessary because the default include pattern was pulling test files into the build artifacts.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️  #-->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
