### PR TITLE
fix(InputBase): restore caret position when clicking wrapper

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -455,14 +455,35 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
   }, []);
 
   const handleClick = (event) => {
-    if (inputRef.current && event.currentTarget === event.target) {
-      inputRef.current.focus();
-    }
+  if (inputRef.current && event.currentTarget === event.target) {
+    const input = inputRef.current;
 
-    if (onClick) {
-      onClick(event);
-    }
-  };
+    // Save current caret position (if any)
+    const pos = typeof input.selectionStart === 'number'
+      ? input.selectionStart
+      : input.value.length;
+
+    input.focus();
+
+    // Restore caret position after focus is forced
+    requestAnimationFrame(() => {
+      try {
+        // If caret was at 0 due to focus forwarding, move to end instead
+        const restorePos =
+          pos === 0 && event.target === event.currentTarget
+            ? input.value.length
+            : pos;
+
+        input.setSelectionRange(restorePos, restorePos);
+      } catch (e) {}
+    });
+  }
+
+  if (onClick) {
+    onClick(event);
+  }
+};
+
   let InputComponent = inputComponent;
   let inputProps = inputPropsProp;
 


### PR DESCRIPTION

This PR fixes an issue where clicking on the `InputBase` wrapper (outside the actual `<input>` element) causes the caret to jump to the beginning of the input value.

### Problem

When a user clicks on the padding/label/wrapper area of `InputBase`, MUI programmatically focuses the real input:

```js
inputRef.current.focus();
```

Some browsers reset the caret to index `0` when focus is forwarded this way, causing unexpected cursor behavior.

### Fix

Before forwarding focus, the caret position is saved, and after focus is applied, it is restored using `requestAnimationFrame` to ensure it runs after the browser’s focus event:

* Preserve caret position (or fallback to end of value)
* Forward focus to the input
* Restore caret position on the next frame

This prevents the caret from jumping to the start.

### Related Issue

Fixes #47336


