### PR TITLE
[website] Fix unclickable banner in the pricing page

### DIFF
--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -1287,7 +1287,7 @@ export default function PricingTable({
 
   return (
     <ThemeProvider theme={transitionTheme}>
-      <Box ref={tableRef} {...props} sx={{ pt: 8, width: '100%', ...props.sx }}>
+      <Box ref={tableRef} {...props} sx={{ pt: 8, width: '100%', contain: 'paint', ...props.sx }}>
         <StickyHead container={tableRef} disableCalculation={columnHeaderHidden} />
         {!columnHeaderHidden && (
           <Box sx={gridSx}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Fix StickyHead positioning conflict with AppHeaderBanner
**Added contain:** 'paint' to the PricingTable wrapper to establish a containing block for the StickyHead component, preventing it from interfering with AppHeaderBanner.

https://github.com/user-attachments/assets/e63e251e-4605-4647-bf78-b9c0bb4dc86a

