### PR TITLE
[chip] Remove unnecessary `onDelete` check

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -396,9 +396,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   const handleDeleteIconClick = (event) => {
     // Stop the event from bubbling up to the `Chip`
     event.stopPropagation();
-    if (onDelete) {
-      onDelete(event);
-    }
+    onDelete(event);
   };
 
   const handleKeyDown = (event) => {


### PR DESCRIPTION
I noticed this while looking at #47628.

The Chip's delete icon is only rendered when `onDelete` callback prop is provided to the component which is already checked [here](https://github.com/mui/material-ui/blob/583e869f5d4aee33c795e92946dc0e96b1e75625/packages/mui-material/src/Chip/Chip.js#L458). So this check inside `handleDeleteIconClick` is redundant.