### PR TITLE
[docs][material-ui] Fix display of colors in dark mode in palette customization page

### DIFF
--- a/docs/data/material/customization/palette/Intentions.js
+++ b/docs/data/material/customization/palette/Intentions.js
@@ -27,7 +27,7 @@ export default function Intentions() {
       <div style={{ backgroundColor: color }} />
       <div>
         <Typography variant="body2">{name}</Typography>
-        <Typography variant="body2" color="textSecondary">
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
           {rgbToHex(color)}
         </Typography>
       </div>


### PR DESCRIPTION
This PR fixes an issue where color value text was not visible in dark mode.

### Before: https://mui.com/material-ui/customization/palette/#values

<img width="935" height="466" alt="image" src="https://github.com/user-attachments/assets/a2404302-1fde-4c3e-9e95-09a04a80fa1c" />



### After: https://deploy-preview-47403--material-ui.netlify.app/material-ui/customization/palette/#values
<img width="937" height="463" alt="image" src="https://github.com/user-attachments/assets/f732bd5e-0bab-419d-8a24-747be947fb6b" />
