### PR TITLE
[docs] Fix default theme viewer styling

### DIFF
--- a/docs/src/modules/components/ThemeViewer.tsx
+++ b/docs/src/modules/components/ThemeViewer.tsx
@@ -153,7 +153,7 @@ function ObjectEntry(props: {
   return (
     <TreeItem
       sx={{
-        paddingLeft: `${depth * 8}px`,
+        paddingLeft: depth,
       }}
       itemId={itemId}
       label={<ObjectEntryLabel objectKey={objectKey} objectValue={objectValue} />}


### PR DESCRIPTION
Address: https://github.com/mui/material-ui/pull/46841#pullrequestreview-3222802919

### Before: https://mui.com/material-ui/customization/default-theme/
<img width="936" height="478" alt="image" src="https://github.com/user-attachments/assets/4b03ec8e-926b-44a0-b833-6eebd52ba28a" />



### After:  https://deploy-preview-47400--material-ui.netlify.app/material-ui/customization/default-theme/
<img width="935" height="467" alt="image" src="https://github.com/user-attachments/assets/d283760b-0984-494c-bf00-4e1dc438683d" />
