### PR TITLE
[accordion] Remove unnecessary handling of `square` prop on Accordion Root

### DIFF
--- a/docs/pages/material-ui/api/accordion.json
+++ b/docs/pages/material-ui/api/accordion.json
@@ -27,7 +27,6 @@
       },
       "default": "{}"
     },
-    "square": { "type": { "name": "bool" }, "default": "false" },
     "sx": {
       "type": {
         "name": "union",

--- a/docs/translations/api-docs/accordion/accordion.json
+++ b/docs/translations/api-docs/accordion/accordion.json
@@ -26,7 +26,6 @@
     },
     "slotProps": { "description": "The props used for each slot inside." },
     "slots": { "description": "The components used for each slot inside." },
-    "square": { "description": "If <code>true</code>, rounded corners are disabled." },
     "sx": {
       "description": "The system prop that allows defining system overrides as well as additional CSS styles."
     },

--- a/packages/mui-material/src/Accordion/Accordion.js
+++ b/packages/mui-material/src/Accordion/Accordion.js
@@ -324,11 +324,6 @@ Accordion.propTypes /* remove-proptypes */ = {
     transition: PropTypes.elementType,
   }),
   /**
-   * If `true`, rounded corners are disabled.
-   * @default false
-   */
-  square: PropTypes.bool,
-  /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([


### PR DESCRIPTION
This PR removes the `square` prop from the `Accordion` API and its docs. The prop is of the `Paper` component which is extended by `AccordionRoot`. It exposed an extra configuration surface that is unnecessary on `Accordion` itself. If it is provided, it will work. See [these](https://github.com/mui/material-ui/blob/a8380603ff61db028638d9625cc5b478322e2935/packages/mui-material/src/Accordion/Accordion.test.js#L164-L177) tests.