### PR TITLE
[slider] Remove deprecated CSS classes

### DIFF
--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -1321,23 +1321,23 @@ npx @mui/codemod@latest deprecations/slider-classes <path>
 
 The following deprecated classes have been removed:
 
-- `thumbColorPrimary` — combine the `.MuiSlider-thumb` and `.MuiSlider-colorPrimary` classes instead
-- `thumbColorSecondary` — combine the `.MuiSlider-thumb` and `.MuiSlider-colorSecondary` classes instead
-- `thumbColorError` — combine the `.MuiSlider-thumb` and `.MuiSlider-colorError` classes instead
-- `thumbColorInfo` — combine the `.MuiSlider-thumb` and `.MuiSlider-colorInfo` classes instead
-- `thumbColorSuccess` — combine the `.MuiSlider-thumb` and `.MuiSlider-colorSuccess` classes instead
-- `thumbColorWarning` — combine the `.MuiSlider-thumb` and `.MuiSlider-colorWarning` classes instead
-- `thumbSizeSmall` — combine the `.MuiSlider-thumb` and `.MuiSlider-sizeSmall` classes instead
+- `thumbColorPrimary` — use `.MuiSlider-colorPrimary > .MuiSlider-thumb` instead
+- `thumbColorSecondary` — use `.MuiSlider-colorSecondary > .MuiSlider-thumb` instead
+- `thumbColorError` — use `.MuiSlider-colorError > .MuiSlider-thumb` instead
+- `thumbColorInfo` — use `.MuiSlider-colorInfo > .MuiSlider-thumb` instead
+- `thumbColorSuccess` — use `.MuiSlider-colorSuccess > .MuiSlider-thumb` instead
+- `thumbColorWarning` — use `.MuiSlider-colorWarning > .MuiSlider-thumb` instead
+- `thumbSizeSmall` — use `.MuiSlider-sizeSmall > .MuiSlider-thumb` instead
 
 ```diff
 -.MuiSlider-thumbColorPrimary
-+.MuiSlider-thumb.MuiSlider-colorPrimary
++.MuiSlider-colorPrimary > .MuiSlider-thumb
 
 -.MuiSlider-thumbColorSecondary
-+.MuiSlider-thumb.MuiSlider-colorSecondary
++.MuiSlider-colorSecondary > .MuiSlider-thumb
 
 -.MuiSlider-thumbSizeSmall
-+.MuiSlider-thumb.MuiSlider-sizeSmall
++.MuiSlider-sizeSmall > .MuiSlider-thumb
 ```
 
 #### Snackbar deprecated props removed

--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -1311,6 +1311,35 @@ The following deprecated props have been removed from the `Slider` component:
  />
 ```
 
+#### Slider deprecated classes removed
+
+Use the [slider-classes codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#slider-classes) below to migrate the code as described in the following section:
+
+```bash
+npx @mui/codemod@latest deprecations/slider-classes <path>
+```
+
+The following deprecated classes have been removed:
+
+- `thumbColorPrimary` — combine the `.MuiSlider-thumb` and `.MuiSlider-colorPrimary` classes instead
+- `thumbColorSecondary` — combine the `.MuiSlider-thumb` and `.MuiSlider-colorSecondary` classes instead
+- `thumbColorError` — combine the `.MuiSlider-thumb` and `.MuiSlider-colorError` classes instead
+- `thumbColorInfo` — combine the `.MuiSlider-thumb` and `.MuiSlider-colorInfo` classes instead
+- `thumbColorSuccess` — combine the `.MuiSlider-thumb` and `.MuiSlider-colorSuccess` classes instead
+- `thumbColorWarning` — combine the `.MuiSlider-thumb` and `.MuiSlider-colorWarning` classes instead
+- `thumbSizeSmall` — combine the `.MuiSlider-thumb` and `.MuiSlider-sizeSmall` classes instead
+
+```diff
+-.MuiSlider-thumbColorPrimary
++.MuiSlider-thumb.MuiSlider-colorPrimary
+
+-.MuiSlider-thumbColorSecondary
++.MuiSlider-thumb.MuiSlider-colorSecondary
+
+-.MuiSlider-thumbSizeSmall
++.MuiSlider-thumb.MuiSlider-sizeSmall
+```
+
 #### Snackbar deprecated props removed
 
 Use the [snackbar-props codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#snackbar-props) below to migrate the code as described in the following section:

--- a/docs/pages/material-ui/api/slider.json
+++ b/docs/pages/material-ui/api/slider.json
@@ -251,55 +251,6 @@
       "isGlobal": false
     },
     {
-      "key": "thumbColorError",
-      "className": "MuiSlider-thumbColorError",
-      "description": "Styles applied to the thumb element if `color=\"error\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "thumbColorInfo",
-      "className": "MuiSlider-thumbColorInfo",
-      "description": "Styles applied to the thumb element if `color=\"info\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "thumbColorPrimary",
-      "className": "MuiSlider-thumbColorPrimary",
-      "description": "Styles applied to the thumb element if `color=\"primary\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "thumbColorSecondary",
-      "className": "MuiSlider-thumbColorSecondary",
-      "description": "Styles applied to the thumb element if `color=\"secondary\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "thumbColorSuccess",
-      "className": "MuiSlider-thumbColorSuccess",
-      "description": "Styles applied to the thumb element if `color=\"success\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "thumbColorWarning",
-      "className": "MuiSlider-thumbColorWarning",
-      "description": "Styles applied to the thumb element if `color=\"warning\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
-      "key": "thumbSizeSmall",
-      "className": "MuiSlider-thumbSizeSmall",
-      "description": "Styles applied to the thumb element if `size=\"small\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
       "key": "trackFalse",
       "className": "MuiSlider-trackFalse",
       "description": "Styles applied to the root element if `track={false}`.",

