### PR TITLE
[FilledInput][Input][InputBase][OutlinedInput] Remove deprecated props and classes

### DIFF
--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -1105,6 +1105,117 @@ If you were using these deprecated class names as `styleOverrides` keys in your 
  });
 ```
 
+#### FilledInput deprecated props removed
+
+Use the [filled-input-props codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#filled-input-props) below to migrate the code as described in the following section:
+
+```bash
+npx @mui/codemod@latest deprecations/filled-input-props <path>
+```
+
+The following deprecated `FilledInput` props have been removed:
+
+- `components` — use `slots` instead
+- `componentsProps` — use `slotProps` instead
+
+```diff
+ <FilledInput
+-  components={{ Root: CustomRoot, Input: CustomInput }}
+-  componentsProps={{ root: { className: 'my-root' }, input: { className: 'my-input' } }}
++  slots={{ root: CustomRoot, input: CustomInput }}
++  slotProps={{ root: { className: 'my-root' }, input: { className: 'my-input' } }}
+ />
+```
+
+#### Input deprecated props removed
+
+Use the [input-props codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#input-props) below to migrate the code as described in the following section:
+
+```bash
+npx @mui/codemod@latest deprecations/input-props <path>
+```
+
+The following deprecated `Input` props have been removed:
+
+- `components` — use `slots` instead
+- `componentsProps` — use `slotProps` instead
+
+```diff
+ <Input
+-  components={{ Root: CustomRoot, Input: CustomInput }}
+-  componentsProps={{ root: { className: 'my-root' }, input: { className: 'my-input' } }}
++  slots={{ root: CustomRoot, input: CustomInput }}
++  slotProps={{ root: { className: 'my-root' }, input: { className: 'my-input' } }}
+ />
+```
+
+#### InputBase deprecated props and classes removed
+
+Use the [input-base-props codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#input-base-props) and [input-base-classes codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#input-base-classes) below to migrate the code as described in the following sections:
+
+```bash
+npx @mui/codemod@latest deprecations/input-base-props <path>
+npx @mui/codemod@latest deprecations/input-base-classes <path>
+```
+
+The following deprecated `InputBase` props have been removed:
+
+- `components` — use `slots` instead
+- `componentsProps` — use `slotProps` instead
+
+```diff
+ <InputBase
+-  components={{ Root: CustomRoot, Input: CustomInput }}
+-  componentsProps={{ root: { className: 'my-root' }, input: { className: 'my-input' } }}
++  slots={{ root: CustomRoot, input: CustomInput }}
++  slotProps={{ root: { className: 'my-root' }, input: { className: 'my-input' } }}
+ />
+```
+
+The following deprecated classes have been removed:
+
+- `inputSizeSmall` — combine `.MuiInputBase-input` and `.MuiInputBase-sizeSmall` instead
+- `inputMultiline` — combine `.MuiInputBase-input` and `.MuiInputBase-multiline` instead
+- `inputAdornedStart` — combine `.MuiInputBase-input` and `.MuiInputBase-adornedStart` instead
+- `inputAdornedEnd` — combine `.MuiInputBase-input` and `.MuiInputBase-adornedEnd` instead
+- `inputHiddenLabel` — combine `.MuiInputBase-input` and `.MuiInputBase-hiddenLabel` instead
+
+```diff
+-.MuiInputBase-inputSizeSmall
++.MuiInputBase-sizeSmall > .MuiInputBase-input
+
+-.MuiInputBase-inputMultiline
++.MuiInputBase-multiline > .MuiInputBase-input
+
+-.MuiInputBase-inputAdornedStart
++.MuiInputBase-adornedStart > .MuiInputBase-input
+
+-.MuiInputBase-inputAdornedEnd
++.MuiInputBase-adornedEnd > .MuiInputBase-input
+
+-.MuiInputBase-inputHiddenLabel
++.MuiInputBase-hiddenLabel > .MuiInputBase-input
+```
+
+#### OutlinedInput deprecated props removed
+
+Use the [outlined-input-props codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#outlined-input-props) below to migrate the code as described in the following section:
+
+```bash
+npx @mui/codemod@latest deprecations/outlined-input-props <path>
+```
+
+The following deprecated `OutlinedInput` props have been removed:
+
+- `components` — use `slots` instead
+
+```diff
+ <OutlinedInput
+-  components={{ Root: CustomRoot, Input: CustomInput }}
++  slots={{ root: CustomRoot, input: CustomInput }}
+ />
+```
+
 #### ListItem deprecated props removed
 
 Use the [list-item-props codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#list-item-props) below to migrate the code as described in the following section:

--- a/docs/pages/material-ui/api/filled-input.json
+++ b/docs/pages/material-ui/api/filled-input.json
@@ -9,18 +9,6 @@
         "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
       }
     },
-    "components": {
-      "type": { "name": "shape", "description": "{ Input?: elementType, Root?: elementType }" },
-      "default": "{}",
-      "deprecated": true,
-      "deprecationInfo": "use the <code>slots</code> prop instead. This prop will be removed in a future major release. See <a href=\"https://mui.com/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "componentsProps": {
-      "type": { "name": "shape", "description": "{ input?: object, root?: object }" },
-      "default": "{}",
-      "deprecated": true,
-      "deprecationInfo": "use the <code>slotProps</code> prop instead. This prop will be removed in a future major release. See <a href=\"https://mui.com/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "disableUnderline": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/material-ui/api/input-base.json
+++ b/docs/pages/material-ui/api/input-base.json
@@ -9,18 +9,6 @@
         "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'warning'<br>&#124;&nbsp;string"
       }
     },
-    "components": {
-      "type": { "name": "shape", "description": "{ Input?: elementType, Root?: elementType }" },
-      "default": "{}",
-      "deprecated": true,
-      "deprecationInfo": "use the <code>slots</code> prop instead. This prop will be removed in a future major release. See <a href=\"https://mui.com/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "componentsProps": {
-      "type": { "name": "shape", "description": "{ input?: object, root?: object }" },
-      "default": "{}",
-      "deprecated": true,
-      "deprecationInfo": "use the <code>slotProps</code> prop instead. This prop will be removed in a future major release. See <a href=\"https://mui.com/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "disableInjectingGlobalStyles": { "type": { "name": "bool" }, "default": "false" },
@@ -142,41 +130,6 @@
       "className": "MuiInputBase-input",
       "description": "Styles applied to the input element.",
       "isGlobal": false
-    },
-    {
-      "key": "inputAdornedEnd",
-      "className": "MuiInputBase-inputAdornedEnd",
-      "description": "Styles applied to the input element if `endAdornment` is provided.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "inputAdornedStart",
-      "className": "MuiInputBase-inputAdornedStart",
-      "description": "Styles applied to the input element if `startAdornment` is provided.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "inputHiddenLabel",
-      "className": "MuiInputBase-inputHiddenLabel",
-      "description": "Styles applied to the input element if `hiddenLabel={true}`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "inputMultiline",
-      "className": "MuiInputBase-inputMultiline",
-      "description": "Styles applied to the input element if `multiline={true}`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "inputSizeSmall",
-      "className": "MuiInputBase-inputSizeSmall",
-      "description": "Styles applied to the input element if `size=\"small\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
     },
     {
       "key": "inputTypeSearch",

--- a/docs/pages/material-ui/api/input.json
+++ b/docs/pages/material-ui/api/input.json
@@ -9,18 +9,6 @@
         "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
       }
     },
