### PR TITLE
[InputBase] Fix test using removed InputProps on TextField

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -682,7 +682,7 @@ describe('<InputBase />', () => {
                   <Select value="" name="suffix" />
                 </InputAdornment>
               ),
-            }
+            },
           }}
         />,
       );


### PR DESCRIPTION
https://github.com/mui/material-ui/pull/47878 missed the update on the test file

## Summary
- Fix InputBase test that still used the deprecated `InputProps` prop on `TextField`, replacing it with `slotProps.input` to match the removal done in #47878

## Test plan
- [x] Verify `InputBase.test.js` passes with the updated prop usage