### PR TITLE
[docs-infra] Fix privacy link

### DIFF
--- a/docs/src/pages/premium-themes/onepirate/modules/views/terms.md
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/terms.md
@@ -19,7 +19,7 @@ Last modified: October 7th, 2018.
 
 ## 2. Privacy
 
-Please see MUI' privacy policy at www.mui.com/privacy for information about how we collect, use, and disclose information about users of the Site and the Services. By using the Site and the Services, you consent to our collection, use, and disclosure of information as set forth in our privacy policy, as we may update that policy from time to time.
+Please see MUI' privacy policy at [www.mui.com/legal/privacy](https://mui.com/legal/privacy/) for information about how we collect, use, and disclose information about users of the Site and the Services. By using the Site and the Services, you consent to our collection, use, and disclosure of information as set forth in our privacy policy, as we may update that policy from time to time.
 
 ## 3. Registration
 


### PR DESCRIPTION
ahrefs caught that this was a http link in the rendered html, but I noticed it also 404ed. Fixed both of the issues