-    "components": {
-      "type": { "name": "shape", "description": "{ Input?: elementType, Root?: elementType }" },
-      "default": "{}",
-      "deprecated": true,
-      "deprecationInfo": "use the <code>slots</code> prop instead. This prop will be removed in a future major release. See <a href=\"https://mui.com/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "componentsProps": {
-      "type": { "name": "shape", "description": "{ input?: object, root?: object }" },
-      "default": "{}",
-      "deprecated": true,
-      "deprecationInfo": "use the <code>slotProps</code> prop instead. This prop will be removed in a future major release. See <a href=\"https://mui.com/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "disableUnderline": { "type": { "name": "bool" }, "default": "false" },
@@ -110,34 +98,6 @@
       "className": "MuiInput-input",
       "description": "Styles applied to the input element.",
       "isGlobal": false
-    },
-    {
-      "key": "inputAdornedEnd",
-      "className": "MuiInput-inputAdornedEnd",
-      "description": "Styles applied to the input element if `endAdornment` is provided.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "inputAdornedStart",
-      "className": "MuiInput-inputAdornedStart",
-      "description": "Styles applied to the input element if `startAdornment` is provided.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "inputMultiline",
-      "className": "MuiInput-inputMultiline",
-      "description": "Styles applied to the input element if `multiline={true}`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "inputSizeSmall",
-      "className": "MuiInput-inputSizeSmall",
-      "description": "Styles applied to the input element if `size=\"small\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
     },
     {
       "key": "inputTypeSearch",

--- a/docs/pages/material-ui/api/outlined-input.json
+++ b/docs/pages/material-ui/api/outlined-input.json
@@ -9,12 +9,6 @@
         "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;string"
       }
     },
-    "components": {
-      "type": { "name": "shape", "description": "{ Input?: elementType, Root?: elementType }" },
-      "default": "{}",
-      "deprecated": true,
-      "deprecationInfo": "use the <code>slots</code> prop instead. This prop will be removed in a future major release. See <a href=\"https://mui.com/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "endAdornment": { "type": { "name": "node" } },
@@ -114,34 +108,6 @@
       "className": "MuiOutlinedInput-input",
       "description": "Styles applied to the input element.",
       "isGlobal": false
-    },
-    {
-      "key": "inputAdornedEnd",
-      "className": "MuiOutlinedInput-inputAdornedEnd",
-      "description": "Styles applied to the input element if `endAdornment` is provided.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "inputAdornedStart",
-      "className": "MuiOutlinedInput-inputAdornedStart",
-      "description": "Styles applied to the input element if `startAdornment` is provided.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "inputMultiline",
-      "className": "MuiOutlinedInput-inputMultiline",
-      "description": "Styles applied to the input element if `multiline={true}`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "inputSizeSmall",
-      "className": "MuiOutlinedInput-inputSizeSmall",
-      "description": "Styles applied to the input element if `size=\"small\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
     },
     {
       "key": "inputTypeSearch",

--- a/docs/translations/api-docs/filled-input/filled-input.json
+++ b/docs/translations/api-docs/filled-input/filled-input.json
@@ -11,10 +11,6 @@
     "color": {
       "description": "The color of the component. It supports both default and custom theme colors, which can be added as shown in the <a href=\"https://mui.com/material-ui/customization/palette/#custom-colors\">palette customization guide</a>. The prop defaults to the value (<code>&#39;primary&#39;</code>) inherited from the parent FormControl component."
     },
-    "components": { "description": "The components used for each slot inside." },
-    "componentsProps": {
-      "description": "The extra props for the slot components. You can override the existing props or add new ones."
-    },
     "defaultValue": {
       "description": "The default value. Use when the component is not controlled."
     },
@@ -75,11 +71,9 @@
     },
     "rows": { "description": "Number of rows to display when multiline option is set to true." },
     "slotProps": {
-      "description": "The extra props for the slot components. You can override the existing props or add new ones.<br>This prop is an alias for the <code>componentsProps</code> prop, which will be deprecated in the future."
+      "description": "The extra props for the slot components. You can override the existing props or add new ones."
     },
