### PR TITLE
[MobileStepper] Remove deprecated LinearProgressProps

### DIFF
--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -932,6 +932,25 @@ If you pass these props via `Select`'s `MenuProps`, update them the same way:
  />
 ```
 
+#### MobileStepper deprecated props removed
+
+Use the [mobile-stepper-props codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#mobile-stepper-props) below to migrate the code as described in the following section:
+
+```bash
+npx @mui/codemod@latest deprecations/mobile-stepper-props <path>
+```
+
+The following deprecated props have been removed:
+
+- `LinearProgressProps` — use `slotProps.progress` instead
+
+```diff
+ <MobileStepper
+-  LinearProgressProps={{ className: 'progress' }}
++  slotProps={{ progress: { className: 'progress' } }}
+ />
+```
+
 #### Popover deprecated props removed
 
 The following deprecated props have been removed:

--- a/docs/pages/material-ui/api/mobile-stepper.json
+++ b/docs/pages/material-ui/api/mobile-stepper.json
@@ -4,11 +4,6 @@
     "activeStep": { "type": { "name": "custom", "description": "integer" }, "default": "0" },
     "backButton": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "LinearProgressProps": {
-      "type": { "name": "object" },
-      "deprecated": true,
-      "deprecationInfo": "Use <code>slotProps.progress</code> instead. This prop will be removed in a future major release. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
     "nextButton": { "type": { "name": "node" } },
     "position": {
       "type": {

--- a/docs/translations/api-docs/mobile-stepper/mobile-stepper.json
+++ b/docs/translations/api-docs/mobile-stepper/mobile-stepper.json
@@ -8,9 +8,6 @@
       "description": "A back button element. For instance, it can be a <code>Button</code> or an <code>IconButton</code>."
     },
     "classes": { "description": "Override or extend the styles applied to the component." },
-    "LinearProgressProps": {
-      "description": "Props applied to the <code>LinearProgress</code> element."
-    },
     "nextButton": {
       "description": "A next button element. For instance, it can be a <code>Button</code> or an <code>IconButton</code>."
     },

--- a/packages/mui-material/src/MobileStepper/MobileStepper.d.ts
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.d.ts
@@ -86,11 +86,6 @@ export interface MobileStepperProps
    */
   classes?: Partial<MobileStepperClasses> | undefined;
   /**
-   * Props applied to the `LinearProgress` element.
-   * @deprecated Use `slotProps.progress` instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  LinearProgressProps?: Partial<LinearProgressProps> | undefined;
-  /**
    * A next button element. For instance, it can be a `Button` or an `IconButton`.
    */
   nextButton: React.ReactNode;

--- a/packages/mui-material/src/MobileStepper/MobileStepper.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.js
@@ -136,7 +136,6 @@ const MobileStepper = React.forwardRef(function MobileStepper(inProps, ref) {
     activeStep = 0,
     backButton,
     className,
-    LinearProgressProps,
     nextButton,
     position = 'bottom',
     steps,
@@ -166,10 +165,7 @@ const MobileStepper = React.forwardRef(function MobileStepper(inProps, ref) {
 
   const externalForwardedProps = {
     slots,
-    slotProps: {
-      progress: LinearProgressProps,
-      ...slotProps,
-    },
+    slotProps,
   };
 
   const [RootSlot, rootSlotProps] = useSlot('root', {
@@ -269,11 +265,6 @@ MobileStepper.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   className: PropTypes.string,
-  /**
-   * Props applied to the `LinearProgress` element.
-   * @deprecated Use `slotProps.progress` instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  LinearProgressProps: PropTypes.object,
   /**
    * A next button element. For instance, it can be a `Button` or an `IconButton`.
    */


### PR DESCRIPTION
## Summary

Remove deprecated `LinearProgressProps` prop from MobileStepper. Users should use `slotProps.progress` instead.

### Breaking change

- `LinearProgressProps` prop has been removed. Use `slotProps.progress` instead.

```diff
 <MobileStepper
-  LinearProgressProps={{ className: 'progress' }}
+  slotProps={{ progress: { className: 'progress' } }}
 />
```

### Migration

Use the [mobile-stepper-props codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#mobile-stepper-props):

```bash
npx @mui/codemod@latest deprecations/mobile-stepper-props <path>
```