### PR TITLE
fix(textfield): expose augmentation interface for formHelperText slot

### DIFF
--- a/packages/mui-material/src/TextField/TextField.d.ts
+++ b/packages/mui-material/src/TextField/TextField.d.ts
@@ -50,6 +50,20 @@ export interface TextFieldSlots {
   select: React.ElementType;
 }
 
+/**
+ * Extension point to allow consumers to augment props for the formHelperText slot.
+ * Example augmentation in the app:
+ * @example
+ * ```typescript
+ * declare module '@mui/material/TextField' {
+ *   interface TextFieldFormHelperTextSlotPropsOverrides {
+ *     'data-testid'?: string; // Example augmentation
+ *   }
+ * }
+ * ```
+ */
+export interface TextFieldFormHelperTextSlotPropsOverrides {}
+
 export type TextFieldSlotsAndSlotProps<InputPropsType> = CreateSlotsAndSlotProps<
   TextFieldSlots,
   {
@@ -77,7 +91,11 @@ export type TextFieldSlotsAndSlotProps<InputPropsType> = CreateSlotsAndSlotProps
      * Props forwarded to the form helper text slot.
      * By default, the available props are based on the [FormHelperText](https://mui.com/material-ui/api/form-helper-text/#props) component.
      */
-    formHelperText: SlotProps<React.ElementType<FormHelperTextProps>, {}, TextFieldOwnerState>;
+    formHelperText: SlotProps<
+      React.ElementType<FormHelperTextProps>,
+      TextFieldFormHelperTextSlotPropsOverrides,
+      TextFieldOwnerState
+    >;
     /**
      * Props forwarded to the select slot.
      * By default, the available props are based on the [Select](https://mui.com/material-ui/api/select/#props) component.


### PR DESCRIPTION
Expose TextFieldFormHelperTextSlotPropsOverrides allowing consumers to augment the formHelperText slot props (for example adding data-* attributes). Added a docs playground demonstrating module augmentation.

Closes #47230

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
