### PR TITLE
fix(transitions): make reflow node param optional and prevent undefined

### DIFF
--- a/packages/mui-material/src/transitions/utils.ts
+++ b/packages/mui-material/src/transitions/utils.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export const reflow = (node: Element) => node.scrollTop;
+export const reflow = (node?: Element) => node?.scrollTop || 0;
 
 interface ComponentProps {
   easing: string | { enter?: string; exit?: string } | undefined;


### PR DESCRIPTION
It fixes https://github.com/mui/material-ui/issues/47735

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
