### PR TITLE
[Autocomplete] fix unintended focus in autocomplete

### DIFF
--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -619,7 +619,7 @@ function useAutocomplete(props) {
       syncHighlightedIndex();
     }
   }, [syncHighlightedIndex, filteredOptionsChanged, popupOpen, disableCloseOnSelect]);
-  
+
   // Tracks browser window focus state.
   React.useEffect(() => {
     const handleWindowFocus = () => {
@@ -632,7 +632,6 @@ function useAutocomplete(props) {
       window.removeEventListener('focus', handleWindowFocus);
     };
   }, []);
-
 
   const handleOpen = (event) => {
     if (open) {


### PR DESCRIPTION
Fixes - #47661 

This issue occurs when the popup of one `Autocomplete` overlaps another `Autocomplete`.

### Reproduction Steps

1. Focus an `Autocomplete` to open its popup.
2. Click outside the browser window (without minimizing it).
3. Click and hold the mouse button on the border of another overlapping `Autocomplete`.

### Observed Behavior

During the `mousedown` phase (before `mouseup`):

- The previously focused `Autocomplete` regains focus.
- For a normal `Autocomplete`, this causes an unintended label shrink.
- For `openOnFocus`, the popup opens (since its getting focused) during the mouse hold and select an option on mouse release.


This behavior appears to be triggered by the following logic inside `handleMouseDown`:

```js
if (event.target.getAttribute('id') !== id) {
  event.preventDefault();
}
```



- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
