### PR TITLE
[FormControlLabel] Fix `slotProps.typography` type to accept any element variant

### DIFF
--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.d.ts
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SxProps } from '@mui/system';
 import { Theme } from '../styles';
 import { InternalStandardProps as StandardProps } from '../internal';
-import Typography from '../Typography';
+import { TypographyProps } from '../Typography';
 import { FormControlLabelClasses } from './formControlLabelClasses';
 import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
 
@@ -18,7 +18,7 @@ export interface FormControlLabelSlots {
 export type FormControlLabelSlotsAndSlotProps = CreateSlotsAndSlotProps<
   FormControlLabelSlots,
   {
-    typography: SlotProps<typeof Typography, {}, FormControlLabelProps>;
+    typography: SlotProps<React.ElementType<TypographyProps>, {}, FormControlLabelProps>;
   }
 >;
 

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.spec.tsx
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.spec.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { expectType } from '@mui/types';
+import { FormControlLabel, Checkbox, TypographyProps } from '@mui/material';
+
+const typographyProps: TypographyProps<'span'> = {
+  component: 'span',
+  onClick: (event) => {
+    expectType<React.MouseEvent<HTMLSpanElement, MouseEvent>, typeof event>(event);
+  },
+};
+
+function Test() {
+  return (
+    <React.Fragment>
+      <FormControlLabel control={<Checkbox />} label="Test" />
+      <FormControlLabel
+        control={<Checkbox />}
+        label="Test"
+        slotProps={{ typography: typographyProps }}
+      />
+      <FormControlLabel
+        control={<Checkbox />}
+        label="Test"
+        slotProps={{
+          typography: {
+            variant: 'h6',
+            noWrap: true,
+          },
+        }}
+      />
+    </React.Fragment>
+  );
+}


### PR DESCRIPTION
## Summary
- Change `SlotProps<typeof Typography, ...>` to `SlotProps<React.ElementType<TypographyProps>, ...>` in `FormControlLabel` so that `TypographyProps<'span'>` (and other element variants) are assignable to `slotProps.typography`
- Using `typeof Typography` locked the slot props to `div` element types (Typography's default), causing type errors when passing props typed for other elements (e.g., `TypographyProps<'span'>` with span-specific event handlers)
- Add `FormControlLabel.spec.tsx` with type tests

## Test plan
- [x] `npx tsc -p packages/mui-material/tsconfig.json --noEmit` passes with no FormControlLabel errors
- [x] New spec file verifies `TypographyProps<'span'>` is assignable to `slotProps.typography`
- [x] Standard Typography props (`variant`, `noWrap`) still work in `slotProps.typography`