### PR TITLE
[Divider] Remove deprecated CSS classes

### DIFF
--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -1016,6 +1016,17 @@ Use `sx={{ opacity : "0.6" }}` (or any opacity):
  />
 ```
 
+#### Divider deprecated classes removed
+
+The following deprecated class has been removed:
+
+- `withChildrenVertical` — combine the `.MuiDivider-withChildren` and `.MuiDivider-vertical` classes instead
+
+```diff
+-.MuiDivider-withChildrenVertical
++.MuiDivider-withChildren.MuiDivider-vertical
+```
+
 #### ImageListItemBar deprecated CSS classes removed
 
 Use the [image-list-item-bar-classes codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#image-list-item-bar-classes) below to migrate the code as described in the following section:

--- a/docs/pages/material-ui/api/divider.json
+++ b/docs/pages/material-ui/api/divider.json
@@ -98,13 +98,6 @@
       "isGlobal": false
     },
     {
-      "key": "withChildrenVertical",
-      "className": "MuiDivider-withChildrenVertical",
-      "description": "Styles applied to the root element if divider have text and `orientation=\"vertical\"`.",
-      "isGlobal": false,
-      "isDeprecated": true
-    },
-    {
       "key": "wrapper",
       "className": "MuiDivider-wrapper",
       "description": "Styles applied to the span children element if `orientation=\"horizontal\"`.",

--- a/docs/translations/api-docs/divider/divider.json
+++ b/docs/translations/api-docs/divider/divider.json
@@ -64,12 +64,6 @@
       "nodeName": "the root element",
       "conditions": "divider have text"
     },
-    "withChildrenVertical": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "divider have text and <code>orientation=\"vertical\"</code>",
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/divider/#divider-classes-MuiDivider-withChildren\">.MuiDivider-withChildren</a> and <a href=\"/material-ui/api/divider/#divider-classes-MuiDivider-vertical\">.MuiDivider-vertical</a> classes instead."
-    },
     "wrapper": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the span children element",

--- a/packages/mui-material/src/Divider/Divider.js
+++ b/packages/mui-material/src/Divider/Divider.js
@@ -19,7 +19,6 @@ const useUtilityClasses = (ownerState) => {
       orientation === 'vertical' && 'vertical',
       flexItem && 'flexItem',
       children && 'withChildren',
-      children && orientation === 'vertical' && 'withChildrenVertical',
       textAlign === 'right' && orientation !== 'vertical' && 'textAlignRight',
       textAlign === 'left' && orientation !== 'vertical' && 'textAlignLeft',
     ],
@@ -42,7 +41,6 @@ const DividerRoot = styled('div', {
       ownerState.orientation === 'vertical' && styles.vertical,
       ownerState.flexItem && styles.flexItem,
       ownerState.children && styles.withChildren,
-      ownerState.children && ownerState.orientation === 'vertical' && styles.withChildrenVertical,
       ownerState.textAlign === 'right' &&
         ownerState.orientation !== 'vertical' &&
         styles.textAlignRight,

--- a/packages/mui-material/src/Divider/Divider.test.js
+++ b/packages/mui-material/src/Divider/Divider.test.js
@@ -44,7 +44,8 @@ describe('<Divider />', () => {
     describe('prop: orientation', () => {
       it('should set the textVertical class', () => {
         const { container } = render(<Divider orientation="vertical">content</Divider>);
-        expect(container.querySelectorAll(`.${classes.withChildrenVertical}`).length).to.equal(1);
+        expect(container.querySelectorAll(`.${classes.withChildren}`).length).to.equal(1);
+        expect(container.querySelectorAll(`.${classes.vertical}`).length).to.equal(1);
         expect(container.querySelectorAll(`.${classes.wrapperVertical}`).length).to.equal(1);
       });
     });

--- a/packages/mui-material/src/Divider/dividerClasses.ts
+++ b/packages/mui-material/src/Divider/dividerClasses.ts
@@ -18,10 +18,6 @@ export interface DividerClasses {
   flexItem: string;
   /** Styles applied to the root element if divider have text. */
   withChildren: string;
-  /** Styles applied to the root element if divider have text and `orientation="vertical"`.
-   * @deprecated Combine the [.MuiDivider-withChildren](/material-ui/api/divider/#divider-classes-MuiDivider-withChildren) and [.MuiDivider-vertical](/material-ui/api/divider/#divider-classes-MuiDivider-vertical) classes instead.
-   */
-  withChildrenVertical: string;
   /** Styles applied to the root element if `textAlign="right" orientation="horizontal"`. */
   textAlignRight: string;
   /** Styles applied to the root element if `textAlign="left" orientation="horizontal"`. */
@@ -47,7 +43,6 @@ const dividerClasses: DividerClasses = generateUtilityClasses('MuiDivider', [
   'flexItem',
   'vertical',
   'withChildren',
-  'withChildrenVertical',
   'textAlignRight',
   'textAlignLeft',
   'wrapper',


### PR DESCRIPTION
## Summary

Removes the deprecated `withChildrenVertical` CSS class from the Divider component.

Users should combine `.MuiDivider-withChildren` and `.MuiDivider-vertical` classes instead.

## Breaking change

```diff
-.MuiDivider-withChildrenVertical
+.MuiDivider-withChildren.MuiDivider-vertical
```