### PR TITLE
[docs] Remove outdated notifications

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -1,20 +1,5 @@
 [
   {
-    "id": 82,
-    "title": "Upcoming changes to MUI X pricing in 2024",
-    "text": "Check out the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x\" href=\"https://mui.com/blog/mui-x-sep-2024-price-update/\">new pricing updates</a> and how to transition to the new model."
-  },
-  {
-    "id": 83,
-    "title": "Material UI v6 is out now",
-    "text": "This major release includes CSS variables support, experimental opt-in CSS extraction, and many more improvements. Check out the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"material-ui-v6\" href=\"https://mui.com/blog/material-ui-v6-is-out/\">announcement blog post</a>."
-  },
-  {
-    "id": 85,
-    "title": "MUI X v8 alpha",
-    "text": "Check our plans for the upcoming stable in the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-v8-alpha-zero\" href=\"https://mui.com/blog/mui-x-v8-alpha-zero/\">announcement blog post</a>."
-  },
-  {
     "id": 87,
     "title": "Material UI v7 is here",
     "text": "This major release improves the integration with modern tools and consistency across the library. Check out the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"material-ui-v7\" href=\"https://mui.com/blog/material-ui-v7-is-here/\">announcement blog post</a>."


### PR DESCRIPTION
Remove three outdated notifications (MUI X pricing 2024, Material UI v6, MUI X v8 alpha) from the docs notification panel, keeping only the two most recent ones.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).