### PR TITLE
[fix:]To run jq first to avoid errors in Setup_corepack.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,11 @@ commands:
         description: 'Set to true if you intend to any browser (for example with playwright).'
     steps:
       - run:
+          name: Install jq
+          command: |
+            sudo apt-get update -y
+            sudo apt-get install -y jq
+      - run:
           name: Set npm registry public signing keys
           command: |
             echo "export COREPACK_INTEGRITY_KEYS='$(curl https://registry.npmjs.org/-/npm/v1/keys | jq -c '{npm: .keys}')'" >> $BASH_ENV


### PR DESCRIPTION
As this edit fixes the 
test_unit
test_lint
test_static
test_browser
test_types
Because to run and install jq in Setup_corepack result in clear esults with 0 errors.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