--- a/docs/translations/api-docs/slider/slider.json
+++ b/docs/translations/api-docs/slider/slider.json
@@ -165,48 +165,6 @@
       "nodeName": "the root element",
       "conditions": "<code>size=\"small\"</code>"
     },
-    "thumbColorError": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the thumb element",
-      "conditions": "<code>color=\"error\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/slider/#Slider-css-MuiSlider-thumb\">.MuiSlider-thumb</a> and <a href=\"/material-ui/api/slider/#slider-classes-MuiSlider-colorError\">.MuiSlider-colorError</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "thumbColorInfo": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the thumb element",
-      "conditions": "<code>color=\"info\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/slider/#Slider-css-MuiSlider-thumb\">.MuiSlider-thumb</a> and <a href=\"/material-ui/api/slider/#slider-classes-MuiSlider-colorInfo\">.MuiSlider-colorInfo</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "thumbColorPrimary": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the thumb element",
-      "conditions": "<code>color=\"primary\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/slider/#Slider-css-MuiSlider-thumb\">.MuiSlider-thumb</a> and <a href=\"/material-ui/api/slider/#slider-classes-MuiSlider-colorPrimary\">.MuiSlider-colorPrimary</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "thumbColorSecondary": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the thumb element",
-      "conditions": "<code>color=\"secondary\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/slider/#Slider-css-MuiSlider-thumb\">.MuiSlider-thumb</a> and <a href=\"/material-ui/api/slider/#slider-classes-MuiSlider-colorSecondary\">.MuiSlider-colorSecondary</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "thumbColorSuccess": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the thumb element",
-      "conditions": "<code>color=\"success\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/slider/#Slider-css-MuiSlider-thumb\">.MuiSlider-thumb</a> and <a href=\"/material-ui/api/slider/#slider-classes-MuiSlider-colorSuccess\">.MuiSlider-colorSuccess</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "thumbColorWarning": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the thumb element",
-      "conditions": "<code>color=\"warning\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/slider/#Slider-css-MuiSlider-thumb\">.MuiSlider-thumb</a> and <a href=\"/material-ui/api/slider/#slider-classes-MuiSlider-colorWarning\">.MuiSlider-colorWarning</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
-    "thumbSizeSmall": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the thumb element",
-      "conditions": "<code>size=\"small\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/slider/#Slider-css-MuiSlider-thumb\">.MuiSlider-thumb</a> and <a href=\"/material-ui/api/slider/#slider-classes-MuiSlider-sizeSmall\">.MuiSlider-sizeSmall</a> classes instead. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
-    },
     "trackFalse": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",

--- a/packages/mui-material/src/Slider/Slider.d.ts
+++ b/packages/mui-material/src/Slider/Slider.d.ts
@@ -114,11 +114,6 @@ export type SliderSlotsAndSlotProps = CreateSlotsAndSlotProps<
   }
 >;
 
