### PR TITLE
[docs] Use direct palette vars in Tailwind v4 snippet

### DIFF
--- a/docs/data/material/integrations/tailwindcss/tailwindcss-v4.md
+++ b/docs/data/material/integrations/tailwindcss/tailwindcss-v4.md
@@ -479,7 +479,7 @@ So when you add these classes to an element…
 
 ### Playground
 
-Visit the [Tailwind CSS Playground](https://play.tailwindcss.com/f1ZIr0qSNG) to explore the classes from Material UI theme tokens.
+Visit the [Tailwind CSS Playground](https://play.tailwindcss.com/mh7Ym0mGff) to explore the classes from Material UI theme tokens.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Updates the Tailwind CSS v4 docs snippet to use direct Material UI palette CSS variables instead of `*Channel` tokens wrapped in `rgb(...)`.

## Why

Some palette values, such as `palette.text.secondary`, include alpha. Mapping them through `rgb(var(--mui-palette-...Channel))` makes them opaque, which causes classes like `text-text-secondary` to resolve to the wrong color.

This updates the snippet so Tailwind classes preserve the original theme token values.

Fixes #47870

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
