### PR TITLE
[docs] Fix Roboto font not loading in iframe demos

### DIFF
--- a/docs/src/modules/components/DemoSandbox.js
+++ b/docs/src/modules/components/DemoSandbox.js
@@ -141,7 +141,7 @@ function DemoIframe(props) {
   const document = frameRef.current?.contentDocument;
   return (
     <React.Fragment>
-      <Iframe onLoad={onLoad} ref={frameRef} title={`${name} demo`} srcDoc={SRC_DOC} {...other} />
+      <Iframe onLoad={onLoad} ref={frameRef} title={`${name} demo`} {...other} srcDoc={SRC_DOC} />
       {iframeLoaded !== false
         ? ReactDOM.createPortal(
             <FramedDemo document={document} isJoy={isJoy} isolated={isolated}>


### PR DESCRIPTION
Noticed while working on https://github.com/mui/material-ui/pull/47635, demos were not using the correct fonts in iframes.

- Add `srcDoc` attribute to iframe demos with Google Fonts link for Roboto
- Fixes font fallback to system fonts (Helvetica/Arial) in demos like https://mui.com/material-ui/react-app-bar/#responsive-app-bar-with-drawer


https://github.com/user-attachments/assets/86a411af-b4d5-4cc8-a573-a0d3949da127

