### PR TITLE
[material-ui][Popper] Fix scroll jump when popperOptions change

### DIFF
--- a/packages/mui-material/src/Popper/BasePopper.tsx
+++ b/packages/mui-material/src/Popper/BasePopper.tsx
@@ -195,7 +195,9 @@ const PopperTooltip = React.forwardRef<HTMLDivElement, PopperTooltipProps>(funct
       popperModifiers = popperModifiers.concat(popperOptions.modifiers);
     }
 
-    const popper = createPopper(resolvedAnchorElement, tooltipRef.current!, {
+    const tooltipNode = tooltipRef.current;
+
+    const popper = createPopper(resolvedAnchorElement, tooltipNode!, {
       placement: rtlPlacement,
       ...popperOptions,
       modifiers: popperModifiers,
@@ -206,6 +208,12 @@ const PopperTooltip = React.forwardRef<HTMLDivElement, PopperTooltipProps>(funct
     return () => {
       popper.destroy();
       handlePopperRefRef.current!(null);
+      if (tooltipNode) {
+        // Restore the fixed positioning to prevent scroll jump before next Popper creation
+        tooltipNode.style.position = 'fixed';
+        tooltipNode.style.top = '0';
+        tooltipNode.style.left = '0';
+      }
     };
   }, [resolvedAnchorElement, disablePortal, modifiers, open, popperOptions, rtlPlacement]);
 

--- a/packages/mui-material/src/Popper/Popper.test.js
+++ b/packages/mui-material/src/Popper/Popper.test.js
@@ -157,6 +157,22 @@ describe('<Popper />', () => {
 
       expect(popperRef.current.state.placement).to.equal('bottom');
     });
+
+    it('should not completely lose position when popperOptions change', () => {
+      const { setProps } = render(<Popper {...defaultProps} placement="top" open />);
+
+      const tooltip = document.querySelector('[role="tooltip"]');
+
+      // Simulate popperOptions reference change
+      setProps({
+        popperOptions: {},
+      });
+
+      // The popper instance might have recreated.
+      // Assert it doesn't revert to static or lose positioning entirely.
+      expect(tooltip.style.position).not.to.equal('');
+      expect(tooltip.style.position).not.to.equal('static');
+    });
   });
 
   describe('prop: keepMounted', () => {


### PR DESCRIPTION
Fixes mui/mui-x#21839

## What
Fixes a bug where providing a dynamic `popperOptions` (e.g., an inline object) to [Popper](cci:7://file:///Users/ayushkumarsingh/Desktop/PROJECTS/OpenSource/material-ui/packages/mui-material/src/Popper:0:0-0:0) or [DatePicker](cci:7://file:///Users/ayushkumarsingh/Desktop/PROJECTS/OpenSource/material-ui/packages/mui-lab/src/DatePicker:0:0-0:0) causes the page to automatically scroll to the bottom when an interior component is auto-focused.

## Why
Issue mui/mui-x#21839 reports that when `popperOptions` is passed to a controlled DatePicker with `views={['month', 'year']}`, selecting a month causes the page to scroll down. 

When `popperOptions` changes its reference (like passing an inline `{}` object on render), [BasePopper.tsx](cci:7://file:///Users/ayushkumarsingh/Desktop/PROJECTS/OpenSource/material-ui/packages/mui-material/src/Popper/BasePopper.tsx:0:0-0:0)’s `useEnhancedEffect` destroys and creates the `popper.js` instance. 

`popper.destroy()` synchronously clears the inline CSS `position`, `top`, and `left` properties applied to the DOM element by `@popperjs/core` before the next instance is created. This temporarily causes the element to revert to `position: static`. Since the Popper is typically mounted in a Portal at the end of the `document.body`, the static element drops to the absolute bottom of the HTML page flow. When the Year view subsequently receives auto-focus, the browser scrolls down to bring the newly-focused element into view, causing the jarring visual jump.

## How
In [packages/mui-material/src/Popper/BasePopper.tsx](cci:7://file:///Users/ayushkumarsingh/Desktop/PROJECTS/OpenSource/material-ui/packages/mui-material/src/Popper/BasePopper.tsx:0:0-0:0), I updated the cleanup phase of the `useEnhancedEffect`. Directly after `popper.destroy()`, we manually restore the original inline `position: fixed` along with `top: 0` and `left: 0`. 
This bridges the small gap right after destruction, ensuring the Portal element remains fixed and detached from regular document flow, completely avoiding bottom-page layouts and subsequent jumping on autofocus.

I also added a simple unit test ensuring `position: static` is not temporarily set.
