### PR TITLE
[TablePagination][TableSortLabel] Remove deprecated props and classes

### DIFF
--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -1127,6 +1127,9 @@ The following deprecated classes have been removed:
 ```diff
 -.MuiTableSortLabel-iconDirectionDesc
 +.MuiTableSortLabel-directionDesc > .MuiTableSortLabel-icon
+
+-.MuiTableSortLabel-iconDirectionAsc
++.MuiTableSortLabel-directionAsc > .MuiTableSortLabel-icon
 ```
 
 #### SpeedDial deprecated props removed

--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -1132,6 +1132,27 @@ The following deprecated classes have been removed:
 +.MuiTableSortLabel-directionAsc > .MuiTableSortLabel-icon
 ```
 
+If you were using these deprecated class names as `styleOverrides` keys in your theme, use the `variants` array in the `icon` override instead:
+
+```diff
+ const theme = createTheme({
+   components: {
+     MuiTableSortLabel: {
+       styleOverrides: {
+-        iconDirectionDesc: { opacity: 1 },
+-        iconDirectionAsc: { opacity: 1 },
++        icon: {
++          variants: [
++            { props: { direction: 'desc' }, style: { opacity: 1 } },
++            { props: { direction: 'asc' }, style: { opacity: 1 } },
++          ],
++        },
+       },
+     },
+   },
+ });
+```
+
 #### SpeedDial deprecated props removed
 
 The deprecated `SpeedDial` props have been removed.

--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -939,6 +939,53 @@ The following deprecated `Snackbar` props have been removed:
  />
 ```
 
+#### TablePagination deprecated props removed
+
+Use the [table-pagination-props codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#table-pagination-props) below to migrate the code as described in the following section:
+
+```bash
+npx @mui/codemod@latest deprecations/table-pagination-props <path>
+```
+
+The following deprecated props have been removed:
+
+- `backIconButtonProps` — use `slotProps.actions.previousButton` instead
+- `nextIconButtonProps` — use `slotProps.actions.nextButton` instead
+- `SelectProps` — use `slotProps.select` instead
+
+```diff
+ <TablePagination
+-  backIconButtonProps={{ disabled: true }}
+-  nextIconButtonProps={{ disabled: true }}
+-  SelectProps={{ variant: 'outlined' }}
++  slotProps={{
++    actions: {
++      previousButton: { disabled: true },
++      nextButton: { disabled: true },
++    },
++    select: { variant: 'outlined' },
++  }}
+ />
+```
+
+#### TableSortLabel deprecated classes removed
+
+Use the [table-sort-label-classes codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#table-sort-label-classes) below to migrate the code as described in the following section:
+
+```bash
+npx @mui/codemod@latest deprecations/table-sort-label-classes <path>
+```
+
+The following deprecated classes have been removed:
+
+- `iconDirectionDesc` — combine the `.MuiTableSortLabel-directionDesc` and `.MuiTableSortLabel-icon` classes instead
+- `iconDirectionAsc` — combine the `.MuiTableSortLabel-directionAsc` and `.MuiTableSortLabel-icon` classes instead
+
+```diff
+-.MuiTableSortLabel-iconDirectionDesc
++.MuiTableSortLabel-directionDesc > .MuiTableSortLabel-icon
+```
+
 #### SpeedDial deprecated props removed
 
 The deprecated `SpeedDial` props have been removed.

--- a/docs/pages/material-ui/api/table-pagination-actions.json
+++ b/docs/pages/material-ui/api/table-pagination-actions.json
@@ -5,18 +5,8 @@
       "required": true,
       "signature": { "type": "function(type: string) => string", "describedArgs": ["type"] }
     },
-    "backIconButtonProps": {
-      "type": { "name": "object" },
-      "deprecated": true,
-      "deprecationInfo": "Use <code>slotProps.previousButton</code> instead."
-    },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "disabled": { "type": { "name": "bool" }, "default": "false" },
-    "nextIconButtonProps": {
-      "type": { "name": "object" },
-      "deprecated": true,
-      "deprecationInfo": "Use <code>slotProps.nextButton</code> instead."
-    }
+    "disabled": { "type": { "name": "bool" }, "default": "false" }
   },
   "name": "TablePaginationActions",
   "imports": [

--- a/docs/pages/material-ui/api/table-pagination.json
+++ b/docs/pages/material-ui/api/table-pagination.json
@@ -12,11 +12,6 @@
     "page": { "type": { "name": "custom", "description": "integer" }, "required": true },
     "rowsPerPage": { "type": { "name": "custom", "description": "integer" }, "required": true },
     "ActionsComponent": { "type": { "name": "elementType" }, "default": "TablePaginationActions" },
-    "backIconButtonProps": {
-      "type": { "name": "object" },
-      "deprecated": true,
-      "deprecationInfo": "Use <code>slotProps.actions.previousButton</code> instead."
-    },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "component": { "type": { "name": "elementType" } },
     "disabled": { "type": { "name": "bool" }, "default": "false" },
@@ -30,11 +25,6 @@
       "default": "function defaultLabelDisplayedRows({ from, to, count }) {\n  return `${formatNumber(from)}–${formatNumber(to)} of ${count !== -1 ? formatNumber(count) : `more than ${formatNumber(to)}`}`;\n}"
     },
     "labelRowsPerPage": { "type": { "name": "node" }, "default": "'Rows per page:'" },
