### PR TITLE
[alert] Remove unnecessary default icon mapping fallback

### DIFF
--- a/packages/mui-material/src/Alert/Alert.js
+++ b/packages/mui-material/src/Alert/Alert.js
@@ -250,9 +250,7 @@ const Alert = React.forwardRef(function Alert(inProps, ref) {
   return (
     <RootSlot {...rootSlotProps}>
       {icon !== false ? (
-        <IconSlot {...iconSlotProps}>
-          {icon || iconMapping[severity]}
-        </IconSlot>
+        <IconSlot {...iconSlotProps}>{icon || iconMapping[severity]}</IconSlot>
       ) : null}
       <MessageSlot {...messageSlotProps}>{children}</MessageSlot>
       {action != null ? <ActionSlot {...actionSlotProps}>{action}</ActionSlot> : null}


### PR DESCRIPTION
The default of `iconMapping` is `defaultIconMapping`, so if `iconMapping` is `null` or `undefined` it will already fallback to `defaultIconMapping`. So the fallback in the JSX is unnecessary and too defensive.