-/**
- * @deprecated Use `SliderRootSlotPropsOverrides` instead.
- */
-export interface SliderComponentsPropsOverrides {}
-
 export interface SliderOwnerState extends SliderProps {
   dragging: boolean;
   marked: boolean;

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -232,9 +232,7 @@ export const SliderTrack = styled('span', {
 export const SliderThumb = styled('span', {
   name: 'MuiSlider',
   slot: 'Thumb',
-  overridesResolver: (props, styles) => {
-    return [styles.thumb];
-  },
+  overridesResolver: (props, styles) => styles.thumb,
 })(
   memoTheme(({ theme }) => ({
     position: 'absolute',

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -232,7 +232,6 @@ export const SliderTrack = styled('span', {
 export const SliderThumb = styled('span', {
   name: 'MuiSlider',
   slot: 'Thumb',
-  overridesResolver: (props, styles) => styles.thumb,
 })(
   memoTheme(({ theme }) => ({
     position: 'absolute',

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -233,12 +233,7 @@ export const SliderThumb = styled('span', {
   name: 'MuiSlider',
   slot: 'Thumb',
   overridesResolver: (props, styles) => {
-    const { ownerState } = props;
-    return [
-      styles.thumb,
-      styles[`thumbColor${capitalize(ownerState.color)}`],
-      ownerState.size !== 'medium' && styles[`thumbSize${capitalize(ownerState.size)}`],
-    ];
+    return [styles.thumb];
   },
 })(
   memoTheme(({ theme }) => ({
@@ -535,12 +530,7 @@ const useUtilityClasses = (ownerState) => {
     markLabel: ['markLabel'],
     markLabelActive: ['markLabelActive'],
     valueLabel: ['valueLabel'],
-    thumb: [
-      'thumb',
-      disabled && 'disabled',
-      size && `thumbSize${capitalize(size)}`,
-      color && `thumbColor${capitalize(color)}`,
-    ],
+    thumb: ['thumb', disabled && 'disabled'],
     active: ['active'],
     disabled: ['disabled'],
     focusVisible: ['focusVisible'],

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1593,16 +1593,13 @@ describe.skipIf(!supportsTouch())('<Slider />', () => {
       const root = document.querySelector(`.${classes.root}`);
       const thumb = document.querySelector(`.${classes.thumb}`);
       expect(root).not.to.have.class(classes.sizeSmall);
-      expect(thumb).not.to.have.class(classes.thumbSizeSmall);
     });
 
     it('should render small slider', () => {
       render(<Slider size="small" />);
 
       const root = document.querySelector(`.${classes.root}`);
-      const thumb = document.querySelector(`.${classes.thumb}`);
       expect(root).to.have.class(classes.sizeSmall);
-      expect(thumb).to.have.class(classes.thumbSizeSmall);
     });
   });
 

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1593,7 +1593,7 @@ describe.skipIf(!supportsTouch())('<Slider />', () => {
       const root = document.querySelector(`.${classes.root}`);
       const thumb = document.querySelector(`.${classes.thumb}`);
       expect(root).not.to.have.class(classes.sizeSmall);
-      expect(thumb).to.have.class(classes.thumb);
+      expect(thumb).not.to.equal(null);
     });
 
     it('should render small slider', () => {

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1591,14 +1591,18 @@ describe.skipIf(!supportsTouch())('<Slider />', () => {
       render(<Slider />);
 
       const root = document.querySelector(`.${classes.root}`);
+      const thumb = document.querySelector(`.${classes.thumb}`);
       expect(root).not.to.have.class(classes.sizeSmall);
+      expect(thumb).to.have.class(classes.thumb);
     });
 
     it('should render small slider', () => {
       render(<Slider size="small" />);
 
       const root = document.querySelector(`.${classes.root}`);
+      const thumb = document.querySelector(`.${classes.thumb}`);
       expect(root).to.have.class(classes.sizeSmall);
+      expect(thumb).to.have.class(classes.thumb);
     });
   });
 

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1591,7 +1591,6 @@ describe.skipIf(!supportsTouch())('<Slider />', () => {
       render(<Slider />);
 
       const root = document.querySelector(`.${classes.root}`);
-      const thumb = document.querySelector(`.${classes.thumb}`);
       expect(root).not.to.have.class(classes.sizeSmall);
     });
 

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1602,7 +1602,7 @@ describe.skipIf(!supportsTouch())('<Slider />', () => {
       const root = document.querySelector(`.${classes.root}`);
       const thumb = document.querySelector(`.${classes.thumb}`);
       expect(root).to.have.class(classes.sizeSmall);
-      expect(thumb).to.have.class(classes.thumb);
+      expect(thumb).not.to.equal(null);
     });
   });
 

--- a/packages/mui-material/src/Slider/sliderClasses.ts
+++ b/packages/mui-material/src/Slider/sliderClasses.ts
@@ -48,34 +48,6 @@ export interface SliderClasses {
   markLabelActive: string;
   /** Styles applied to the root element if `size="small"`. */
   sizeSmall: string;
-  /** Styles applied to the thumb element if `color="primary"`.
-   * @deprecated Combine the [.MuiSlider-thumb](/material-ui/api/slider/#Slider-css-MuiSlider-thumb) and [.MuiSlider-colorPrimary](/material-ui/api/slider/#slider-classes-MuiSlider-colorPrimary) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  thumbColorPrimary: string;
-  /** Styles applied to the thumb element if `color="secondary"`.
-   * @deprecated Combine the [.MuiSlider-thumb](/material-ui/api/slider/#Slider-css-MuiSlider-thumb) and [.MuiSlider-colorSecondary](/material-ui/api/slider/#slider-classes-MuiSlider-colorSecondary) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  thumbColorSecondary: string;
-  /** Styles applied to the thumb element if `color="error"`.
-   * @deprecated Combine the [.MuiSlider-thumb](/material-ui/api/slider/#Slider-css-MuiSlider-thumb) and [.MuiSlider-colorError](/material-ui/api/slider/#slider-classes-MuiSlider-colorError) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  thumbColorError: string;
-  /** Styles applied to the thumb element if `color="info"`.
-   * @deprecated Combine the [.MuiSlider-thumb](/material-ui/api/slider/#Slider-css-MuiSlider-thumb) and [.MuiSlider-colorInfo](/material-ui/api/slider/#slider-classes-MuiSlider-colorInfo) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  thumbColorInfo: string;
-  /** Styles applied to the thumb element if `color="success"`.
-   * @deprecated Combine the [.MuiSlider-thumb](/material-ui/api/slider/#Slider-css-MuiSlider-thumb) and [.MuiSlider-colorSuccess](/material-ui/api/slider/#slider-classes-MuiSlider-colorSuccess) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  thumbColorSuccess: string;
-  /** Styles applied to the thumb element if `color="warning"`.
-   * @deprecated Combine the [.MuiSlider-thumb](/material-ui/api/slider/#Slider-css-MuiSlider-thumb) and [.MuiSlider-colorWarning](/material-ui/api/slider/#slider-classes-MuiSlider-colorWarning) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  thumbColorWarning: string;
-  /** Styles applied to the thumb element if `size="small"`.
-   * @deprecated Combine the [.MuiSlider-thumb](/material-ui/api/slider/#Slider-css-MuiSlider-thumb) and [.MuiSlider-sizeSmall](/material-ui/api/slider/#slider-classes-MuiSlider-sizeSmall) classes instead. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
-   */
-  thumbSizeSmall: string;
   /** Styles applied to the thumb label element. */
   valueLabel: string;
   /** Styles applied to the thumb label element if it's open. */
@@ -112,16 +84,9 @@ const sliderClasses: SliderClasses = generateUtilityClasses('MuiSlider', [
   'rail',
   'sizeSmall',
   'thumb',
-  'thumbColorPrimary',
-  'thumbColorSecondary',
-  'thumbColorError',
-  'thumbColorSuccess',
-  'thumbColorInfo',
-  'thumbColorWarning',
   'track',
   'trackInverted',
   'trackFalse',
-  'thumbSizeSmall',
   'valueLabel',
   'valueLabelOpen',
   'valueLabelCircle',


### PR DESCRIPTION
## Summary

Removes the following deprecated CSS classes from the Slider component:

- `thumbColorPrimary` — use `.MuiSlider-colorPrimary > .MuiSlider-thumb` instead
- `thumbColorSecondary` — use `.MuiSlider-colorSecondary > .MuiSlider-thumb` instead
- `thumbColorError` — use `.MuiSlider-colorError > .MuiSlider-thumb` instead
- `thumbColorInfo` — use `.MuiSlider-colorInfo > .MuiSlider-thumb` instead
- `thumbColorSuccess` — use `.MuiSlider-colorSuccess > .MuiSlider-thumb` instead
- `thumbColorWarning` — use `.MuiSlider-colorWarning > .MuiSlider-thumb` instead
- `thumbSizeSmall` — use `.MuiSlider-sizeSmall > .MuiSlider-thumb` instead

Also removes the deprecated `SliderComponentsPropsOverrides` interface (use `SliderRootSlotPropsOverrides` instead).

## Breaking change

Users relying on deprecated compound CSS classes should migrate to combining individual classes. A codemod is available:

```bash
npx @mui/codemod@latest deprecations/slider-classes <path>
```