### PR TITLE
[docs] Update typo in TailwindCSS v4 integration with Next.js docs

### DIFF
--- a/docs/data/material/integrations/tailwindcss/tailwindcss-v4.md
+++ b/docs/data/material/integrations/tailwindcss/tailwindcss-v4.md
@@ -36,7 +36,7 @@ export default function RootLayout() {
 
 2. Configure the layer order in the Tailwind CSS file:
 
-```css title="src/app/globals.css"
+```css title="src/app/global.css"
 @layer theme, base, mui, components, utilities;
 @import 'tailwindcss';
 ```


### PR DESCRIPTION
The docs used two different file names for the global css file: `src/app/globals.css` and `src/app/global.css` which was confusing. I changed it to `src/app/global.css` which is fitting to the [nextjs docs](https://nextjs.org/docs/app/getting-started/css#global-css).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
