### PR TITLE
Add Claude session setup and fix navigator property definition

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (cloud) environment
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Install dependencies using yarn (monorepo with workspaces)
+yarn install
+
+# Node v22 auto-detects ESM from import syntax, which bypasses @babel/register
+# used by mocha tests. Disable this so tests can run.
+echo 'export NODE_OPTIONS="--no-experimental-detect-module"' >> "$CLAUDE_ENV_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/test-utils/src/createDOM.js
+++ b/packages/test-utils/src/createDOM.js
@@ -54,9 +54,13 @@ function createDOM() {
   }
   global.window.Touch = Touch;
 
-  global.navigator = {
-    userAgent: 'node.js',
-  };
+  Object.defineProperty(global, 'navigator', {
+    value: {
+      userAgent: 'node.js',
+    },
+    configurable: true,
+    writable: true,
+  });
 
   Object.keys(dom.window)
     .filter((key) => !blacklist.includes(key))


### PR DESCRIPTION
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Summary

This PR adds Claude IDE integration configuration and fixes a test environment issue with the navigator object definition.

## Changes

### Claude IDE Integration
- Added `.claude/settings.json` to configure Claude IDE hooks
- Added `.claude/hooks/session-start.sh` to automatically set up the development environment when using Claude in remote (cloud) mode
  - Installs dependencies using yarn (monorepo with workspaces)
  - Configures Node.js options to disable experimental ESM detection, which was interfering with @babel/register used by mocha tests

### Test Environment Fix
- Modified `packages/test-utils/src/createDOM.js` to properly define the `navigator` global object
  - Changed from simple assignment to `Object.defineProperty()` with proper descriptors
  - Ensures the property is configurable and writable, which is necessary for test isolation and proper cleanup
  - Prevents issues with property redefinition in test suites

## Motivation

The Claude hooks enable seamless development setup in Claude IDE's remote environment. The navigator property fix ensures that the test DOM creation is more robust and follows proper JavaScript property definition patterns, preventing potential issues with test isolation.

https://claude.ai/code/session_01LqfwweXnkhZdAf9VoY3j8b