### PR TITLE
[code-infra] Revive docs bundle analyzer

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -29,11 +29,11 @@ export default withDocsInfra({
   webpack: (config: NextConfig, options): NextConfig => {
     const plugins = config.plugins.slice();
 
-    if (process.env.DOCS_STATS_ENABLED) {
+    if (process.env.DOCS_STATS_ENABLED && !options.isServer) {
       plugins.push(
         // For all options see https://github.com/th0r/webpack-bundle-analyzer#as-plugin
         new BundleAnalyzerPlugin({
-          analyzerMode: 'server',
+          analyzerMode: 'static',
           generateStatsFile: true,
           analyzerPort: options.isServer ? 8888 : 8889,
           reportTitle: `${options.isServer ? 'server' : 'client'} docs bundle`,

--- a/docs/package.json
+++ b/docs/package.json
@@ -102,7 +102,7 @@
     "styled-components": "^6.1.19",
     "stylis": "4.2.0",
     "use-count-up": "^3.0.1",
-    "webpack-bundle-analyzer": "^4.10.2"
+    "webpack-bundle-analyzer": "^5.0.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-react-constant-elements": "^7.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,8 +527,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(react@19.2.0)
       webpack-bundle-analyzer:
-        specifier: ^4.10.2
-        version: 4.10.2
+        specifier: ^5.0.1
+        version: 5.0.1
     devDependencies:
       '@babel/plugin-transform-react-constant-elements':
         specifier: ^7.27.1
@@ -8320,10 +8320,6 @@ packages:
     resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
-  gzip-size@6.0.0:
-    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
-    engines: {node: '>=10'}
-
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
@@ -12443,9 +12439,9 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
-  webpack-bundle-analyzer@4.10.2:
-    resolution: {integrity: sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==}
-    engines: {node: '>= 10.13.0'}
+  webpack-bundle-analyzer@5.0.1:
+    resolution: {integrity: sha512-PUp3YFOHysSw8t+13rcF+8o5SGaP/AZ5KnIF3qJfFodv4xJkmixnfcyy+LOwNadpzvyrEKpaMlewAG2sFUfdpw==}
+    engines: {node: '>= 20.9.0'}
     hasBin: true
 
   webpack-cli@6.0.1:
@@ -20762,10 +20758,6 @@ snapshots:
   graphql@16.11.0:
     optional: true
 
-  gzip-size@6.0.0:
-    dependencies:
-      duplexer: 0.1.2
-
   handlebars@4.7.8:
     dependencies:
       minimist: 1.2.8
@@ -25654,7 +25646,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-bundle-analyzer@4.10.2:
+  webpack-bundle-analyzer@5.0.1:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       acorn: 8.15.0
@@ -25662,7 +25654,6 @@ snapshots:
       commander: 7.2.0
       debounce: 1.2.1
       escape-string-regexp: 4.0.0
-      gzip-size: 6.0.0
       html-escaper: 2.0.2
       opener: 1.5.2
       picocolors: 1.1.1


### PR DESCRIPTION
This OOMs consistently, until I disable the analyzer for the server bundles. We don't care about them, they're only used to statically generate pages.

<img width="1478" height="971" alt="Screenshot 2025-12-01 at 10 36 20" src="https://github.com/user-attachments/assets/349843bc-ed71-48de-a31a-94b410233af9" />
