### PR TITLE
[docs-infra] Add some `ComponentLinkHeader` bottom margin

### DIFF
--- a/packages/mui-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx
+++ b/packages/mui-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx
@@ -15,8 +15,7 @@ import MaterialDesignIcon from '../svgIcons/MaterialDesignIcon';
 import { useTranslate } from '../i18n';
 
 const Root = styled('ul')(({ theme }) => ({
-  margin: 0,
-  marginTop: theme.spacing(2),
+  margin: theme.spacing(2, 0),
   padding: 0,
   listStyle: 'none',
   display: 'flex',


### PR DESCRIPTION
Fix number field page formatting where the header is not followed by a h2: https://deploy-preview-47328--material-ui.netlify.app/material-ui/react-number-field/
