### PR TITLE
[docs] Update Autocomplete deprecated props removal migration guide docs

### DIFF
--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -268,8 +268,15 @@ Use the [autocomplete-props codemod](https://github.com/mui/material-ui/tree/HEA
 npx @mui/codemod@latest deprecations/autocomplete-props <path>
 ```
 
-The deprecated `Autocomplete` props have been removed.
-Use the `slots`, `slotProps`, and `renderValue` props instead:
+The following deprecated props have been removed from the `Autocomplete` component:
+
+- `ChipProps` → use `slotProps.chip`
+- `componentsProps` → use `slotProps`
+- `ListboxComponent` → use `slots.listbox`
+- `ListboxProps` → use `slotProps.listbox`
+- `PaperComponent` → use `slots.paper`
+- `PopperComponent` → use `slots.popper`
+- `renderTags` → use `renderValue`
 
 ```diff
  <Autocomplete


### PR DESCRIPTION
Preview: https://deploy-preview-47990--material-ui.netlify.app/material-ui/migration/upgrade-to-v9/#deprecated-apis-removed