### PR TITLE
[codemod] Add card-header-props migration guide

### DIFF
--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -870,6 +870,36 @@ CSS transforms:
 npx @mui/codemod@next deprecations/button-group-classes <path>
 ```
 
+#### `card-header-props`
+
+```diff
+ <CardHeader
+-  titleTypographyProps={{ variant: 'h6' }}
+-  subheaderTypographyProps={{ variant: 'body2' }}
++  slotProps={{
++    title: { variant: 'h6' },
++    subheader: { variant: 'body2' }
++  }}
+ />
+```
+
+```diff
+ MuiCardHeader: {
+   defaultProps: {
+-    titleTypographyProps: { variant: 'h6' },
+-    subheaderTypographyProps: { variant: 'body2' },
++    slotProps: {
++      title: { variant: 'h6' },
++      subheader: { variant: 'body2' },
++    },
+   },
+ },
+```
+
+```bash
+npx @mui/codemod@next deprecations/card-header-props <path>
+```
+
 #### `chip-classes`
 
 JS transforms:


### PR DESCRIPTION
## Summary
- Add missing `card-header-props` deprecation migration guide to the codemod README
- Documents `titleTypographyProps` → `slotProps.title` and `subheaderTypographyProps` → `slotProps.subheader` transforms

## Test plan
- [x] Verified diff matches the actual codemod behavior from test fixtures