### PR TITLE
[useAutocomplete] Add aria-multiselectable to listbox props when multiple is true

### DIFF
--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -1232,7 +1232,7 @@ function useAutocomplete(props) {
       role: 'listbox',
       id: `${id}-listbox`,
       'aria-labelledby': `${id}-label`,
-      'aria-multiselectable': multiple ?? undefined,
+      'aria-multiselectable': multiple || undefined,
       ref: handleListboxRef,
       onMouseDown: (event) => {
         // Prevent blur

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
@@ -449,17 +449,21 @@ describe('useAutocomplete', () => {
     it('should set aria-multiselectable on the listbox when multiple prop is true', () => {
       function Test(props) {
         const { options } = props;
-        const { getInputProps } = useAutocomplete({
+        const { getListboxProps, getInputProps } = useAutocomplete({
           options,
           open: true,
           multiple: true,
         });
-        return <input {...getInputProps()} />;
+        return (
+          <div>
+            <input {...getInputProps()} />
+            <ul {...getListboxProps()} />;
+          </div>
+        );
       }
 
       render(<Test options={['foo', 'bar']} />);
-      const input = screen.getByRole('combobox');
-      fireEvent.focus(input);
+
       const listbox = screen.getByRole('listbox');
 
       expect(listbox).to.have.attribute('aria-multiselectable', 'true');
@@ -468,17 +472,20 @@ describe('useAutocomplete', () => {
     it('should not set aria-multiselectable on the listbox when multiple prop is false', () => {
       function Test(props) {
         const { options } = props;
-        const { getInputProps } = useAutocomplete({
+        const { getListboxProps, getInputProps } = useAutocomplete({
           options,
           open: true,
           multiple: false,
         });
-        return <input {...getInputProps()} />;
+        return (
+          <div>
+            <input {...getInputProps()} />
+            <ul {...getListboxProps()} />;
+          </div>
+        );
       }
 
       render(<Test options={['foo', 'bar']} />);
-      const input = screen.getByRole('combobox');
-      fireEvent.focus(input);
       const listbox = screen.getByRole('listbox');
 
       expect(listbox).to.not.have.attribute('aria-multiselectable');


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/44417

- if `multiple` prop is supplied, listbox receives `aria-multiselectable="true"`, nothing otherwise.
- matches the multiple select behaviour (not the default select one) and the BaseUI equivalent component.
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
