### PR TITLE
[docs][system] Update sizing docs to clarify `(0, 1]` behavior.

### DIFF
--- a/docs/data/system/sizing/sizing.md
+++ b/docs/data/system/sizing/sizing.md
@@ -19,9 +19,9 @@ Otherwise, it is directly set on the CSS property.
 
 ```jsx
 <Box sx={{ width: 1/4 }}> // Equivalent to width: '25%'
-<Box sx={{ width: 300 }}> // Numbers are converted to pixel values.
+<Box sx={{ width: 300 }}> // Numbers above 1 are treated as pixel values.
 <Box sx={{ width: '75%' }}> // String values are used as raw CSS.
-<Box sx={{ width: 1 }}> // 100%
+<Box sx={{ width: 1 }}> // 100% -- numbers in the range `(0, 1]` are treated as percentage values from 0 to 100%.
 ```
 
 ## Width


### PR DESCRIPTION
Adding some qualifiers to the docs that said "[All] numbers are treated as pixel values" -- that's simply not the case. For library authors animating values or supporting continuous values that may go into the range of 0..1 -- they may encounter surprises if they take at face value the statement "numbers are pixels" (if only that were true!) :smile: 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

RE the phrasing change ("converted to" versus "treated as") -- no conversion is taking place. Conversion happens when converting a number from one unit into another. It requires a "from" unit and a "to" unit. It appears that "pixels" is the "from" unit. And pixels is also the "to" unit because the style output is a pixel string like `${n}px`. One does not say "convert a pixel to a pixel".

The phrasing of "treated as" makes sense. The library _treats_ these numbers _as if_ they were pixel values. Hence the phrase "treated as numbers".