-    "slots": {
-      "description": "The components used for each slot inside.<br>This prop is an alias for the <code>components</code> prop, which will be deprecated in the future."
-    },
+    "slots": { "description": "The components used for each slot inside." },
     "startAdornment": { "description": "Start <code>InputAdornment</code> for this component." },
     "sx": {
       "description": "The system prop that allows defining system overrides as well as additional CSS styles."

--- a/docs/translations/api-docs/input-base/input-base.json
+++ b/docs/translations/api-docs/input-base/input-base.json
@@ -11,10 +11,6 @@
     "color": {
       "description": "The color of the component. It supports both default and custom theme colors, which can be added as shown in the <a href=\"https://mui.com/material-ui/customization/palette/#custom-colors\">palette customization guide</a>. The prop defaults to the value (<code>&#39;primary&#39;</code>) inherited from the parent FormControl component."
     },
-    "components": { "description": "The components used for each slot inside." },
-    "componentsProps": {
-      "description": "The extra props for the slot components. You can override the existing props or add new ones."
-    },
     "defaultValue": {
       "description": "The default value. Use when the component is not controlled."
     },
@@ -80,11 +76,9 @@
     "rows": { "description": "Number of rows to display when multiline option is set to true." },
     "size": { "description": "The size of the component." },
     "slotProps": {
-      "description": "The extra props for the slot components. You can override the existing props or add new ones.<br>This prop is an alias for the <code>componentsProps</code> prop, which will be deprecated in the future."
+      "description": "The extra props for the slot components. You can override the existing props or add new ones."
     },
-    "slots": {
-      "description": "The components used for each slot inside.<br>This prop is an alias for the <code>components</code> prop, which will be deprecated in the future."
-    },
+    "slots": { "description": "The components used for each slot inside." },
     "startAdornment": { "description": "Start <code>InputAdornment</code> for this component." },
     "sx": {
       "description": "The system prop that allows defining system overrides as well as additional CSS styles."
@@ -143,36 +137,6 @@
       "conditions": "<code>hiddenLabel={true}</code>"
     },
     "input": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the input element" },
-    "inputAdornedEnd": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>endAdornment</code> is provided",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-adornedEnd\">.MuiInputBase-adornedEnd</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "inputAdornedStart": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>startAdornment</code> is provided",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-adornedStart\">.MuiInputBase-adornedStart</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "inputHiddenLabel": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>hiddenLabel={true}</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-hiddenLabel\">.MuiInputBase-hiddenLabel</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "inputMultiline": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>multiline={true}</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-multiline\">.MuiInputBase-multiline</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "inputSizeSmall": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>size=\"small\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-sizeSmall\">.MuiInputBase-sizeSmall</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
     "inputTypeSearch": { "description": "" },
     "multiline": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",

--- a/docs/translations/api-docs/input/input.json
+++ b/docs/translations/api-docs/input/input.json
@@ -11,10 +11,6 @@
     "color": {
       "description": "The color of the component. It supports both default and custom theme colors, which can be added as shown in the <a href=\"https://mui.com/material-ui/customization/palette/#custom-colors\">palette customization guide</a>. The prop defaults to the value (<code>&#39;primary&#39;</code>) inherited from the parent FormControl component."
     },
-    "components": { "description": "The components used for each slot inside." },
-    "componentsProps": {
-      "description": "The extra props for the slot components. You can override the existing props or add new ones."
-    },
     "defaultValue": {
       "description": "The default value. Use when the component is not controlled."
     },
@@ -72,11 +68,9 @@
     },
     "rows": { "description": "Number of rows to display when multiline option is set to true." },
     "slotProps": {
-      "description": "The extra props for the slot components. You can override the existing props or add new ones.<br>This prop is an alias for the <code>componentsProps</code> prop, which will be deprecated in the future."
+      "description": "The extra props for the slot components. You can override the existing props or add new ones."
     },
-    "slots": {
-      "description": "The components used for each slot inside.<br>This prop is an alias for the <code>components</code> prop, which will be deprecated in the future."
-    },
+    "slots": { "description": "The components used for each slot inside." },
     "startAdornment": { "description": "Start <code>InputAdornment</code> for this component." },
     "sx": {
       "description": "The system prop that allows defining system overrides as well as additional CSS styles."
@@ -120,30 +114,6 @@
       "conditions": "<code>fullWidth={true}</code>"
     },
     "input": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the input element" },
