### PR TITLE
[code-infra] Remove CI coverage collection and upload to Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           react-version: << parameters.react-version >>
       - run:
           name: Tests fake browser
-          command: pnpm test:node --no-isolate --no-file-parallelism --coverage
+          command: pnpm test:node --no-isolate --no-file-parallelism
       - run:
           name: internal-scripts
           command: |
@@ -95,8 +95,6 @@ jobs:
             else
               echo "no changes"
             fi
-      - code-infra/upload-coverage:
-          key: '<< parameters.react-version >>-jsdom'
       - store_test_results:
           path: test-results
 
@@ -224,7 +222,7 @@ jobs:
           react-version: << parameters.react-version >>
       - run:
           name: Tests chromium
-          command: pnpm test:browser --no-isolate --no-file-parallelism --coverage
+          command: pnpm test:browser --no-isolate --no-file-parallelism
       - run:
           name: Tests webkit
           environment:
@@ -235,15 +233,6 @@ jobs:
           environment:
             VITEST_BROWSERS: 'firefox'
           command: pnpm test:browser --no-isolate --no-file-parallelism
-      - run:
-          name: Check coverage generated
-          command: |
-            if ! [[ -s coverage/lcov.info ]]
-            then
-              exit 1
-            fi
-      - code-infra/upload-coverage:
-          key: '<< parameters.react-version >>-browser'
       - store_test_results:
           path: test-results
   test_e2e:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: auto
-        threshold: 1%
-    patch: off
-comment: false


### PR DESCRIPTION
## Summary
- Remove `--coverage` flags from test commands in CI
- Remove `code-infra/upload-coverage` steps from CI
- Delete `codecov.yml`

Part of https://github.com/mui/mui-public/issues/860