-    "nextIconButtonProps": {
-      "type": { "name": "object" },
-      "deprecated": true,
-      "deprecationInfo": "Use <code>slotProps.actions.nextButton</code> instead."
-    },
     "onRowsPerPageChange": {
       "type": { "name": "func" },
       "signature": {
@@ -48,12 +38,6 @@
         "description": "Array&lt;number<br>&#124;&nbsp;{ label: string, value: number }&gt;"
       },
       "default": "[10, 25, 50, 100]"
-    },
-    "SelectProps": {
-      "type": { "name": "object" },
-      "default": "{}",
-      "deprecated": true,
-      "deprecationInfo": "Use <code>slotProps.select</code> instead."
     },
     "showFirstButton": { "type": { "name": "bool" }, "default": "false" },
     "showLastButton": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/material-ui/api/table-sort-label.json
+++ b/docs/pages/material-ui/api/table-sort-label.json
@@ -65,20 +65,6 @@
       "className": "MuiTableSortLabel-directionDesc",
       "description": "Styles applied to the root element if `direction=\"desc\"`.",
       "isGlobal": false
-    },
-    {
-      "key": "iconDirectionAsc",
-      "className": "MuiTableSortLabel-iconDirectionAsc",
-      "description": "Styles applied to the icon component if `direction=\"asc\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "iconDirectionDesc",
-      "className": "MuiTableSortLabel-iconDirectionDesc",
-      "description": "Styles applied to the icon component if `direction=\"desc\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
     }
   ],
   "spread": true,

--- a/docs/translations/api-docs/table-pagination-actions/table-pagination-actions.json
+++ b/docs/translations/api-docs/table-pagination-actions/table-pagination-actions.json
@@ -1,9 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "backIconButtonProps": {
-      "description": "This prop is an alias for <code>slotProps.previousButton</code> and will be overridden by it if both are used."
-    },
     "classes": { "description": "Override or extend the styles applied to the component." },
     "disabled": { "description": "If <code>true</code>, the component is disabled." },
     "getItemAriaLabel": {
@@ -14,9 +11,6 @@
           "description": "The link or button type to format (&#39;first&#39; | &#39;last&#39; | &#39;next&#39; | &#39;previous&#39;)."
         }
       }
-    },
-    "nextIconButtonProps": {
-      "description": "This prop is an alias for <code>slotProps.nextButton</code> and will be overridden by it if both are used."
     }
   },
   "classDescriptions": {},

--- a/docs/translations/api-docs/table-pagination/table-pagination.json
+++ b/docs/translations/api-docs/table-pagination/table-pagination.json
@@ -4,9 +4,6 @@
     "ActionsComponent": {
       "description": "The component used for displaying the actions. Either a string to use a HTML element or a component."
     },