-    "inputAdornedEnd": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>endAdornment</code> is provided",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-adornedEnd\">.MuiInputBase-adornedEnd</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "inputAdornedStart": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>startAdornment</code> is provided",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-adornedStart\">.MuiInputBase-adornedStart</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "inputMultiline": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>multiline={true}</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-multiline\">.MuiInputBase-multiline</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "inputSizeSmall": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>size=\"small\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-sizeSmall\">.MuiInputBase-sizeSmall</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
     "inputTypeSearch": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the input element",

--- a/docs/translations/api-docs/outlined-input/outlined-input.json
+++ b/docs/translations/api-docs/outlined-input/outlined-input.json
@@ -11,7 +11,6 @@
     "color": {
       "description": "The color of the component. It supports both default and custom theme colors, which can be added as shown in the <a href=\"https://mui.com/material-ui/customization/palette/#custom-colors\">palette customization guide</a>. The prop defaults to the value (<code>&#39;primary&#39;</code>) inherited from the parent FormControl component."
     },
-    "components": { "description": "The components used for each slot inside." },
     "defaultValue": {
       "description": "The default value. Use when the component is not controlled."
     },
@@ -116,30 +115,6 @@
       "conditions": "the component is focused"
     },
     "input": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the input element" },
-    "inputAdornedEnd": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>endAdornment</code> is provided",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-adornedEnd\">.MuiInputBase-adornedEnd</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "inputAdornedStart": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>startAdornment</code> is provided",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-adornedStart\">.MuiInputBase-adornedStart</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "inputMultiline": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>multiline={true}</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-multiline\">.MuiInputBase-multiline</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "inputSizeSmall": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>size=\"small\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-input\">.MuiInputBase-input</a> and <a href=\"/material-ui/api/input-base/#input-base-classes-MuiInputBase-sizeSmall\">.MuiInputBase-sizeSmall</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
     "inputTypeSearch": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the input element",

