### PR TITLE
docs(palette): add missing import in TS augmentation example

### DIFF
--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -279,6 +279,8 @@ If you're using TypeScript, then you'll need to use [module augmentation](/mater
 <!-- tested with packages/mui-material/test/typescript/augmentation/paletteColors.spec.ts -->
 
 ```ts
+import '@mui/material/styles';
+
 declare module '@mui/material/styles' {
   interface PaletteColor {
     darker?: string;


### PR DESCRIPTION
This PR adds the missing `@mui/material/styles` import to the TypeScript module
augmentation example in the "Adding color tokens" section of the palette documentation.

Without this import, the augmentation can cause issues with other
`@mui/material/styles` imports in a user's project.

**Changes:**
- Updated `docs/data/material/customization/palette/palette.md`
- Added `import '@mui/material/styles';` above the augmentation block

**Related issue:**
Fixes mui/material-ui#47425