-    "backIconButtonProps": {
-      "description": "Props applied to the back arrow <a href=\"https://mui.com/material-ui/api/icon-button/\"><code>IconButton</code></a> component.<br>This prop is an alias for <code>slotProps.actions.previousButton</code> and will be overridden by it if both are used."
-    },
     "classes": { "description": "Override or extend the styles applied to the component." },
     "component": {
       "description": "The component used for the root node. Either a string to use a HTML element or a component."
@@ -30,9 +27,6 @@
     "labelRowsPerPage": {
       "description": "Customize the rows per page label.<br>For localization purposes, you can use the provided <a href=\"https://mui.com/material-ui/guides/localization/\">translations</a>."
     },
-    "nextIconButtonProps": {
-      "description": "Props applied to the next arrow <a href=\"https://mui.com/material-ui/api/icon-button/\"><code>IconButton</code></a> element.<br>This prop is an alias for <code>slotProps.actions.nextButton</code> and will be overridden by it if both are used."
-    },
     "onPageChange": {
       "description": "Callback fired when the page is changed.",
       "typeDescriptions": {
@@ -52,9 +46,6 @@
     },
     "rowsPerPageOptions": {
       "description": "Customizes the options of the rows per page select field. If less than two options are available, no select field will be displayed. Use -1 for the value with a custom label to show all the rows."
-    },
-    "SelectProps": {
-      "description": "Props applied to the rows per page <a href=\"https://mui.com/material-ui/api/select/\"><code>Select</code></a> element.<br>This prop is an alias for <code>slotProps.select</code> and will be overridden by it if both are used."
     },
     "showFirstButton": { "description": "If <code>true</code>, show the first-page button." },
     "showLastButton": { "description": "If <code>true</code>, show the last-page button." },

--- a/docs/translations/api-docs/table-sort-label/table-sort-label.json
+++ b/docs/translations/api-docs/table-sort-label/table-sort-label.json
@@ -30,18 +30,6 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>direction=\"desc\"</code>"
-    },
-    "iconDirectionAsc": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the icon component",
-      "conditions": "<code>direction=\"asc\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/table-sort-label/#TableSortLabel-css-MuiTableSortLabel-icon\">.MuiTableSortLabel-icon</a> and <a href=\"/material-ui/api/table-sort-label/#table-sort-label-classes-MuiTableSortLabel-directionAsc\">.MuiTableSortLabel-directionAsc</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "iconDirectionDesc": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the icon component",
-      "conditions": "<code>direction=\"desc\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/table-sort-label/#TableSortLabel-css-MuiTableSortLabel-icon\">.MuiTableSortLabel-icon</a> and <a href=\"/material-ui/api/table-sort-label/#table-sort-label-classes-MuiTableSortLabel-directionDesc\">.MuiTableSortLabel-directionDesc</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
     }
   },
   "slotDescriptions": {

--- a/packages/mui-material/src/TablePagination/TablePagination.d.ts
+++ b/packages/mui-material/src/TablePagination/TablePagination.d.ts
@@ -7,7 +7,6 @@ import {
   TablePaginationActionsSlots,
 } from '../TablePaginationActions';
 import { TableCellProps } from '../TableCell';
-import { IconButtonProps } from '../IconButton';
 import { SelectProps } from '../Select';
 import { TablePaginationClasses } from './tablePaginationClasses';
 import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';

--- a/packages/mui-material/src/TablePagination/TablePagination.d.ts
+++ b/packages/mui-material/src/TablePagination/TablePagination.d.ts
@@ -161,13 +161,6 @@ export interface TablePaginationOwnProps extends TablePaginationBaseProps {
    */
   ActionsComponent?: React.ElementType<TablePaginationActionsProps> | undefined;
   /**
-   * Props applied to the back arrow [`IconButton`](https://mui.com/material-ui/api/icon-button/) component.
-   *
-   * This prop is an alias for `slotProps.actions.previousButton` and will be overridden by it if both are used.
-   * @deprecated Use `slotProps.actions.previousButton` instead.
-   */
-  backIconButtonProps?: Partial<IconButtonProps> | undefined;
-  /**
    * Override or extend the styles applied to the component.
    */
   classes?: Partial<TablePaginationClasses> | undefined;
@@ -212,13 +205,6 @@ export interface TablePaginationOwnProps extends TablePaginationBaseProps {
    */
   labelRowsPerPage?: React.ReactNode;
   /**
-   * Props applied to the next arrow [`IconButton`](https://mui.com/material-ui/api/icon-button/) element.
-   *
-   * This prop is an alias for `slotProps.actions.nextButton` and will be overridden by it if both are used.
-   * @deprecated Use `slotProps.actions.nextButton` instead.
-   */
-  nextIconButtonProps?: Partial<IconButtonProps> | undefined;
-  /**
    * Callback fired when the page is changed.
    *
    * @param {React.MouseEvent<HTMLButtonElement> | null} event The event source of the callback.
@@ -250,15 +236,6 @@ export interface TablePaginationOwnProps extends TablePaginationBaseProps {
    * @default [10, 25, 50, 100]
    */
   rowsPerPageOptions?: ReadonlyArray<number | { value: number; label: string }> | undefined;
-  /**
-   * Props applied to the rows per page [`Select`](https://mui.com/material-ui/api/select/) element.
-   *
-   * This prop is an alias for `slotProps.select` and will be overridden by it if both are used.
-   * @deprecated Use `slotProps.select` instead.
-   *
-   * @default {}
-   */
-  SelectProps?: Partial<SelectProps> | undefined;
   /**
    * If `true`, show the first-page button.
    * @default false

--- a/packages/mui-material/src/TablePagination/TablePagination.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.js
@@ -149,7 +149,6 @@ const TablePagination = React.forwardRef(function TablePagination(inProps, ref) 
   const props = useDefaultProps({ props: inProps, name: 'MuiTablePagination' });
   const {
     ActionsComponent = TablePaginationActions,
-    backIconButtonProps,
     colSpan: colSpanProp,
     component = TableCell,
     count,
@@ -157,13 +156,11 @@ const TablePagination = React.forwardRef(function TablePagination(inProps, ref) 
     getItemAriaLabel = defaultGetAriaLabel,
     labelDisplayedRows = defaultLabelDisplayedRows,
     labelRowsPerPage = 'Rows per page:',
-    nextIconButtonProps,
     onPageChange,
     onRowsPerPageChange,
     page,
     rowsPerPage,
     rowsPerPageOptions = [10, 25, 50, 100],
-    SelectProps = {},
     showFirstButton = false,
     showLastButton = false,
     slotProps = {},
@@ -174,7 +171,7 @@ const TablePagination = React.forwardRef(function TablePagination(inProps, ref) 
   const ownerState = props;
   const classes = useUtilityClasses(ownerState);
 
-  const selectProps = slotProps?.select ?? SelectProps;
+  const selectProps = slotProps?.select ?? {};
 
   const MenuItemComponent = selectProps.native ? 'option' : TablePaginationMenuItem;
 
@@ -305,9 +302,7 @@ const TablePagination = React.forwardRef(function TablePagination(inProps, ref) 
         </DisplayedRows>
         <ActionsComponent
           className={classes.actions}
-          backIconButtonProps={backIconButtonProps}
           count={count}
-          nextIconButtonProps={nextIconButtonProps}
           onPageChange={onPageChange}
           page={page}
           rowsPerPage={rowsPerPage}
@@ -334,13 +329,6 @@ TablePagination.propTypes /* remove-proptypes */ = {
    * @default TablePaginationActions
    */
   ActionsComponent: PropTypes.elementType,
-  /**
-   * Props applied to the back arrow [`IconButton`](https://mui.com/material-ui/api/icon-button/) component.
-   *
-   * This prop is an alias for `slotProps.actions.previousButton` and will be overridden by it if both are used.
-   * @deprecated Use `slotProps.actions.previousButton` instead.
-   */
-  backIconButtonProps: PropTypes.object,
   /**
    * Override or extend the styles applied to the component.
    */
@@ -395,13 +383,6 @@ TablePagination.propTypes /* remove-proptypes */ = {
    */
   labelRowsPerPage: PropTypes.node,
   /**
-   * Props applied to the next arrow [`IconButton`](https://mui.com/material-ui/api/icon-button/) element.
-   *
-   * This prop is an alias for `slotProps.actions.nextButton` and will be overridden by it if both are used.
-   * @deprecated Use `slotProps.actions.nextButton` instead.
-   */
-  nextIconButtonProps: PropTypes.object,
-  /**
    * Callback fired when the page is changed.
    *
    * @param {React.MouseEvent<HTMLButtonElement> | null} event The event source of the callback.
@@ -454,15 +435,6 @@ TablePagination.propTypes /* remove-proptypes */ = {
       }),
     ]).isRequired,
   ),
-  /**
-   * Props applied to the rows per page [`Select`](https://mui.com/material-ui/api/select/) element.
-   *
-   * This prop is an alias for `slotProps.select` and will be overridden by it if both are used.
-   * @deprecated Use `slotProps.select` instead.
-   *
-   * @default {}
-   */
-  SelectProps: PropTypes.object,
   /**
    * If `true`, show the first-page button.
    * @default false

--- a/packages/mui-material/src/TablePagination/TablePagination.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.js
@@ -172,7 +172,9 @@ const TablePagination = React.forwardRef(function TablePagination(inProps, ref) 
   const classes = useUtilityClasses(ownerState);
 
   const selectProps =
-    typeof slotProps?.select === 'function' ? slotProps.select(ownerState) : slotProps?.select ?? {};
+    typeof slotProps?.select === 'function'
+      ? slotProps.select(ownerState)
+      : (slotProps?.select ?? {});
 
   const MenuItemComponent = selectProps.native ? 'option' : TablePaginationMenuItem;
 

--- a/packages/mui-material/src/TablePagination/TablePagination.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.js
@@ -171,7 +171,8 @@ const TablePagination = React.forwardRef(function TablePagination(inProps, ref) 
   const ownerState = props;
   const classes = useUtilityClasses(ownerState);
 
-  const selectProps = slotProps?.select ?? {};
+  const selectProps =
+    typeof slotProps?.select === 'function' ? slotProps.select(ownerState) : slotProps?.select ?? {};
 
   const MenuItemComponent = selectProps.native ? 'option' : TablePaginationMenuItem;
 

--- a/packages/mui-material/src/TablePagination/TablePagination.test.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.test.js
@@ -381,16 +381,14 @@ describe('<TablePagination />', () => {
     });
   });
 
-  describe('prop: backIconButtonProps', () => {
+  describe('slotProps: actions.previousButton', () => {
     it('should apply props to the back button', () => {
-      const backIconButtonPropsDisabled = true;
-
       render(
         <table>
           <TableFooter>
             <TableRow>
               <TablePagination
-                backIconButtonProps={{ disabled: backIconButtonPropsDisabled }}
+                slotProps={{ actions: { previousButton: { disabled: true } } }}
                 count={1}
                 page={0}
                 onPageChange={noop}
@@ -403,20 +401,18 @@ describe('<TablePagination />', () => {
       );
 
       const backButton = screen.getByRole('button', { name: 'Go to previous page' });
-      expect(backButton).to.have.property('disabled', backIconButtonPropsDisabled);
+      expect(backButton).to.have.property('disabled', true);
     });
   });
 
-  describe('prop: nextIconButtonProps', () => {
+  describe('slotProps: actions.nextButton', () => {
     it('should apply props to the next button', () => {
-      const nextIconButtonPropsDisabled = true;
-
       render(
         <table>
           <TableFooter>
             <TableRow>
               <TablePagination
-                nextIconButtonProps={{ disabled: nextIconButtonPropsDisabled }}
+                slotProps={{ actions: { nextButton: { disabled: true } } }}
                 count={1}
                 page={0}
                 onPageChange={noop}
@@ -429,7 +425,7 @@ describe('<TablePagination />', () => {
       );
 
       const nextButton = screen.getByRole('button', { name: 'Go to next page' });
-      expect(nextButton).to.have.property('disabled', nextIconButtonPropsDisabled);
+      expect(nextButton).to.have.property('disabled', true);
     });
   });
 
@@ -513,7 +509,7 @@ describe('<TablePagination />', () => {
     });
   });
 
-  describe('prop: SelectProps', () => {
+  describe('slotProps: select', () => {
     it('does allow manual label ids', () => {
       render(
         <table>
@@ -525,7 +521,7 @@ describe('<TablePagination />', () => {
                 onPageChange={noop}
                 onRowsPerPageChange={noop}
                 rowsPerPage={10}
-                SelectProps={{ id: 'foo', labelId: 'bar' }}
+                slotProps={{ select: { id: 'foo', labelId: 'bar' } }}
               />
             </TableRow>
           </TableFooter>
@@ -548,7 +544,7 @@ describe('<TablePagination />', () => {
                   onPageChange={noop}
                   onRowsPerPageChange={noop}
                   rowsPerPage={10}
-                  SelectProps={{ variant }}
+                  slotProps={{ select: { variant } }}
                 />
               </TableRow>
             </TableFooter>
@@ -595,19 +591,15 @@ describe('<TablePagination />', () => {
   describe('prop: slotProps', () => {
     describe('actions', () => {
       describe('previousButton', () => {
-        it('should override backIconButtonProps', () => {
-          const slotPropsDisabled = false;
-          const backIconButtonPropsDisabled = true;
-
+        it('should apply slotProps to previous button', () => {
           render(
             <table>
               <TableFooter>
                 <TableRow>
                   <TablePagination
-                    backIconButtonProps={{ disabled: backIconButtonPropsDisabled }}
                     slotProps={{
                       actions: {
-                        previousButton: { disabled: slotPropsDisabled },
+                        previousButton: { disabled: true },
                       },
                     }}
                     count={1}
@@ -622,24 +614,19 @@ describe('<TablePagination />', () => {
           );
 
           const backButton = screen.getByRole('button', { name: 'Go to previous page' });
-          expect(slotPropsDisabled).not.to.equal(backIconButtonPropsDisabled);
-          expect(backButton).to.have.property('disabled', slotPropsDisabled);
+          expect(backButton).to.have.property('disabled', true);
         });
       });
 
       describe('nextButton', () => {
-        it('should override nextIconButtonProps', () => {
-          const slotPropsDisabled = false;
-          const nextIconButtonPropsDisabled = true;
-
+        it('should apply slotProps to next button', () => {
           render(
             <table>
               <TableFooter>
                 <TableRow>
                   <TablePagination
-                    nextIconButtonProps={{ disabled: nextIconButtonPropsDisabled }}
                     slotProps={{
-                      actions: { nextButton: { disabled: slotPropsDisabled } },
+                      actions: { nextButton: { disabled: true } },
                     }}
                     count={1}
                     page={0}
@@ -653,8 +640,7 @@ describe('<TablePagination />', () => {
           );
 
           const nextButton = screen.getByRole('button', { name: 'Go to next page' });
-          expect(slotPropsDisabled).not.to.equal(nextIconButtonPropsDisabled);
-          expect(nextButton).to.have.property('disabled', slotPropsDisabled);
+          expect(nextButton).to.have.property('disabled', true);
         });
       });
 
@@ -702,17 +688,13 @@ describe('<TablePagination />', () => {
     });
 
     describe('select', () => {
-      it('should override SelectProps', () => {
-        const slotPropsDisabled = false;
-        const SelectPropsDisabled = true;
-
+      it('should apply slotProps to select', () => {
         render(
           <table>
             <TableFooter>
               <TableRow>
                 <TablePagination
-                  SelectProps={{ disabled: SelectPropsDisabled }}
-                  slotProps={{ select: { disabled: slotPropsDisabled } }}
+                  slotProps={{ select: { disabled: true } }}
                   count={1}
                   page={0}
                   onPageChange={noop}
@@ -725,8 +707,7 @@ describe('<TablePagination />', () => {
         );
 
         const combobox = screen.getByRole('combobox');
-        expect(slotPropsDisabled).not.to.equal(SelectPropsDisabled);
-        expect(combobox.parentElement).not.to.have.class(inputClasses.disabled);
+        expect(combobox.parentElement).to.have.class(inputClasses.disabled);
       });
     });
   });
@@ -825,9 +806,11 @@ describe('<TablePagination />', () => {
                 rowsPerPage={10}
                 page={0}
                 onPageChange={noop}
-                SelectProps={{
-                  inputProps: { 'aria-label': 'rows per page' },
-                  native: true,
+                slotProps={{
+                  select: {
+                    inputProps: { 'aria-label': 'rows per page' },
+                    native: true,
+                  },
                 }}
               />
             </TableRow>

--- a/packages/mui-material/src/TablePaginationActions/TablePaginationActions.d.ts
+++ b/packages/mui-material/src/TablePaginationActions/TablePaginationActions.d.ts
@@ -4,11 +4,6 @@ import { SvgIconProps } from '../SvgIcon';
 
 export interface TablePaginationActionsProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
-   * This prop is an alias for `slotProps.previousButton` and will be overridden by it if both are used.
-   * @deprecated Use `slotProps.previousButton` instead.
-   */
-  backIconButtonProps?: Partial<IconButtonProps> | undefined;
-  /**
    * Override or extend the styles applied to the component.
    */
   classes?: {} | undefined;
@@ -28,11 +23,6 @@ export interface TablePaginationActionsProps extends React.HTMLAttributes<HTMLDi
    * @returns {string}
    */
   getItemAriaLabel: (type: 'first' | 'last' | 'next' | 'previous') => string;
-  /**
-   * This prop is an alias for `slotProps.nextButton` and will be overridden by it if both are used.
-   * @deprecated Use `slotProps.nextButton` instead.
-   */
-  nextIconButtonProps?: Partial<IconButtonProps> | undefined;
   onPageChange: (event: React.MouseEvent<HTMLButtonElement> | null, page: number) => void;
   page: number;
   rowsPerPage: number;

--- a/packages/mui-material/src/TablePaginationActions/TablePaginationActions.js
+++ b/packages/mui-material/src/TablePaginationActions/TablePaginationActions.js
@@ -32,12 +32,10 @@ const TablePaginationActions = React.forwardRef(function TablePaginationActions(
   const props = useDefaultProps({ props: inProps, name: 'MuiTablePaginationActions' });
 
   const {
-    backIconButtonProps,
     className,
     count,
     disabled = false,
     getItemAriaLabel,
-    nextIconButtonProps,
     onPageChange,
     page,
     rowsPerPage,
@@ -112,7 +110,7 @@ const TablePaginationActions = React.forwardRef(function TablePaginationActions(
         color="inherit"
         aria-label={getItemAriaLabel('previous', page)}
         title={getItemAriaLabel('previous', page)}
-        {...(previousButtonSlotProps ?? backIconButtonProps)}
+        {...previousButtonSlotProps}
       >
         {isRtl ? (
           <NextButtonIcon {...slotProps.nextButtonIcon} />
@@ -126,7 +124,7 @@ const TablePaginationActions = React.forwardRef(function TablePaginationActions(
         color="inherit"
         aria-label={getItemAriaLabel('next', page)}
         title={getItemAriaLabel('next', page)}
-        {...(nextButtonSlotProps ?? nextIconButtonProps)}
+        {...nextButtonSlotProps}
       >
         {isRtl ? (
           <PreviousButtonIcon {...slotProps.previousButtonIcon} />
@@ -159,11 +157,6 @@ TablePaginationActions.propTypes /* remove-proptypes */ = {
   // │    To update them, edit the d.ts file and run `pnpm proptypes`.     │
   // └─────────────────────────────────────────────────────────────────────┘
   /**
-   * This prop is an alias for `slotProps.previousButton` and will be overridden by it if both are used.
-   * @deprecated Use `slotProps.previousButton` instead.
-   */
-  backIconButtonProps: PropTypes.object,
-  /**
    * @ignore
    */
   children: PropTypes.node,
@@ -193,11 +186,6 @@ TablePaginationActions.propTypes /* remove-proptypes */ = {
    * @returns {string}
    */
   getItemAriaLabel: PropTypes.func.isRequired,
-  /**
-   * This prop is an alias for `slotProps.nextButton` and will be overridden by it if both are used.
-   * @deprecated Use `slotProps.nextButton` instead.
-   */
-  nextIconButtonProps: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.js
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.js
@@ -60,7 +60,7 @@ const TableSortLabelRoot = styled(ButtonBase, {
 const TableSortLabelIcon = styled('span', {
   name: 'MuiTableSortLabel',
   slot: 'Icon',
-  overridesResolver: (props, styles) => [styles.icon],
+  overridesResolver: (props, styles) => styles.icon,
 })(
   memoTheme(({ theme }) => ({
     fontSize: 18,

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.js
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.js
@@ -17,7 +17,7 @@ const useUtilityClasses = (ownerState) => {
 
   const slots = {
     root: ['root', active && 'active', `direction${capitalize(direction)}`],
-    icon: ['icon', `iconDirection${capitalize(direction)}`],
+    icon: ['icon'],
   };
 
   return composeClasses(slots, getTableSortLabelUtilityClass, classes);
@@ -60,11 +60,7 @@ const TableSortLabelRoot = styled(ButtonBase, {
 const TableSortLabelIcon = styled('span', {
   name: 'MuiTableSortLabel',
   slot: 'Icon',
-  overridesResolver: (props, styles) => {
-    const { ownerState } = props;
-
-    return [styles.icon, styles[`iconDirection${capitalize(ownerState.direction)}`]];
-  },
+  overridesResolver: (props, styles) => [styles.icon],
 })(
   memoTheme(({ theme }) => ({
     fontSize: 18,

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.test.js
@@ -47,9 +47,6 @@ describe('<TableSortLabel />', () => {
 
     it('when given direction desc should have desc direction class', () => {
       const { container } = render(<TableSortLabel direction="desc" />);
-      const icon = container.querySelector(`.${classes.icon}`);
-      expect(icon).not.to.have.class(classes.iconDirectionAsc);
-      expect(icon).to.have.class(classes.iconDirectionDesc);
       expect(container.firstChild).to.have.class(classes.directionDesc);
       expect(container.querySelector(`.${classes.directionDesc} > .${classes.icon}`)).not.equal(
         null,
@@ -58,9 +55,6 @@ describe('<TableSortLabel />', () => {
 
     it('when given direction asc should have asc direction class', () => {
       const { container } = render(<TableSortLabel direction="asc" />);
-      const icon = container.querySelector(`.${classes.icon}`);
-      expect(icon).not.to.have.class(classes.iconDirectionDesc);
-      expect(icon).to.have.class(classes.iconDirectionAsc);
       expect(container.firstChild).to.have.class(classes.directionAsc);
       expect(container.querySelector(`.${classes.directionAsc} > .${classes.icon}`)).not.equal(
         null,

--- a/packages/mui-material/src/TableSortLabel/tableSortLabelClasses.ts
+++ b/packages/mui-material/src/TableSortLabel/tableSortLabelClasses.ts
@@ -12,14 +12,6 @@ export interface TableSortLabelClasses {
   active: string;
   /** Styles applied to the icon component. */
   icon: string;
-  /** Styles applied to the icon component if `direction="desc"`.
-   * @deprecated Combine the [.MuiTableSortLabel-icon](/material-ui/api/table-sort-label/#TableSortLabel-css-MuiTableSortLabel-icon) and [.MuiTableSortLabel-directionDesc](/material-ui/api/table-sort-label/#table-sort-label-classes-MuiTableSortLabel-directionDesc) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  iconDirectionDesc: string;
-  /** Styles applied to the icon component if `direction="asc"`.
-   * @deprecated Combine the [.MuiTableSortLabel-icon](/material-ui/api/table-sort-label/#TableSortLabel-css-MuiTableSortLabel-icon) and [.MuiTableSortLabel-directionAsc](/material-ui/api/table-sort-label/#table-sort-label-classes-MuiTableSortLabel-directionAsc) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  iconDirectionAsc: string;
 }
 
 export type TableSortLabelClassKey = keyof TableSortLabelClasses;
@@ -32,8 +24,6 @@ const tableSortLabelClasses: TableSortLabelClasses = generateUtilityClasses('Mui
   'root',
   'active',
   'icon',
-  'iconDirectionDesc',
-  'iconDirectionAsc',
   'directionDesc',
   'directionAsc',
 ]);


### PR DESCRIPTION
## Summary

Remove all deprecated props and classes from TablePagination and TableSortLabel.

## Breaking changes

### TablePagination

- `backIconButtonProps` prop removed — use `slotProps.actions.previousButton` instead
- `nextIconButtonProps` prop removed — use `slotProps.actions.nextButton` instead
- `SelectProps` prop removed — use `slotProps.select` instead

### TableSortLabel

- `iconDirectionDesc` class removed — combine `.MuiTableSortLabel-directionDesc` and `.MuiTableSortLabel-icon` instead
- `iconDirectionAsc` class removed — combine `.MuiTableSortLabel-directionAsc` and `.MuiTableSortLabel-icon` instead

Codemods available:
```bash
npx @mui/codemod@latest deprecations/table-pagination-props <path>
npx @mui/codemod@latest deprecations/table-sort-label-classes <path>
```

Relates to #47987