### PR TITLE
docs: add no-animal-violence Vale package for inclusive language checking

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -7,7 +7,7 @@ MinAlertLevel = warning
 # 2. Update/create YAML files
 # 3. Run `pnpm docs:zipRules` to generate the zip files
 # 4. You can test locally by replacing the url with the file path of the generated zip
-Packages = Google, docs/mui-vale.zip
+Packages = Google, docs/mui-vale.zip, https://github.com/Open-Paws/vale-no-animal-violence/releases/latest/download/NoAnimalViolence.zip
 
 [formats]
 mdx = md
@@ -19,7 +19,7 @@ TokenIgnores = (<\/?[A-Z].+>)
 # Ignore code injections that start with {{...
 BlockIgnores = {{.*
 
-BasedOnStyles = MUI
+BasedOnStyles = MUI, NoAnimalViolence
 
 # Google errors:
 Google.GenderBias = YES # No Gender bias


### PR DESCRIPTION
Adds the [NoAnimalViolence](https://github.com/Open-Paws/vale-no-animal-violence) Vale package to the existing Vale setup. This package flags phrases that normalize violence toward animals (e.g. "kill two birds with one stone", "beat a dead horse", "cattle vs. pets") and suggests clearer professional alternatives.

## Changes

- `.vale.ini`: add `NoAnimalViolence` package URL to `Packages =` and `NoAnimalViolence` to `BasedOnStyles`

## The package

The [vale-no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) package detects phrases like:
- "kill two birds with one stone" → "accomplish two things at once"
- "beat a dead horse" → "belabor the point"
- "guinea pig" → "test subject"
- "cattle vs. pets" → "ephemeral vs. persistent"
- "canary deployment" → "progressive rollout"
- "monkey patch" → "runtime patch"

All rules are at `warning` level — informational, not blocking.

Part of the [Open Paws](https://openpaws.ai) no-animal-violence toolchain for inclusive language.