### PR TITLE
[autocomplete] Defer option rendering for virtualized listboxes

### DIFF
--- a/docs/data/material/components/autocomplete/Virtualize.js
+++ b/docs/data/material/components/autocomplete/Virtualize.js
@@ -26,13 +26,9 @@ function RowComponent({ index, itemData, style }) {
     );
   }
 
-  const { key, ...optionProps } = dataSet[0];
-
-  return (
-    <Typography key={key} component="li" {...optionProps} noWrap style={inlineStyle}>
-      {`#${dataSet[2] + 1} - ${dataSet[1]}`}
-    </Typography>
-  );
+  return React.cloneElement(dataSet, {
+    style: inlineStyle,
+  });
 }
 
 // Adapter for react-window v2
@@ -41,12 +37,9 @@ RowComponent.propTypes = {
   index: PropTypes.number.isRequired,
   itemData: PropTypes.arrayOf(
     PropTypes.oneOfType([
-      PropTypes.arrayOf(
-        PropTypes.oneOfType([PropTypes.element, PropTypes.number, PropTypes.string])
-          .isRequired,
-      ),
+      PropTypes.element,
       PropTypes.shape({
-        children: PropTypes.node,
+        children: PropTypes.arrayOf(PropTypes.element),
         group: PropTypes.string.isRequired,
         key: PropTypes.number.isRequired,
       }),
@@ -60,7 +53,11 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) 
   const itemData = [];
   const optionIndexMap = React.useMemo(() => new Map(), []);
 
-  children.forEach((item) => {
+  const childItems = (Array.isArray(children) ? children : [children]).filter(
+    Boolean,
+  );
+
+  childItems.forEach((item) => {
     itemData.push(item);
     if ('children' in item && Array.isArray(item.children)) {
       itemData.push(...item.children);
@@ -69,8 +66,8 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) 
 
   // Map option values to their indices in the flattened array
   itemData.forEach((item, index) => {
-    if (Array.isArray(item) && item[1]) {
-      optionIndexMap.set(item[1], index);
+    if (React.isValidElement(item)) {
+      optionIndexMap.set(item.props.option, index);
     }
   });
 
@@ -193,7 +190,11 @@ export default function Virtualize() {
       options={OPTIONS}
       groupBy={(option) => option[0].toUpperCase()}
       renderInput={(params) => <TextField {...params} label="10,000 options" />}
-      renderOption={(props, option, state) => [props, option, state.index]}
+      renderOption={(props, option, state) => (
+        <Typography component="li" {...props} noWrap>
+          {`#${state.index + 1} - ${option}`}
+        </Typography>
+      )}
       renderGroup={(params) => params}
       onHighlightChange={handleHighlightChange}
       slots={{
@@ -202,6 +203,7 @@ export default function Virtualize() {
       slotProps={{
         listbox: {
           component: ListboxComponent,
+          virtualized: true,
           internalListRef,
           onItemsBuilt: handleItemsBuilt,
         },

--- a/docs/data/material/components/autocomplete/Virtualize.js
+++ b/docs/data/material/components/autocomplete/Virtualize.js
@@ -27,7 +27,7 @@ function RowComponent({ index, itemData, style }) {
   }
 
   return React.cloneElement(dataSet, {
-    style: inlineStyle,
+    style: { ...dataSet.props.style, ...inlineStyle },
   });
 }
 

--- a/docs/data/material/components/autocomplete/Virtualize.js
+++ b/docs/data/material/components/autocomplete/Virtualize.js
@@ -26,8 +26,9 @@ function RowComponent({ index, itemData, style }) {
     );
   }
 
-  return React.cloneElement(dataSet, {
-    style: { ...dataSet.props.style, ...inlineStyle },
+  return React.createElement(dataSet.type, {
+    ...dataSet.props,
+    optionStyle: inlineStyle,
   });
 }
 
@@ -209,7 +210,7 @@ export default function Virtualize() {
       groupBy={(option) => option[0].toUpperCase()}
       renderInput={(params) => <TextField {...params} label="10,000 options" />}
       renderOption={(props, option, state) => (
-        <Typography component="li" {...props} noWrap>
+        <Typography component="li" {...props} style={state.style} noWrap>
           {`#${state.index + 1} - ${option}`}
         </Typography>
       )}

--- a/docs/data/material/components/autocomplete/Virtualize.js
+++ b/docs/data/material/components/autocomplete/Virtualize.js
@@ -37,11 +37,29 @@ RowComponent.propTypes = {
   index: PropTypes.number.isRequired,
   itemData: PropTypes.arrayOf(
     PropTypes.oneOfType([
-      PropTypes.element,
       PropTypes.shape({
-        children: PropTypes.arrayOf(PropTypes.element),
+        children: PropTypes.arrayOf(
+          PropTypes.shape({
+            key: PropTypes.string,
+            props: PropTypes.shape({
+              index: PropTypes.number.isRequired,
+              option: PropTypes.string.isRequired,
+              style: PropTypes.object,
+            }).isRequired,
+            type: PropTypes.oneOfType([PropTypes.func, PropTypes.string]).isRequired,
+          }),
+        ).isRequired,
         group: PropTypes.string.isRequired,
         key: PropTypes.number.isRequired,
+      }),
+      PropTypes.shape({
+        key: PropTypes.string,
+        props: PropTypes.shape({
+          index: PropTypes.number.isRequired,
+          option: PropTypes.string.isRequired,
+          style: PropTypes.object,
+        }).isRequired,
+        type: PropTypes.oneOfType([PropTypes.func, PropTypes.string]).isRequired,
       }),
     ]).isRequired,
   ).isRequired,

--- a/docs/data/material/components/autocomplete/Virtualize.js
+++ b/docs/data/material/components/autocomplete/Virtualize.js
@@ -28,7 +28,7 @@ function RowComponent({ index, itemData, style }) {
 
   return React.createElement(dataSet.type, {
     ...dataSet.props,
-    optionStyle: inlineStyle,
+    style: { ...dataSet.props.style, ...inlineStyle },
   });
 }
 

--- a/docs/data/material/components/autocomplete/Virtualize.tsx
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx
@@ -53,7 +53,7 @@ function RowComponent({
 
   return React.createElement(dataSet.type, {
     ...dataSet.props,
-    optionStyle: inlineStyle,
+    style: { ...dataSet.props.style, ...inlineStyle },
   });
 }
 

--- a/docs/data/material/components/autocomplete/Virtualize.tsx
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx
@@ -52,7 +52,7 @@ function RowComponent({
   }
 
   return React.cloneElement(dataSet, {
-    style: inlineStyle,
+    style: { ...dataSet.props.style, ...inlineStyle },
   });
 }
 

--- a/docs/data/material/components/autocomplete/Virtualize.tsx
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx
@@ -15,13 +15,19 @@ import Typography from '@mui/material/Typography';
 
 const LISTBOX_PADDING = 8; // px
 
+type OptionRow = React.ReactElement<{
+  option: string;
+  index: number;
+  style?: React.CSSProperties;
+}>;
+
 type ItemData = Array<
   | {
       key: number;
       group: string;
-      children: React.ReactNode;
+      children: OptionRow[];
     }
-  | [React.ReactElement, string, number]
+  | OptionRow
 >;
 
 function RowComponent({
@@ -45,13 +51,9 @@ function RowComponent({
     );
   }
 
-  const { key, ...optionProps } = dataSet[0];
-
-  return (
-    <Typography key={key} component="li" {...optionProps} noWrap style={inlineStyle}>
-      {`#${dataSet[2] + 1} - ${dataSet[1]}`}
-    </Typography>
-  );
+  return React.cloneElement(dataSet, {
+    style: inlineStyle,
+  });
 }
 
 // Adapter for react-window v2
@@ -66,7 +68,11 @@ const ListboxComponent = React.forwardRef<
   const itemData: ItemData = [];
   const optionIndexMap = React.useMemo(() => new Map<string, number>(), []);
 
-  (children as ItemData).forEach((item) => {
+  const childItems = (Array.isArray(children) ? children : [children]).filter(
+    Boolean,
+  ) as ItemData;
+
+  childItems.forEach((item) => {
     itemData.push(item);
     if ('children' in item && Array.isArray(item.children)) {
       itemData.push(...item.children);
@@ -75,8 +81,8 @@ const ListboxComponent = React.forwardRef<
 
   // Map option values to their indices in the flattened array
   itemData.forEach((item, index) => {
-    if (Array.isArray(item) && item[1]) {
-      optionIndexMap.set(item[1], index);
+    if (React.isValidElement(item)) {
+      optionIndexMap.set(item.props.option, index);
     }
   });
 
@@ -189,9 +195,11 @@ export default function Virtualize() {
       options={OPTIONS}
       groupBy={(option) => option[0].toUpperCase()}
       renderInput={(params) => <TextField {...params} label="10,000 options" />}
-      renderOption={(props, option, state) =>
-        [props, option, state.index] as React.ReactNode
-      }
+      renderOption={(props, option, state) => (
+        <Typography component="li" {...props} noWrap>
+          {`#${state.index + 1} - ${option}`}
+        </Typography>
+      )}
       renderGroup={(params) => params as any}
       onHighlightChange={handleHighlightChange}
       slots={{
@@ -200,6 +208,7 @@ export default function Virtualize() {
       slotProps={{
         listbox: {
           component: ListboxComponent,
+          virtualized: true,
           internalListRef,
           onItemsBuilt: handleItemsBuilt,
         } as any,

--- a/docs/data/material/components/autocomplete/Virtualize.tsx
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx
@@ -51,8 +51,9 @@ function RowComponent({
     );
   }
 
-  return React.cloneElement(dataSet, {
-    style: { ...dataSet.props.style, ...inlineStyle },
+  return React.createElement(dataSet.type, {
+    ...dataSet.props,
+    optionStyle: inlineStyle,
   });
 }
 
@@ -196,7 +197,7 @@ export default function Virtualize() {
       groupBy={(option) => option[0].toUpperCase()}
       renderInput={(params) => <TextField {...params} label="10,000 options" />}
       renderOption={(props, option, state) => (
-        <Typography component="li" {...props} noWrap>
+        <Typography component="li" {...props} style={state.style} noWrap>
           {`#${state.index + 1} - ${option}`}
         </Typography>
       )}

--- a/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
@@ -95,6 +95,7 @@ export interface AutocompleteRenderOptionState {
   inputValue: string;
   index: number;
   selected: boolean;
+  style?: React.CSSProperties | undefined;
 }
 
 export interface AutocompleteRenderGroupParams {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
@@ -23,6 +23,14 @@ import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
 
 export interface AutocompletePaperSlotPropsOverrides {}
 export interface AutocompletePopperSlotPropsOverrides {}
+export interface AutocompleteListboxSlotPropsOverrides {
+  /**
+   * If `true`, option rendering is deferred until the custom listbox renders the child.
+   * This is useful for virtualized listbox implementations.
+   * @default false
+   */
+  virtualized?: boolean | undefined;
+}
 
 export {
   AutocompleteChangeDetails,
@@ -182,7 +190,7 @@ export type AutocompleteSlotsAndSlotProps<
           ref?: React.Ref<Element> | undefined;
         }
       >,
-      {},
+      AutocompleteListboxSlotPropsOverrides,
       AutocompleteOwnerState<Value, Multiple, DisableClearable, FreeSolo, ChipComponent>
     >;
     paper: SlotProps<

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -76,13 +76,12 @@ function AutocompleteOptionRenderer(props) {
     ownerState,
     optionClassName,
     optionKey,
-    optionStyle,
     ...other
   } = props;
 
   const optionProps = getOptionProps({ option, index });
   const className = [optionClassName, other.className].filter(Boolean).join(' ');
-  const style = optionStyle ? { ...other.style, ...optionStyle } : other.style;
+  const style = other.style;
 
   return renderOption(
     {
@@ -97,7 +96,7 @@ function AutocompleteOptionRenderer(props) {
       selected: optionProps['aria-selected'],
       index,
       inputValue,
-      style: optionStyle,
+      style,
     },
     ownerState,
   );

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import integerPropType from '@mui/utils/integerPropType';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';
+import resolveComponentProps from '@mui/utils/resolveComponentProps';
 import useAutocomplete, { createFilterOptions } from '../useAutocomplete';
 import Popper from '../Popper';
 import ListSubheader from '../ListSubheader';
@@ -64,6 +65,39 @@ const useUtilityClasses = (ownerState) => {
 
   return composeClasses(slots, getAutocompleteUtilityClass, classes);
 };
+
+function AutocompleteOptionRenderer(props) {
+  const {
+    getOptionProps,
+    renderOption,
+    option,
+    index,
+    inputValue,
+    ownerState,
+    optionClassName,
+    optionKey,
+    ...other
+  } = props;
+
+  const optionProps = getOptionProps({ option, index });
+  const className = [optionClassName, other.className].filter(Boolean).join(' ');
+
+  return renderOption(
+    {
+      ...optionProps,
+      ...other,
+      className,
+      key: optionKey,
+    },
+    option,
+    {
+      selected: optionProps['aria-selected'],
+      index,
+      inputValue,
+    },
+    ownerState,
+  );
+}
 
 const AutocompleteRoot = styled('div', {
   name: 'MuiAutocomplete',
@@ -528,6 +562,12 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
     slots,
     slotProps,
   };
+  const resolvedListboxSlotProps = resolveComponentProps(
+    externalForwardedProps.slotProps.listbox,
+    ownerState,
+  );
+  const { virtualized: virtualizedListbox = false, ...listboxSlotProps } =
+    resolvedListboxSlotProps || {};
 
   const [RootSlot, rootProps] = useSlot('root', {
     ref,
@@ -543,7 +583,13 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
 
   const [ListboxSlot, listboxProps] = useSlot('listbox', {
     elementType: AutocompleteListbox,
-    externalForwardedProps,
+    externalForwardedProps: {
+      ...externalForwardedProps,
+      slotProps: {
+        ...externalForwardedProps.slotProps,
+        listbox: listboxSlotProps,
+      },
+    },
     ownerState,
     className: classes.listbox,
     additionalProps: otherListboxProps,
@@ -669,17 +715,35 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
   const renderOption = renderOptionProp || defaultRenderOption;
 
   const renderListOption = (option, index) => {
-    const optionProps = getOptionProps({ option, index });
+    if (!virtualizedListbox) {
+      const optionProps = getOptionProps({ option, index });
 
-    return renderOption(
-      { ...optionProps, className: classes.option },
-      option,
-      {
-        selected: optionProps['aria-selected'],
-        index,
-        inputValue,
-      },
-      ownerState,
+      return renderOption(
+        { ...optionProps, className: classes.option },
+        option,
+        {
+          selected: optionProps['aria-selected'],
+          index,
+          inputValue,
+        },
+        ownerState,
+      );
+    }
+
+    const optionKey = getOptionKey?.(option) ?? getOptionLabel(option);
+
+    return (
+      <AutocompleteOptionRenderer
+        key={optionKey}
+        optionKey={optionKey}
+        option={option}
+        index={index}
+        renderOption={renderOption}
+        getOptionProps={getOptionProps}
+        inputValue={inputValue}
+        ownerState={ownerState}
+        optionClassName={classes.option}
+      />
     );
   };
 

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -76,16 +76,19 @@ function AutocompleteOptionRenderer(props) {
     ownerState,
     optionClassName,
     optionKey,
+    optionStyle,
     ...other
   } = props;
 
   const optionProps = getOptionProps({ option, index });
   const className = [optionClassName, other.className].filter(Boolean).join(' ');
+  const style = optionStyle ? { ...other.style, ...optionStyle } : other.style;
 
   return renderOption(
     {
       ...optionProps,
       ...other,
+      style,
       className,
       key: optionKey,
     },
@@ -94,6 +97,7 @@ function AutocompleteOptionRenderer(props) {
       selected: optionProps['aria-selected'],
       index,
       inputValue,
+      style: optionStyle,
     },
     ownerState,
   );

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -730,7 +730,10 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
       );
     }
 
-    const optionKey = getOptionKey?.(option) ?? getOptionLabel(option);
+    let optionKey = getOptionKey?.(option);
+    if (optionKey == null) {
+      optionKey = `${getOptionLabel(option)}-${index}`;
+    }
 
     return (
       <AutocompleteOptionRenderer

--- a/packages/mui-material/src/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.spec.tsx
@@ -67,6 +67,13 @@ function MyAutocomplete<
   renderInput={() => null}
 />;
 
+// Tests presence of virtualized prop in listbox slot props
+<Autocomplete
+  options={['1', '2', '3']}
+  slotProps={{ listbox: { virtualized: true } }}
+  renderInput={() => null}
+/>;
+
 // Tests presence of onMouseDown prop in InputProps
 <Autocomplete
   options={['1', '2', '3']}

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -3607,6 +3607,61 @@ describe('<Autocomplete />', () => {
       expect(screen.getByRole('option')).to.have.text('option-0');
     });
 
+    it('should pass virtualized row style through renderOption state', () => {
+      const optionStyles = [];
+      const VirtualizedListbox = React.forwardRef(function VirtualizedListbox(props, ref) {
+        const { children, ...other } = props;
+        const childItems = (Array.isArray(children) ? children : [children]).filter(Boolean);
+
+        return (
+          <div ref={ref} {...other}>
+            {childItems.map((child, index) => {
+              if (!React.isValidElement(child)) {
+                return child;
+              }
+
+              return React.createElement(child.type, {
+                key: child.key,
+                ...child.props,
+                optionStyle: {
+                  position: 'absolute',
+                  top: index * 10,
+                },
+              });
+            })}
+          </div>
+        );
+      });
+
+      render(
+        <Autocomplete
+          disablePortal
+          open
+          options={['option-0', 'option-1']}
+          renderInput={(params) => <TextField {...params} />}
+          renderOption={(props, option, state) => {
+            optionStyles.push(state.style?.top);
+            return (
+              <li {...props} data-testid={option}>
+                {option}
+              </li>
+            );
+          }}
+          slotProps={{
+            listbox: {
+              component: VirtualizedListbox,
+              virtualized: true,
+            },
+          }}
+        />,
+      );
+
+      expect([...new Set(optionStyles)]).to.deep.equal([0, 10]);
+      const optionNode = screen.getByTestId('option-1');
+      expect(optionNode.style.position).to.equal('absolute');
+      expect(optionNode.style.top).to.equal('10px');
+    });
+
     it('should support duplicate labels in virtualized mode when renderOption provides a unique key', () => {
       const VirtualizedListbox = React.forwardRef(function VirtualizedListbox(props, ref) {
         const { children, ...other } = props;

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -3602,7 +3602,7 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      expect(renderOption.callCount).to.be.lessThan(10);
+      expect(renderOption.callCount).to.equal(strictModeDoubleLoggingSuppressed ? 1 : 2);
       expect(screen.getAllByRole('option')).to.have.length(1);
       expect(screen.getByRole('option')).to.have.text('option-0');
     });
@@ -3623,7 +3623,8 @@ describe('<Autocomplete />', () => {
               return React.createElement(child.type, {
                 key: child.key,
                 ...child.props,
-                optionStyle: {
+                style: {
+                  ...child.props.style,
                   position: 'absolute',
                   top: index * 10,
                 },

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -3716,10 +3716,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           disablePortal
           open
-          options={[
-            { label: 'John' },
-            { label: 'John' },
-          ]}
+          options={[{ label: 'John' }, { label: 'John' }]}
           getOptionLabel={(option) => option.label}
           renderInput={(params) => <TextField {...params} />}
           renderOption={(props, option) => {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -3572,6 +3572,40 @@ describe('<Autocomplete />', () => {
       const renderedOption = screen.getByTestId('optionLi');
       expect(renderedOption).to.have.text('Max');
     });
+
+    it('should defer renderOption until the custom listbox renders an option', () => {
+      const renderOption = spy((props, option) => <li {...props}>{option}</li>);
+      const VirtualizedListbox = React.forwardRef(function VirtualizedListbox(props, ref) {
+        const { children, ...other } = props;
+        const firstChild = Array.isArray(children) ? children[0] : children;
+
+        return (
+          <div ref={ref} {...other}>
+            {firstChild}
+          </div>
+        );
+      });
+
+      render(
+        <Autocomplete
+          disablePortal
+          open
+          options={Array.from({ length: 100 }, (_, index) => `option-${index}`)}
+          renderInput={(params) => <TextField {...params} />}
+          renderOption={renderOption}
+          slotProps={{
+            listbox: {
+              component: VirtualizedListbox,
+              virtualized: true,
+            },
+          }}
+        />,
+      );
+
+      expect(renderOption.callCount).to.be.lessThan(10);
+      expect(screen.getAllByRole('option')).to.have.length(1);
+      expect(screen.getByRole('option')).to.have.text('option-0');
+    });
   });
 
   // https://github.com/mui/material-ui/issues/36212

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -3606,6 +3606,121 @@ describe('<Autocomplete />', () => {
       expect(screen.getAllByRole('option')).to.have.length(1);
       expect(screen.getByRole('option')).to.have.text('option-0');
     });
+
+    it('should support duplicate labels in virtualized mode when renderOption provides a unique key', () => {
+      const VirtualizedListbox = React.forwardRef(function VirtualizedListbox(props, ref) {
+        const { children, ...other } = props;
+
+        return (
+          <div ref={ref} {...other}>
+            {children}
+          </div>
+        );
+      });
+
+      render(
+        <Autocomplete
+          disablePortal
+          open
+          options={[
+            { id: '1', label: 'John' },
+            { id: '2', label: 'John' },
+          ]}
+          getOptionLabel={(option) => option.label}
+          renderInput={(params) => <TextField {...params} />}
+          renderOption={(props, option) => (
+            <li {...props} key={option.id}>
+              {option.label}
+            </li>
+          )}
+          slotProps={{
+            listbox: {
+              component: VirtualizedListbox,
+              virtualized: true,
+            },
+          }}
+        />,
+      );
+
+      expect(screen.getAllByRole('option')).to.have.length(2);
+    });
+
+    it('should generate unique fallback keys in virtualized mode when labels are duplicated', () => {
+      const keys = [];
+      const VirtualizedListbox = React.forwardRef(function VirtualizedListbox(props, ref) {
+        const { children, ...other } = props;
+
+        return (
+          <div ref={ref} {...other}>
+            {children}
+          </div>
+        );
+      });
+
+      render(
+        <Autocomplete
+          disablePortal
+          open
+          options={[
+            { label: 'John' },
+            { label: 'John' },
+          ]}
+          getOptionLabel={(option) => option.label}
+          renderInput={(params) => <TextField {...params} />}
+          renderOption={(props, option) => {
+            keys.push(props.key);
+            return <li {...props}>{option.label}</li>;
+          }}
+          slotProps={{
+            listbox: {
+              component: VirtualizedListbox,
+              virtualized: true,
+            },
+          }}
+        />,
+      );
+
+      expect([...new Set(keys)]).to.deep.equal(['John-0', 'John-1']);
+    });
+
+    it('should preserve falsy getOptionKey values in virtualized mode', () => {
+      const keys = [];
+      const VirtualizedListbox = React.forwardRef(function VirtualizedListbox(props, ref) {
+        const { children, ...other } = props;
+
+        return (
+          <div ref={ref} {...other}>
+            {children}
+          </div>
+        );
+      });
+
+      render(
+        <Autocomplete
+          disablePortal
+          open
+          options={[
+            { id: 0, label: 'John' },
+            { id: 1, label: 'John' },
+          ]}
+          getOptionLabel={(option) => option.label}
+          getOptionKey={(option) => option.id}
+          renderInput={(params) => <TextField {...params} />}
+          renderOption={(props, option) => {
+            keys.push(props.key);
+            return <li {...props}>{option.label}</li>;
+          }}
+          slotProps={{
+            listbox: {
+              component: VirtualizedListbox,
+              virtualized: true,
+            },
+          }}
+        />,
+      );
+
+      expect([...new Set(keys)]).to.deep.equal([0, 1]);
+    });
   });
 
   // https://github.com/mui/material-ui/issues/36212


### PR DESCRIPTION
Try it here: https://stackblitz.com/edit/gbo3nzp4?file=src%2FDemo.tsx

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


Related to #34712

## Summary

This PR improves `Autocomplete` performance for virtualized listboxes by deferring option rendering until a row is actually mounted.

## Problem

Today, `Autocomplete` eagerly calls `getOptionProps` and `renderOption` for every option before passing `children` to a custom listbox. This means virtualization can reduce mounted DOM nodes, but it still pays the render cost for the full option set up front.

That is the bottleneck reported in #34712.

## What changed

- added an opt-in `slotProps.listbox.virtualized` flag for custom virtualized listboxes
- deferred option materialization behind a lazy option element when that flag is enabled
- preserved the existing behavior for non-virtualized listboxes
- updated the virtualization demo to render visible rows from lazy option elements
- added type coverage for the new listbox slot prop
- added a regression test to verify `renderOption` is not invoked for the whole option set when the custom listbox only renders visible rows

## Benchmarks

Local benchmark with 10,000 options and a custom virtualized listbox:

### Structural result

- `renderOption` calls on open: `10000 -> 1`
- `renderOption` calls on first input change: `20000 -> 2`

### Runtime result with a heavier `renderOption`

- open: `47.08ms -> 19.19ms`
- first input change: `100.65ms -> 34.10ms`

This keeps the default path unchanged while removing the eager full-list rendering cost from the virtualized path.

## Tests

- `pnpm exec eslint packages/mui-material/src/Autocomplete/Autocomplete.js packages/mui-material/src/Autocomplete/Autocomplete.d.ts packages/mui-material/src/Autocomplete/Autocomplete.spec.tsx packages/mui-material/src/Autocomplete/Autocomplete.test.js docs/data/material/components/autocomplete/Virtualize.tsx docs/data/material/components/autocomplete/Virtualize.js --max-warnings 0`
- `pnpm test:node packages/mui-material/src/Autocomplete/Autocomplete.test.js`

## Notes

`pnpm -F @mui/material build` currently fails in this workspace due to existing `TS6305` errors from dependent package build outputs (`mui-types`, `mui-utils`, `mui-system`). The transpilation step completes successfully; the failure happens during declaration generation outside the scope of this change.

