### PR TITLE
[PaginationItem] Remove deprecated props

### DIFF
--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -744,6 +744,35 @@ The following deprecated prop has been removed:
  />
 ```
 
+#### PaginationItem deprecated props removed
+
+Use the [pagination-item-props codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#pagination-item-props) below to migrate the code as described in the following section:
+
+```bash
+npx @mui/codemod@latest deprecations/pagination-item-props <path>
+```
+
+The following deprecated props have been removed:
+
+- `components` — use `slots` instead
+
+```diff
+ <PaginationItem
+-  components={{
+-    first: MyFirstIcon,
+-    last: MyLastIcon,
+-    previous: MyPreviousIcon,
+-    next: MyNextIcon,
+-  }}
++  slots={{
++    first: MyFirstIcon,
++    last: MyLastIcon,
++    previous: MyPreviousIcon,
++    next: MyNextIcon,
++  }}
+ />
+```
+
 #### Popper deprecated props removed
 
 Use the [popper-props codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#popper-props) below to migrate the code as described in the following section:

--- a/docs/pages/material-ui/api/pagination-item.json
+++ b/docs/pages/material-ui/api/pagination-item.json
@@ -9,15 +9,6 @@
       "default": "'standard'"
     },
     "component": { "type": { "name": "elementType" } },
-    "components": {
-      "type": {
-        "name": "shape",
-        "description": "{ first?: elementType, last?: elementType, next?: elementType, previous?: elementType }"
-      },
-      "default": "{}",
-      "deprecated": true,
-      "deprecationInfo": "use the <code>slots</code> prop instead. This prop will be removed in a future major release. See <a href=\"https://mui.com/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
     "disabled": { "type": { "name": "bool" }, "default": "false" },
     "page": { "type": { "name": "node" } },
     "selected": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/translations/api-docs/pagination-item/pagination-item.json
+++ b/docs/translations/api-docs/pagination-item/pagination-item.json
@@ -8,9 +8,6 @@
     "component": {
       "description": "The component used for the root node. Either a string to use a HTML element or a component."
     },
-    "components": {
-      "description": "The components used for each slot inside.<br>This prop is an alias for the <code>slots</code> prop. It&#39;s recommended to use the <code>slots</code> prop instead."
-    },
     "disabled": { "description": "If <code>true</code>, the component is disabled." },
     "page": { "description": "The current page number." },
     "selected": { "description": "If <code>true</code> the pagination item is selected." },

--- a/packages/mui-material/src/PaginationItem/PaginationItem.d.ts
+++ b/packages/mui-material/src/PaginationItem/PaginationItem.d.ts
@@ -99,23 +99,6 @@ export interface PaginationItemOwnProps extends PaginationItemSlotsAndSlotProps 
       >
     | undefined;
   /**
-   * The components used for each slot inside.
-   *
-   * This prop is an alias for the `slots` prop.
-   * It's recommended to use the `slots` prop instead.
-   *
-   * @default {}
-   * @deprecated use the `slots` prop instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](https://mui.com/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  components?:
-    | {
-        first?: React.ElementType | undefined;
-        last?: React.ElementType | undefined;
-        next?: React.ElementType | undefined;
-        previous?: React.ElementType | undefined;
-      }
-    | undefined;
-  /**
    * If `true`, the component is disabled.
    * @default false
    */

--- a/packages/mui-material/src/PaginationItem/PaginationItem.js
+++ b/packages/mui-material/src/PaginationItem/PaginationItem.js
@@ -301,7 +301,6 @@ const PaginationItem = React.forwardRef(function PaginationItem(inProps, ref) {
     className,
     color = 'standard',
     component,
-    components = {},
     disabled = false,
     page,
     selected = false,
@@ -329,12 +328,7 @@ const PaginationItem = React.forwardRef(function PaginationItem(inProps, ref) {
   const classes = useUtilityClasses(ownerState);
 
   const externalForwardedProps = {
-    slots: {
-      previous: slots.previous ?? components.previous,
-      next: slots.next ?? components.next,
-      first: slots.first ?? components.first,
-      last: slots.last ?? components.last,
-    },
+    slots,
     slotProps,
   };
 
@@ -442,21 +436,6 @@ PaginationItem.propTypes /* remove-proptypes */ = {
    * Either a string to use a HTML element or a component.
    */
   component: PropTypes.elementType,
-  /**
-   * The components used for each slot inside.
-   *
-   * This prop is an alias for the `slots` prop.
-   * It's recommended to use the `slots` prop instead.
-   *
-   * @default {}
-   * @deprecated use the `slots` prop instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](https://mui.com/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  components: PropTypes.shape({
-    first: PropTypes.elementType,
-    last: PropTypes.elementType,
-    next: PropTypes.elementType,
-    previous: PropTypes.elementType,
-  }),
   /**
    * If `true`, the component is disabled.
    * @default false

--- a/packages/mui-material/src/PaginationItem/PaginationItem.test.js
+++ b/packages/mui-material/src/PaginationItem/PaginationItem.test.js
@@ -20,7 +20,6 @@ describe('<PaginationItem />', () => {
     refInstanceof: window.HTMLButtonElement,
     testVariantProps: { variant: 'foo' },
     testStateOverrides: { prop: 'variant', value: 'outlined', styleKey: 'outlined' },
-    testLegacyComponentsProp: true,
     slots: {
       first: {},
       last: {},
@@ -28,13 +27,15 @@ describe('<PaginationItem />', () => {
       next: {},
     },
     skip: [
-      'componentProp',
       'componentsProp',
-      // uses non-standard camel-case fields in `components`
+      // Icon slots (first, last, previous, next) only render when `type` matches
+      // (e.g. type="first" for the first slot). The conformance test renders
+      // <PaginationItem /> which defaults to type="page", so icon slots are absent.
+      // Manual slot tests below cover this instead.
       'slotsProp',
       'slotPropsProp',
-      'slotPropsCallback', // not supported yet
-      'slotPropsCallbackWithPropsAsOwnerState', // not supported yet
+      'slotPropsCallback',
+      'slotPropsCallbackWithPropsAsOwnerState',
     ],
   }));
 
@@ -173,69 +174,6 @@ describe('<PaginationItem />', () => {
         render(<PaginationItem page={1} slotProps={slotProps} slots={slots} type={slot} />);
 
         expect(screen.getByTestId(`slot-${slot}`)).not.to.equal(null);
-      });
-    });
-
-    it('icons passed in slots should override icons passed in components prop', () => {
-      const slots = {
-        previous: CustomPreviousIcon,
-        next: CustomNextIcon,
-        first: CustomFirstIcon,
-        last: CustomLastIcon,
-      };
-
-      const slotProps = {
-        previous: { 'data-testid': 'slot-previous' },
-        next: { 'data-testid': 'slot-next' },
-        first: { 'data-testid': 'slot-first' },
-        last: { 'data-testid': 'slot-last' },
-      };
-
-      const components = {
-        previous: CustomPreviousIcon,
-        next: CustomNextIcon,
-        first: CustomFirstIcon,
-        last: CustomLastIcon,
-      };
-
-      ['first', 'previous', 'next', 'last'].forEach((slot) => {
-        render(
-          <PaginationItem
-            page={1}
-            slotProps={slotProps}
-            components={components}
-            slots={slots}
-            type={slot}
-          />,
-        );
-
-        expect(screen.getByTestId(`slot-${slot}`)).not.to.equal(null);
-        expect(screen.queryByTestId(`custom-${slot}`)).to.equal(null);
-      });
-    });
-
-    it('should apply slotProps to icons passed in slots prop', () => {
-      const slotProps = {
-        previous: { 'data-testid': 'component-previous' },
-        next: { 'data-testid': 'component-next' },
-        first: { 'data-testid': 'component-first' },
-        last: { 'data-testid': 'component-last' },
-      };
-
-      const components = {
-        previous: CustomPreviousIcon,
-        next: CustomNextIcon,
-        first: CustomFirstIcon,
-        last: CustomLastIcon,
-      };
-
-      ['first', 'previous', 'next', 'last'].forEach((slot) => {
-        render(
-          <PaginationItem page={1} slotProps={slotProps} components={components} type={slot} />,
-        );
-
-        expect(screen.getByTestId(`component-${slot}`)).not.to.equal(null);
-        expect(screen.queryByTestId(`custom-${slot}`)).to.equal(null);
       });
     });
 


### PR DESCRIPTION
## Summary

Remove the deprecated `components` prop from `PaginationItem`. Users should use the `slots` prop instead.

### Breaking change

The `components` prop has been removed. Use `slots` instead:

```diff
 <PaginationItem
-  components={{
-    first: MyFirstIcon,
-    last: MyLastIcon,
-    previous: MyPreviousIcon,
-    next: MyNextIcon,
-  }}
+  slots={{
+    first: MyFirstIcon,
+    last: MyLastIcon,
+    previous: MyPreviousIcon,
+    next: MyNextIcon,
+  }}
 />
```

A codemod is available:
```bash
npx @mui/codemod@latest deprecations/pagination-item-props <path>
```

## Checklist

- [x] Prop removed from component source and types
- [x] PropTypes removed
- [x] Tests updated
- [x] `pnpm proptypes && pnpm docs:api` run
- [x] Migration guide updated in upgrade-to-v9.md
- [x] `pnpm prettier && pnpm eslint && pnpm typescript` pass
- [x] Unit tests pass

Closes https://github.com/mui/material-ui/issues/47987 (partial)