### PR TITLE
[docs-infra] Import font module for nextjs transpilation

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -33,9 +33,12 @@ import NextHead from 'next/head';
 import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import * as React from 'react';
+
 import * as config from '../config';
 import '../public/static/components-gallery/base-theme.css';
 import './global.css';
+
+export { fontClasses } from '@mui/docs/nextFonts';
 
 // Remove the license warning from demonstration purposes
 LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUI_LICENSE);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fix font class generation with next.js. It has to be imported in _app to be generated.

Bug:
<img width="397" height="59" alt="Screenshot 2026-03-09 at 11 59 05 PM" src="https://github.com/user-attachments/assets/d17b0870-2e62-4fbb-b866-133def3de9fd" />

After fix:
<img width="414" height="50" alt="Screenshot 2026-03-09 at 11 59 17 PM" src="https://github.com/user-attachments/assets/b3dcf86a-739f-4d5c-84ec-1724f4f4361d" />

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
