### PR TITLE
docs(material-next): add documentation for customizing the Material You theme (#37601)

### DIFF
--- a/docs/data/material/customization/new-custom-theme.mdx
+++ b/docs/data/material/customization/new-custom-theme.mdx
@@ -37,18 +37,18 @@ export default function App() {
 
 ## Tokens you can typically override
 
-* `mdSys.color` — core color tokens used by Material You components
-* `mdSys.shape` — corner radii / shape tokens
-* `mdSys.typescale` — typography scale tokens
-* `mdSys.motion` — animation/motion tokens
-* `mdSys.elevation` — elevation/shadow tokens
+- `mdSys.color` — core color tokens used by Material You components
+- `mdSys.shape` — corner radii / shape tokens
+- `mdSys.typescale` — typography scale tokens
+- `mdSys.motion` — animation/motion tokens
+- `mdSys.elevation` — elevation/shadow tokens
 
 > **Note:** The exact token names and structure may evolve as `@mui/material-next` matures. Use the package's API docs to confirm the current token names; this guide shows the common pattern and a concrete example.
 
 ## Tips
 
-* Prefer `createTheme` + `ThemeProvider` so your theme composes with MUI defaults.
-* Test visual changes by previewing a few Material You components (Button, Card, Switch).
-* If you need to override very specific styles, use `sx` as a complement to theming.
+- Prefer `createTheme` + `ThemeProvider` so your theme composes with MUI defaults.
+- Test visual changes by previewing a few Material You components (Button, Card, Switch).
+- If you need to override very specific styles, use `sx` as a complement to theming.
 
 </content>


### PR DESCRIPTION
This PR adds a short guide showing how to provide a custom theme for Material You components in @mui/material-next.

- Demonstrates using createTheme and ThemeProvider with mdSys tokens.
- Explains common tokens that can be overridden.

This is a docs-only change.

Closes #37601.
