### PR TITLE
[api-docs-builder] Validate slots prop and Slots interface export consistency

### DIFF
--- a/packages/api-docs-builder/ProjectSettings.ts
+++ b/packages/api-docs-builder/ProjectSettings.ts
@@ -75,12 +75,6 @@ export interface ProjectSettings {
    */
   skipSlotsAndClasses?: boolean;
   /**
-   * If `true`, throws an error when there's a mismatch between a component's `slots` prop
-   * and its corresponding `XyzSlots` export. When `false`, only warnings are logged.
-   * @default false
-   */
-  slotsMismatchIsError?: boolean;
-  /**
    * The path to the translation directory.
    */
   translationPagesDirectory: string;

--- a/packages/api-docs-builder/utils/parseSlotsAndClasses.ts
+++ b/packages/api-docs-builder/utils/parseSlotsAndClasses.ts
@@ -38,8 +38,7 @@ function getComponentDeclaration(
   componentName: string,
 ): ts.Node | null {
   const unstableName = `Unstable_${componentName}`;
-  const componentSymbol =
-    project.exports[componentName] ?? project.exports[unstableName];
+  const componentSymbol = project.exports[componentName] ?? project.exports[unstableName];
 
   if (!componentSymbol) {
     return null;
@@ -74,13 +73,7 @@ export default function parseSlotsAndClasses({
     componentName,
     muiName,
   );
-  const slots = extractSlots(
-    typescriptProject,
-    componentName,
-    classDefinitions,
-    slotInterfaceName,
-    projectSettings.slotsMismatchIsError,
-  );
+  const slots = extractSlots(typescriptProject, componentName, classDefinitions, slotInterfaceName);
 
   const nonSlotClassDefinitions = classDefinitions.filter(
     (classDefinition) => !Object.keys(slots).includes(classDefinition.key),
@@ -203,7 +196,6 @@ function extractSlots(
   componentName: string,
   classDefinitions: ComponentClassDefinition[],
   slotsInterfaceNameParams?: string,
-  slotsMismatchIsError?: boolean,
 ): Record<string, Slot> {
   const defaultSlotsInterfaceName = `${componentName}Slots`;
   const slotsInterfaceName = slotsInterfaceNameParams ?? defaultSlotsInterfaceName;
@@ -227,21 +219,17 @@ function extractSlots(
 
   if (!exportedSymbol) {
     if (hasSlotsProp()) {
-      const message = `Component "${componentName}" has a "slots" prop but is missing the "${slotsInterfaceName}" export.`;
-      if (slotsMismatchIsError) {
-        throw new Error(message);
-      }
-      console.warn(message);
+      console.warn(
+        `Component "${componentName}" has a "slots" prop but is missing the "${slotsInterfaceName}" export.`,
+      );
     }
     return {};
   }
 
   if (!hasSlotsProp()) {
-    const message = `"${slotsInterfaceName}" is exported but component "${componentName}" has no "slots" prop.`;
-    if (slotsMismatchIsError) {
-      throw new Error(message);
-    }
-    console.warn(message);
+    console.warn(
+      `"${slotsInterfaceName}" is exported but component "${componentName}" has no "slots" prop.`,
+    );
   }
 
   const type = project.checker.getDeclaredTypeOfSymbol(exportedSymbol);


### PR DESCRIPTION
As per https://github.com/mui/mui-x/pull/20915#issuecomment-3754049131

Not throwing yet, but only warning if there is a `slots` prop. We can turn into an error once we've fixed it up for both X and Core.