### PR TITLE
[styles] Fix TableCell border with cssVariables nativeColor

### DIFF
--- a/packages/mui-material/src/styles/createTheme.test.js
+++ b/packages/mui-material/src/styles/createTheme.test.js
@@ -781,5 +781,26 @@ describe('createTheme', () => {
         'color-mix(in oklch, hsl(0 0% 100%), #000 20%)',
       );
     });
+
+    it('[nativeColor] should resolve alpha before applying color-mix for TableCell border', () => {
+      const theme = createTheme({
+        cssVariables: {
+          nativeColor: true,
+        },
+      });
+
+      // palette.divider is rgba(0, 0, 0, 0.12) by default.
+      // The TableCell border should first resolve alpha to 1 (giving an
+      // opaque color) and then apply lighten via color-mix. Before the fix,
+      // safeAlpha was also routed through color-mix which produced
+      // color-mix(in srgb, rgba(0, 0, 0, 0.12), transparent 0%) - a no-op
+      // that kept the low alpha, resulting in a near-white border.
+      const border = theme.palette.TableCell.border;
+
+      // The border value should use the opaque version of the divider color
+      // (alpha set to 1) as the base for the lighten color-mix, not a
+      // color-mix with transparent that fails to adjust the alpha.
+      expect(border).to.equal('color-mix(in oklch, rgba(0, 0, 0, 1), #fff 88%)');
+    });
   });
 });

--- a/packages/mui-material/src/styles/createThemeWithVars.js
+++ b/packages/mui-material/src/styles/createThemeWithVars.js
@@ -223,10 +223,14 @@ export default function createThemeWithVars(options = {}, ...args) {
 
     function colorMix(method, color, coefficient) {
       if (colorSpace) {
-        let mixer;
+        // color-mix with transparent doesn't correctly set the alpha channel;
+        // it blends towards transparent instead of replacing the alpha value.
+        // For safeAlpha, apply it directly so the resulting concrete color can
+        // still be used as input to subsequent color-mix operations.
         if (method === safeAlpha) {
-          mixer = `transparent ${((1 - coefficient) * 100).toFixed(0)}%`;
+          return method(color, coefficient);
         }
+        let mixer;
         if (method === safeDarken) {
           mixer = `#000 ${(coefficient * 100).toFixed(0)}%`;
         }


### PR DESCRIPTION
Fixes #47749

When `cssVariables` is enabled with `nativeColor: true`, the `TableCell` border color becomes nearly invisible. The root cause is in how `colorMix` handles the `safeAlpha` method.

The `colorMix` helper was producing `color-mix(in oklch, rgba(0,0,0,0.12), transparent 0%)` for the alpha step, which is a no-op -- it doesn't actually change the alpha value. So `palette.divider` (`rgba(0,0,0,0.12)`) kept its low alpha going into the lighten step, resulting in a near-white border (`rgba(250,250,250,0.89)`) instead of the expected visible gray.

The fix makes `safeAlpha` always resolve directly to a concrete color value rather than going through `color-mix`, since CSS `color-mix` can't properly set an explicit alpha channel. The resolved opaque color then works correctly as input for the subsequent `lighten`/`darken` color-mix operation.

**Before**: `color-mix(in oklch, color-mix(in oklch, rgba(0,0,0,0.12), transparent 0%), #fff 88%)` -> near white
**After**: `color-mix(in oklch, rgba(0, 0, 0, 1), #fff 88%)` -> visible gray

This also fixes the same issue for the dark mode `TableCell` border, `Tooltip` background, and any other place where `safeAlpha` is used as a nested `colorMix` call.