### PR TITLE
[docs] Fix the keyboard navigation in GroupedMenu example

### DIFF
--- a/docs/data/material/components/menus/GroupedMenu.js
+++ b/docs/data/material/components/menus/GroupedMenu.js
@@ -10,9 +10,10 @@ const StyledListHeader = Object.assign(
     backgroundImage: 'var(--Paper-overlay)',
   }),
   {
-    // IMPORTANT: this property is needed to prevent the component from being focused
-    // when navigating with the keyboard, as ListSubheader is not a focusable element.
-    // For example, ListSubheader has it set to true by default, so does Divider.
+    // IMPORTANT: The base ListSubheader component sets `muiSkipListHighlight = true`
+    // by default, but wrapping it with `styled(ListSubheader)` does not preserve
+    // that static field. We re-declare it here so the menu list continues to skip
+    // highlighting this non-focusable subheader when navigating with the keyboard.
     muiSkipListHighlight: true,
   },
 );

--- a/docs/data/material/components/menus/GroupedMenu.tsx
+++ b/docs/data/material/components/menus/GroupedMenu.tsx
@@ -10,9 +10,10 @@ const StyledListHeader = Object.assign(
     backgroundImage: 'var(--Paper-overlay)',
   }),
   {
-    // IMPORTANT: this property is needed to prevent the component from being focused
-    // when navigating with the keyboard, as ListSubheader is not a focusable element.
-    // For example, ListSubheader has it set to true by default, so does Divider.
+    // IMPORTANT: The base ListSubheader component sets `muiSkipListHighlight = true`
+    // by default, but wrapping it with `styled(ListSubheader)` does not preserve
+    // that static field. We re-declare it here so the menu list continues to skip
+    // highlighting this non-focusable subheader when navigating with the keyboard.
     muiSkipListHighlight: true,
   },
 );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Adding this property will fix the keyboard navigation for the example, by intentionally skipping non-focusable items. Also added a comment explaining why.

Preview: https://deploy-preview-47842--material-ui.netlify.app/material-ui/react-menu/#grouped-menu