### PR TITLE
[number field] Fix scroll behavior

### DIFF
--- a/docs/data/material/components/number-field/components/NumberField.js
+++ b/docs/data/material/components/number-field/components/NumberField.js
@@ -25,7 +25,6 @@ function NumberField({ id: idProp, label, error, size = 'medium', ...other }) {
   }
   return (
     <BaseNumberField.Root
-      allowWheelScrub
       {...other}
       render={(props, state) => (
         <FormControl

--- a/docs/data/material/components/number-field/components/NumberField.tsx
+++ b/docs/data/material/components/number-field/components/NumberField.tsx
@@ -34,7 +34,6 @@ export default function NumberField({
   }
   return (
     <BaseNumberField.Root
-      allowWheelScrub
       {...other}
       render={(props, state) => (
         <FormControl


### PR DESCRIPTION
A quick follow-up on #47165, while I landed on the page by chance, looking at the base-ui.com backlinks. Having `allowWheelScrub` seems pointless:

1. This is an option from Base UI. What we build on top of it should assume that Base UI already has the correct default behaviors. So, unless there is a plan to change it in Base UI, but it can't change now because of BCs, I believe we need to rely on Base UI default behaviors, not hide them.
2. It's listed as part of why a component like this one can bring value: #19154, in https://mui.com/material-ui/react-text-field/#type-quot-number-quot too

Preview: https://deploy-preview-47397--material-ui.netlify.app/material-ui/react-number-field/