### PR TITLE
[code-infra] Fix build of @mui/icons-material

### DIFF
--- a/packages/mui-icons-material/lib/index.js
+++ b/packages/mui-icons-material/lib/index.js
@@ -1,5 +1,5 @@
 /**
- * @mui/icons-material v9.0.0-alpha.0
+ * @mui/icons-material
  *
  * @license MIT
  * This source code is licensed under the MIT license found in the

--- a/packages/mui-icons-material/lib/index.mjs
+++ b/packages/mui-icons-material/lib/index.mjs
@@ -1,5 +1,5 @@
 /**
- * @mui/icons-material v9.0.0-alpha.0
+ * @mui/icons-material
  *
  * @license MIT
  * This source code is licensed under the MIT license found in the

--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -27,7 +27,8 @@
     "url": "https://opencollective.com/mui-org"
   },
   "scripts": {
-    "build": "rimraf build && shx cp -r lib/ build/ && pnpm build:copy-files && pnpm build:typings",
+    "build": "rimraf build && shx cp -r lib/ build/ && pnpm build:copy-files && pnpm build:typings && pnpm build:pkg-json",
+    "build:pkg-json": "node ./scripts/merge-package-json.mjs",
     "build:lib": "code-infra build --flat --hasLargeFiles --skipMainCheck --buildTypes false",
     "build:lib:clean": "rimraf lib && pnpm build:lib && pnpm attw-icons && shx cp -R build lib && rimraf build",
     "build:copy-files": "shx cp README.md ../../CHANGELOG.md ../../LICENSE build",

--- a/packages/mui-icons-material/scripts/merge-package-json.mjs
+++ b/packages/mui-icons-material/scripts/merge-package-json.mjs
@@ -1,0 +1,45 @@
+/* eslint-disable no-console */
+import path from 'path';
+import * as fs from 'fs/promises';
+import url from 'url';
+
+const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
+const packageDir = path.resolve(currentDirectory, '..');
+
+/**
+ * Reads `package.json` and `lib/package.json`, then creates a new package.json
+ * where all fields come from the root `package.json` but the `exports` field
+ * is copied over from `lib/package.json`.
+ */
+async function run() {
+  const rootPackageJsonPath = path.resolve(packageDir, 'package.json');
+  const libPackageJsonPath = path.resolve(packageDir, 'lib/package.json');
+  const buildPackageJsonPath = path.resolve(packageDir, 'build/package.json');
+
+  const [rootPackageJson, libPackageJson] = await Promise.all([
+    fs.readFile(rootPackageJsonPath, 'utf8').then((content) => JSON.parse(content)),
+    fs.readFile(libPackageJsonPath, 'utf8').then((content) => JSON.parse(content)),
+  ]);
+
+  const mergedPackageJson = {
+    ...rootPackageJson,
+    exports: libPackageJson.exports,
+  };
+  delete mergedPackageJson.publishConfig?.directory;
+  // Remove fields that shouldn't be in the published package
+  delete mergedPackageJson.devDependencies;
+  delete mergedPackageJson.scripts;
+
+  await fs.writeFile(
+    buildPackageJsonPath,
+    `${JSON.stringify(mergedPackageJson, null, 2)}\n`,
+    'utf8',
+  );
+
+  console.log('✅ package.json created successfully.');
+}
+
+run().catch((error) => {
+  console.error('Error creating package.json files:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
The version was not being updated from the source package.json. Added a new script to copy over source package.json but keep exports from `lib/package.json`.

Fixes the [failing](https://github.com/mui/material-ui/actions/runs/22447581128/job/65006364904) publish for the package.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
