### PR TITLE
[docs] Fix link to contributing guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Package managers other than pnpm (like npm or Yarn) are not supported and will n
 
 ## How can I add a new demo to the documentation?
 
-[You can follow this guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md)
+[You can follow this guide](../CONTRIBUTING.md)
 on how to get started contributing to MUI.
 
 ## How do I help to improve the translations?

--- a/packages/mui-joy/README.md
+++ b/packages/mui-joy/README.md
@@ -30,7 +30,7 @@ The documentation features [a collection of example projects using Joy UI](http
 
 ## Contributing
 
-Read the [contributing guide](/CONTRIBUTING.md) to learn about the development process, how to propose bug fixes and improvements, and how to build and test your changes.
+Read the [contributing guide](../../CONTRIBUTING.md) to learn about the development process, how to propose bug fixes and improvements, and how to build and test your changes.
 
 Contributing to Joy UI is about more than just issues and pull requests!
 There are many other ways to [support Joy UI](https://mui.com/material-ui/getting-started/faq/#mui-is-awesome-how-can-i-support-the-project) beyond contributing to the code base.
@@ -46,7 +46,7 @@ Future plans and high-priority features and enhancements can be found in the [ro
 ## License
 
 This project is licensed under the terms of the
-[MIT license](/LICENSE).
+[MIT license](../../LICENSE).
 
 ## Security
 

--- a/packages/mui-material/README.md
+++ b/packages/mui-material/README.md
@@ -33,7 +33,7 @@ Our documentation features [a collection of example projects using Material UI]
 
 ## Contributing
 
-Read the [contributing guide](/CONTRIBUTING.md) to learn about our development process, how to propose bug fixes and improvements, and how to build and test your changes.
+Read the [contributing guide](../../CONTRIBUTING.md) to learn about our development process, how to propose bug fixes and improvements, and how to build and test your changes.
 
 Contributing to Material UI is about more than just issues and pull requests!
 There are many other ways to [support Material UI](https://mui.com/material-ui/getting-started/faq/#mui-is-awesome-how-can-i-support-the-project) beyond contributing to the code base.
@@ -49,7 +49,7 @@ Future plans and high-priority features and enhancements can be found in the [ro
 ## License
 
 This project is licensed under the terms of the
-[MIT license](/LICENSE).
+[MIT license](../../LICENSE).
 
 ## Security
 


### PR DESCRIPTION
See in https://www.npmjs.com/package/@mui/material how it's broken.

Base UI was broken too, I pushed to master by mistake 😁, but at least, it worked: https://github.com/mui/base-ui/commit/9327ecde016b061afe996ba138bf255345fc2f61. But we also needed  https://github.com/mui/base-ui/pull/3538. 