### PR TITLE
[docs] Do not encourage downloading the MCP with npx -y and @latest

### DIFF
--- a/docs/data/material/getting-started/mcp/mcp.md
+++ b/docs/data/material/getting-started/mcp/mcp.md
@@ -25,7 +25,7 @@ The sections below detail how to set up the Material UI MCP in popular agentic 
 
 > ⚠️ **Security note**
 >
-> Using `npx -y` with `@latest` will always download and execute the latest version of the package.
+> Using `npx -y` with `@latest` always download and execute the latest version of the package.
 > In privileged execution environments (for example, when used with tools like GitHub Copilot or Claude),
 > this can increase the risk if the package is ever compromised.
 >


### PR DESCRIPTION
Related to #47211

## Summary
Added documentation for security considerations when using `npx -y` with `@latest` in MCP setup, and suggested a safer alternative using a locally installed package with a lockfile.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