--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -284,8 +284,6 @@ const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
 
   const {
     disableUnderline = false,
-    components = {},
-    componentsProps: componentsPropsProp,
     fullWidth = false,
     hiddenLabel, // declare here to prevent spreading to DOM
     inputComponent = 'input',
@@ -308,13 +306,12 @@ const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
   const classes = useUtilityClasses(props);
   const filledInputComponentsProps = { root: { ownerState }, input: { ownerState } };
 
-  const componentsProps =
-    (slotProps ?? componentsPropsProp)
-      ? deepmerge(filledInputComponentsProps, slotProps ?? componentsPropsProp)
-      : filledInputComponentsProps;
+  const componentsProps = slotProps
+    ? deepmerge(filledInputComponentsProps, slotProps)
+    : filledInputComponentsProps;
 
-  const RootSlot = slots.root ?? components.Root ?? FilledInputRoot;
-  const InputSlot = slots.input ?? components.Input ?? FilledInputInput;
+  const RootSlot = slots.root ?? FilledInputRoot;
+  const InputSlot = slots.input ?? FilledInputInput;
 
   return (
     <InputBase
@@ -360,29 +357,6 @@ FilledInput.propTypes /* remove-proptypes */ = {
     PropTypes.oneOf(['primary', 'secondary']),
     PropTypes.string,
   ]),
-  /**
-   * The components used for each slot inside.
-   *
-   * @deprecated use the `slots` prop instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](https://mui.com/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   *
-   * @default {}
-   */
-  components: PropTypes.shape({
-    Input: PropTypes.elementType,
-    Root: PropTypes.elementType,
-  }),
-  /**
-   * The extra props for the slot components.
-   * You can override the existing props or add new ones.
-   *
-   * @deprecated use the `slotProps` prop instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](https://mui.com/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   *
-   * @default {}
-   */
-  componentsProps: PropTypes.shape({
-    input: PropTypes.object,
-    root: PropTypes.object,
-  }),
   /**
    * The default value. Use when the component is not controlled.
    */
@@ -489,8 +463,6 @@ FilledInput.propTypes /* remove-proptypes */ = {
    * The extra props for the slot components.
    * You can override the existing props or add new ones.
    *
-   * This prop is an alias for the `componentsProps` prop, which will be deprecated in the future.
-   *
    * @default {}
    */
   slotProps: PropTypes.shape({
@@ -499,8 +471,6 @@ FilledInput.propTypes /* remove-proptypes */ = {
   }),
   /**
    * The components used for each slot inside.
-   *
-   * This prop is an alias for the `components` prop, which will be deprecated in the future.
    *
    * @default {}
    */

--- a/packages/mui-material/src/FilledInput/FilledInput.test.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.test.js
@@ -17,7 +17,7 @@ describe('<FilledInput />', () => {
     testDeepOverrides: { slotName: 'input', slotClassName: classes.input },
     testVariantProps: { variant: 'contained', fullWidth: true },
     testStateOverrides: { prop: 'size', value: 'small', styleKey: 'sizeSmall' },
-    testLegacyComponentsProp: true,
+
     slots: {
       // can't test with DOM element as Input places an ownerState prop on it unconditionally.
       root: { expectedClassName: classes.root, testWithElement: null },
@@ -52,11 +52,6 @@ describe('<FilledInput />', () => {
   it('should forward classes to InputBase', () => {
     render(<FilledInput error classes={{ error: 'error' }} />);
     expect(document.querySelector('.error')).not.to.equal(null);
-  });
-
-  it('should respects the componentsProps if passed', () => {
-    render(<FilledInput componentsProps={{ root: { 'data-test': 'test' } }} />);
-    expect(document.querySelector('[data-test=test]')).not.to.equal(null);
   });
 
   it('should respect the classes coming from InputBase', () => {

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -143,8 +143,6 @@ const Input = React.forwardRef(function Input(inProps, ref) {
   const props = useDefaultProps({ props: inProps, name: 'MuiInput' });
   const {
     disableUnderline = false,
-    components = {},
-    componentsProps: componentsPropsProp,
     fullWidth = false,
     inputComponent = 'input',
     multiline = false,
@@ -159,13 +157,12 @@ const Input = React.forwardRef(function Input(inProps, ref) {
   const ownerState = { disableUnderline };
   const inputComponentsProps = { root: { ownerState } };
 
-  const componentsProps =
-    (slotProps ?? componentsPropsProp)
-      ? deepmerge(slotProps ?? componentsPropsProp, inputComponentsProps)
-      : inputComponentsProps;
+  const componentsProps = slotProps
+    ? deepmerge(slotProps, inputComponentsProps)
+    : inputComponentsProps;
 
-  const RootSlot = slots.root ?? components.Root ?? InputRoot;
-  const InputSlot = slots.input ?? components.Input ?? InputInput;
+  const RootSlot = slots.root ?? InputRoot;
+  const InputSlot = slots.input ?? InputInput;
 
   return (
     <InputBase
@@ -211,29 +208,6 @@ Input.propTypes /* remove-proptypes */ = {
     PropTypes.oneOf(['primary', 'secondary']),
     PropTypes.string,
   ]),
-  /**
-   * The components used for each slot inside.
-   *
-   * @deprecated use the `slots` prop instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](https://mui.com/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   *
-   * @default {}
-   */
-  components: PropTypes.shape({
-    Input: PropTypes.elementType,
-    Root: PropTypes.elementType,
-  }),
-  /**
-   * The extra props for the slot components.
-   * You can override the existing props or add new ones.
-   *
-   * @deprecated use the `slotProps` prop instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](https://mui.com/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   *
-   * @default {}
-   */
-  componentsProps: PropTypes.shape({
-    input: PropTypes.object,
-    root: PropTypes.object,
-  }),
   /**
    * The default value. Use when the component is not controlled.
    */
@@ -333,8 +307,6 @@ Input.propTypes /* remove-proptypes */ = {
    * The extra props for the slot components.
    * You can override the existing props or add new ones.
    *
-   * This prop is an alias for the `componentsProps` prop, which will be deprecated in the future.
-   *
    * @default {}
    */
   slotProps: PropTypes.shape({
@@ -343,8 +315,6 @@ Input.propTypes /* remove-proptypes */ = {
   }),
   /**
    * The components used for each slot inside.
-   *
-   * This prop is an alias for the `components` prop, which will be deprecated in the future.
    *
    * @default {}
    */

--- a/packages/mui-material/src/Input/Input.test.js
+++ b/packages/mui-material/src/Input/Input.test.js
@@ -16,7 +16,7 @@ describe('<Input />', () => {
     testDeepOverrides: { slotName: 'input', slotClassName: classes.input },
     testVariantProps: { variant: 'contained', fullWidth: true },
     testStateOverrides: { prop: 'size', value: 'small', styleKey: 'sizeSmall' },
-    testLegacyComponentsProp: true,
+
     slots: {
       // can't test with DOM element as Input places an ownerState prop on it unconditionally.
       root: { expectedClassName: classes.root, testWithElement: null },
@@ -33,11 +33,6 @@ describe('<Input />', () => {
   it('should forward classes to InputBase', () => {
     render(<Input error classes={{ error: 'error' }} />);
     expect(document.querySelector('.error')).not.to.equal(null);
-  });
-
-  it('should respects the componentsProps if passed', () => {
-    render(<Input componentsProps={{ root: { 'data-test': 'test' } }} />);
-    expect(document.querySelector('[data-test=test]')).not.to.equal(null);
   });
 
   it('should respect the classes coming from InputBase', () => {

--- a/packages/mui-material/src/Input/inputClasses.ts
+++ b/packages/mui-material/src/Input/inputClasses.ts
@@ -25,22 +25,6 @@ export interface InputClasses {
   fullWidth: string;
   /** Styles applied to the input element. */
   input: string;
-  /** Styles applied to the input element if `size="small"`.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-sizeSmall](/material-ui/api/input-base/#input-base-classes-MuiInputBase-sizeSmall) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputSizeSmall: string;
-  /** Styles applied to the input element if `multiline={true}`.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-multiline](/material-ui/api/input-base/#input-base-classes-MuiInputBase-multiline) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputMultiline: string;
-  /** Styles applied to the input element if `startAdornment` is provided.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-adornedStart](/material-ui/api/input-base/#input-base-classes-MuiInputBase-adornedStart) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputAdornedStart: string;
-  /** Styles applied to the input element if `endAdornment` is provided.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-adornedEnd](/material-ui/api/input-base/#input-base-classes-MuiInputBase-adornedEnd) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputAdornedEnd: string;
   /** Styles applied to the input element if `type="search"`. */
   inputTypeSearch: string;
 }

--- a/packages/mui-material/src/InputBase/InputBase.d.ts
+++ b/packages/mui-material/src/InputBase/InputBase.d.ts
@@ -55,37 +55,6 @@ export interface InputBaseProps extends StandardProps<
       >
     | undefined;
   /**
-   * The components used for each slot inside.
-   *
-   * @deprecated use the `slots` prop instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](https://mui.com/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   *
-   * @default {}
-   */
-  components?:
-    | {
-        Root?: React.ElementType | undefined;
-        Input?: React.ElementType | undefined;
-      }
-    | undefined;
-  /**
-   * The extra props for the slot components.
-   * You can override the existing props or add new ones.
-   *
-   * @deprecated use the `slotProps` prop instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](https://mui.com/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   *
-   * @default {}
-   */
-  componentsProps?:
-    | {
-        root?:
-          | (React.HTMLAttributes<HTMLDivElement> & InputBaseComponentsPropsOverrides)
-          | undefined;
-        input?:
-          | (React.InputHTMLAttributes<HTMLInputElement> & InputBaseComponentsPropsOverrides)
-          | undefined;
-      }
-    | undefined;
-  /**
    * The default value. Use when the component is not controlled.
    */
   defaultValue?: unknown;
@@ -213,8 +182,6 @@ export interface InputBaseProps extends StandardProps<
    * The extra props for the slot components.
    * You can override the existing props or add new ones.
    *
-   * This prop is an alias for the `componentsProps` prop, which will be deprecated in the future.
-   *
    * @default {}
    */
   slotProps?:
@@ -231,8 +198,6 @@ export interface InputBaseProps extends StandardProps<
     | undefined;
   /**
    * The components used for each slot inside.
-   *
-   * This prop is an alias for the `components` prop, which will be deprecated in the future.
    *
    * @default {}
    */

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -39,15 +39,7 @@ export const rootOverridesResolver = (props, styles) => {
 export const inputOverridesResolver = (props, styles) => {
   const { ownerState } = props;
 
-  return [
-    styles.input,
-    ownerState.size === 'small' && styles.inputSizeSmall,
-    ownerState.multiline && styles.inputMultiline,
-    ownerState.type === 'search' && styles.inputTypeSearch,
-    ownerState.startAdornment && styles.inputAdornedStart,
-    ownerState.endAdornment && styles.inputAdornedEnd,
-    ownerState.hiddenLabel && styles.inputHiddenLabel,
-  ];
+  return [styles.input, ownerState.type === 'search' && styles.inputTypeSearch];
 };
 
 const useUtilityClasses = (ownerState) => {
@@ -87,11 +79,6 @@ const useUtilityClasses = (ownerState) => {
       'input',
       disabled && 'disabled',
       type === 'search' && 'inputTypeSearch',
-      multiline && 'inputMultiline',
-      size === 'small' && 'inputSizeSmall',
-      hiddenLabel && 'inputHiddenLabel',
-      startAdornment && 'inputAdornedStart',
-      endAdornment && 'inputAdornedEnd',
       readOnly && 'readOnly',
     ],
   };
@@ -273,8 +260,6 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
     autoFocus,
     className,
     color,
-    components = {},
-    componentsProps = {},
     defaultValue,
     disabled,
     disableInjectingGlobalStyles,
@@ -522,11 +507,11 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
-  const Root = slots.root || components.Root || InputBaseRoot;
-  const rootProps = slotProps.root || componentsProps.root || {};
+  const Root = slots.root || InputBaseRoot;
+  const rootProps = slotProps.root || {};
 
-  const Input = slots.input || components.Input || InputBaseInput;
-  inputProps = { ...inputProps, ...(slotProps.input ?? componentsProps.input) };
+  const Input = slots.input || InputBaseInput;
+  inputProps = { ...inputProps, ...slotProps.input };
 
   return (
     <React.Fragment>
@@ -642,29 +627,6 @@ InputBase.propTypes /* remove-proptypes */ = {
     PropTypes.oneOf(['primary', 'secondary', 'error', 'info', 'success', 'warning']),
     PropTypes.string,
   ]),
-  /**
-   * The components used for each slot inside.
-   *
-   * @deprecated use the `slots` prop instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](https://mui.com/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   *
-   * @default {}
-   */
-  components: PropTypes.shape({
-    Input: PropTypes.elementType,
-    Root: PropTypes.elementType,
-  }),
-  /**
-   * The extra props for the slot components.
-   * You can override the existing props or add new ones.
-   *
-   * @deprecated use the `slotProps` prop instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](https://mui.com/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   *
-   * @default {}
-   */
-  componentsProps: PropTypes.shape({
-    input: PropTypes.object,
-    root: PropTypes.object,
-  }),
   /**
    * The default value. Use when the component is not controlled.
    */
@@ -802,8 +764,6 @@ InputBase.propTypes /* remove-proptypes */ = {
    * The extra props for the slot components.
    * You can override the existing props or add new ones.
    *
-   * This prop is an alias for the `componentsProps` prop, which will be deprecated in the future.
-   *
    * @default {}
    */
   slotProps: PropTypes.shape({
@@ -812,8 +772,6 @@ InputBase.propTypes /* remove-proptypes */ = {
   }),
   /**
    * The components used for each slot inside.
-   *
-   * This prop is an alias for the `components` prop, which will be deprecated in the future.
    *
    * @default {}
    */

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -29,7 +29,6 @@ describe('<InputBase />', () => {
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiInputBase',
     testVariantProps: { size: 'small' },
-    testLegacyComponentsProp: true,
     slots: {
       // can't test with DOM element as InputBase places an ownerState prop on it unconditionally.
       root: { expectedClassName: classes.root, testWithElement: null },
@@ -37,6 +36,7 @@ describe('<InputBase />', () => {
     },
     skip: [
       'componentProp',
+      'componentsProp',
       'slotPropsCallback', // not supported yet
       'slotPropsCallbackWithPropsAsOwnerState', // not supported yet
     ],
@@ -355,13 +355,13 @@ describe('<InputBase />', () => {
     });
 
     describe('size', () => {
-      it('should have the inputSizeSmall class in a dense context', () => {
+      it('should have the sizeSmall class on the root in a dense context', () => {
         const { container } = render(
           <FormControl size="small">
             <InputBase />
           </FormControl>,
         );
-        expect(container.querySelector('input')).to.have.class(classes.inputSizeSmall);
+        expect(container.querySelector(`.${classes.root}`)).to.have.class(classes.sizeSmall);
       });
 
       it('should be overridden by props', () => {
@@ -373,20 +373,20 @@ describe('<InputBase />', () => {
           );
         }
         const { container, setProps } = render(<InputBaseInFormWithMargin />);
-        expect(container.querySelector('input')).not.to.have.class(classes.inputSizeSmall);
+        expect(container.querySelector(`.${classes.root}`)).not.to.have.class(classes.sizeSmall);
 
         setProps({ size: 'small' });
-        expect(container.querySelector('input')).to.have.class(classes.inputSizeSmall);
+        expect(container.querySelector(`.${classes.root}`)).to.have.class(classes.sizeSmall);
       });
 
-      it('has an inputHiddenLabel class to further reduce margin', () => {
+      it('has the hiddenLabel class on the root to further reduce margin', () => {
         render(
           <FormControl hiddenLabel margin="dense">
             <InputBase />
           </FormControl>,
         );
 
-        expect(screen.getByRole('textbox')).to.have.class(classes.inputHiddenLabel);
+        expect(screen.getByRole('textbox').parentElement).to.have.class(classes.hiddenLabel);
       });
     });
 

--- a/packages/mui-material/src/InputBase/inputBaseClasses.ts
+++ b/packages/mui-material/src/InputBase/inputBaseClasses.ts
@@ -30,27 +30,7 @@ export interface InputBaseClasses {
   readOnly: string;
   /** Styles applied to the input element. */
   input: string;
-  /** Styles applied to the input element if `size="small"`.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-sizeSmall](/material-ui/api/input-base/#input-base-classes-MuiInputBase-sizeSmall) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputSizeSmall: string;
-  /** Styles applied to the input element if `multiline={true}`.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-multiline](/material-ui/api/input-base/#input-base-classes-MuiInputBase-multiline) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputMultiline: string;
   inputTypeSearch: string;
-  /** Styles applied to the input element if `startAdornment` is provided.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-adornedStart](/material-ui/api/input-base/#input-base-classes-MuiInputBase-adornedStart) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputAdornedStart: string;
-  /** Styles applied to the input element if `endAdornment` is provided.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-adornedEnd](/material-ui/api/input-base/#input-base-classes-MuiInputBase-adornedEnd) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputAdornedEnd: string;
-  /** Styles applied to the input element if `hiddenLabel={true}`.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-hiddenLabel](/material-ui/api/input-base/#input-base-classes-MuiInputBase-hiddenLabel) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputHiddenLabel: string;
 }
 
 export type InputBaseClassKey = keyof InputBaseClasses;
@@ -74,12 +54,7 @@ const inputBaseClasses: InputBaseClasses = generateUtilityClasses('MuiInputBase'
   'hiddenLabel',
   'readOnly',
   'input',
-  'inputSizeSmall',
-  'inputMultiline',
   'inputTypeSearch',
-  'inputAdornedStart',
-  'inputAdornedEnd',
-  'inputHiddenLabel',
 ]);
 
 export default inputBaseClasses;

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -190,7 +190,6 @@ const OutlinedInputInput = styled(InputBaseInput, {
 const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
   const props = useDefaultProps({ props: inProps, name: 'MuiOutlinedInput' });
   const {
-    components = {},
     fullWidth = false,
     inputComponent = 'input',
     label,
@@ -225,8 +224,8 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
     type,
   };
 
-  const RootSlot = slots.root ?? components.Root ?? OutlinedInputRoot;
-  const InputSlot = slots.input ?? components.Input ?? OutlinedInputInput;
+  const RootSlot = slots.root ?? OutlinedInputRoot;
+  const InputSlot = slots.input ?? OutlinedInputInput;
 
   const [NotchedSlot, notchedProps] = useSlot('notchedOutline', {
     elementType: NotchedOutlineRoot,
@@ -307,17 +306,6 @@ OutlinedInput.propTypes /* remove-proptypes */ = {
     PropTypes.oneOf(['primary', 'secondary']),
     PropTypes.string,
   ]),
-  /**
-   * The components used for each slot inside.
-   *
-   * @deprecated use the `slots` prop instead. This prop will be removed in a future major release. See [Migrating from deprecated APIs](https://mui.com/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   *
-   * @default {}
-   */
-  components: PropTypes.shape({
-    Input: PropTypes.elementType,
-    Root: PropTypes.elementType,
-  }),
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
@@ -22,7 +22,7 @@ describe('<OutlinedInput />', () => {
     testDeepOverrides: { slotName: 'input', slotClassName: classes.input },
     testVariantProps: { variant: 'contained', fullWidth: true },
     testStateOverrides: { prop: 'size', value: 'small', styleKey: 'sizeSmall' },
-    testLegacyComponentsProp: ['root', 'input'],
+
     slots: {
       // can't test with DOM element as InputBase places an ownerState prop on it unconditionally.
       root: { expectedClassName: classes.root, testWithElement: null },
@@ -63,11 +63,6 @@ describe('<OutlinedInput />', () => {
   it('should forward classes to InputBase', () => {
     render(<OutlinedInput error classes={{ error: 'error' }} />);
     expect(document.querySelector('.error')).not.to.equal(null);
-  });
-
-  it('should respects the componentsProps if passed', () => {
-    render(<OutlinedInput componentsProps={{ root: { 'data-test': 'test' } }} />);
-    expect(document.querySelector('[data-test=test]')).not.to.equal(null);
   });
 
   it('should respect the classes coming from InputBase', () => {

--- a/packages/mui-material/src/OutlinedInput/outlinedInputClasses.ts
+++ b/packages/mui-material/src/OutlinedInput/outlinedInputClasses.ts
@@ -25,22 +25,6 @@ export interface OutlinedInputClasses {
   notchedOutline: string;
   /** Styles applied to the input element. */
   input: string;
-  /** Styles applied to the input element if `size="small"`.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-sizeSmall](/material-ui/api/input-base/#input-base-classes-MuiInputBase-sizeSmall) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputSizeSmall: string;
-  /** Styles applied to the input element if `multiline={true}`.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-multiline](/material-ui/api/input-base/#input-base-classes-MuiInputBase-multiline) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputMultiline: string;
-  /** Styles applied to the input element if `startAdornment` is provided.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-adornedStart](/material-ui/api/input-base/#input-base-classes-MuiInputBase-adornedStart) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputAdornedStart: string;
-  /** Styles applied to the input element if `endAdornment` is provided.
-   * @deprecated Combine the [.MuiInputBase-input](/material-ui/api/input-base/#input-base-classes-MuiInputBase-input) and [.MuiInputBase-adornedEnd](/material-ui/api/input-base/#input-base-classes-MuiInputBase-adornedEnd) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  inputAdornedEnd: string;
   /** Styles applied to the input element if `type="search"`. */
   inputTypeSearch: string;
 }

--- a/packages/mui-material/src/TextField/TextField.spec.tsx
+++ b/packages/mui-material/src/TextField/TextField.spec.tsx
@@ -22,14 +22,14 @@ import { FormHelperTextProps } from '@mui/material/FormHelperText';
     <TextField
       variant="standard"
       slotProps={{
-        input: { classes: { inputAdornedStart: 'search-input', inputAdornedEnd: 'search-input' } },
+        input: { classes: { adornedStart: 'search-input', adornedEnd: 'search-input' } },
       }}
     />
   );
   const DefaultInputAdorned = (
     <TextField
       slotProps={{
-        input: { classes: { inputAdornedStart: 'search-input', inputAdornedEnd: 'search-input' } },
+        input: { classes: { adornedStart: 'search-input', adornedEnd: 'search-input' } },
       }}
     />
   );
@@ -62,7 +62,7 @@ import { FormHelperTextProps } from '@mui/material/FormHelperText';
   const filled = (
     <TextField
       variant="filled"
-      slotProps={{ input: { classes: { inputAdornedStart: 'adorned-start' } } }}
+      slotProps={{ input: { classes: { adornedStart: 'adorned-start' } } }}
       onChange={(event) => {
         // type inference for event still works?
         const value = event.target.value;

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -92,8 +92,8 @@ describe('<TextField />', () => {
     it('should forward the multiline prop to Input', () => {
       render(<TextField variant="standard" multiline />);
 
-      expect(screen.getByRole('textbox', { hidden: false })).to.have.class(
-        inputBaseClasses.inputMultiline,
+      expect(screen.getByRole('textbox', { hidden: false }).parentElement).to.have.class(
+        inputBaseClasses.multiline,
       );
     });
 


### PR DESCRIPTION
## Summary

Remove deprecated `components`/`componentsProps` props from **InputBase**, **FilledInput**, **Input**, and **OutlinedInput**.

Remove deprecated compound classes from **InputBase** (and inherited by Input, OutlinedInput): `inputSizeSmall`, `inputMultiline`, `inputAdornedStart`, `inputAdornedEnd`, `inputHiddenLabel`.

## Breaking changes

**Props removed:**
- `components` — use `slots` instead
- `componentsProps` — use `slotProps` instead

**Classes removed (InputBase):**
- `inputSizeSmall` — use `.MuiInputBase-sizeSmall > .MuiInputBase-input`
- `inputMultiline` — use `.MuiInputBase-multiline > .MuiInputBase-input`
- `inputAdornedStart` — use `.MuiInputBase-adornedStart > .MuiInputBase-input`
- `inputAdornedEnd` — use `.MuiInputBase-adornedEnd > .MuiInputBase-input`
- `inputHiddenLabel` — use `.MuiInputBase-hiddenLabel > .MuiInputBase-input`

Codemods available: `input-base-props`, `input-base-classes`, `input-props`, `filled-input-props`, `outlined-input-props`

Closes #47987 (partial — InputBase, Input, FilledInput, OutlinedInput)