### PR TITLE
[material-ui][SwipeableDrawer] preserve paper ref when merging slot props

### DIFF
--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -115,6 +115,49 @@ describe('<SwipeableDrawer />', () => {
   describe('swipe to open', () => {
     const bodyWidth = document.body.offsetWidth;
     const windowHeight = window.innerHeight;
+
+    it('should keep the internal paper ref when an external paper ref is provided', () => {
+      const handleClose = spy();
+      const externalPaperRef = React.createRef();
+
+      render(
+        <SwipeableDrawer
+          anchor="left"
+          onOpen={() => {}}
+          onClose={handleClose}
+          open
+          slotProps={{
+            paper: { component: FakePaper, ref: externalPaperRef },
+          }}
+        >
+          <div data-testid="drawer">SwipeableDrawer</div>
+        </SwipeableDrawer>,
+      );
+
+      const drawer = screen.getByTestId('drawer');
+      const closeTouches = [
+        { pageX: 200, clientY: 0 },
+        { pageX: 180, clientY: 0 },
+        { pageX: 10, clientY: 0 },
+      ];
+
+      fireEvent.touchStart(drawer, {
+        touches: [new Touch({ identifier: 0, target: drawer, ...closeTouches[0] })],
+      });
+      fireEvent.touchMove(drawer, {
+        touches: [new Touch({ identifier: 0, target: drawer, ...closeTouches[1] })],
+      });
+      fireEvent.touchMove(drawer, {
+        touches: [new Touch({ identifier: 0, target: drawer, ...closeTouches[2] })],
+      });
+      fireEvent.touchEnd(drawer, {
+        changedTouches: [new Touch({ identifier: 0, target: drawer, ...closeTouches[2] })],
+      });
+
+      expect(handleClose.callCount).to.equal(1);
+      expect(externalPaperRef.current).not.to.equal(null);
+    });
+
     const tests = [
       {
         anchor: 'left',

--- a/packages/mui-material/src/utils/mergeSlotProps.test.ts
+++ b/packages/mui-material/src/utils/mergeSlotProps.test.ts
@@ -83,6 +83,29 @@ describe('utils/index.js', () => {
       });
     });
 
+    it('merges refs', () => {
+      const defaultRef = React.createRef<HTMLDivElement>();
+      const externalRef = React.createRef<HTMLDivElement>();
+
+      const merged = mergeSlotProps<{ ref?: React.Ref<HTMLDivElement> }>(
+        { ref: externalRef },
+        { ref: defaultRef },
+      );
+
+      expect(merged.ref).to.be.a('function');
+
+      const instance = document.createElement('div');
+      const cleanup = (merged.ref as React.RefCallback<HTMLDivElement>)(instance);
+
+      expect(defaultRef.current).to.equal(instance);
+      expect(externalRef.current).to.equal(instance);
+
+      cleanup?.();
+
+      expect(defaultRef.current).to.equal(null);
+      expect(externalRef.current).to.equal(null);
+    });
+
     it('external slot props is a function', () => {
       expect(
         mergeSlotProps<(ownerState: OwnerState) => OwnerState, OwnerState>(
@@ -109,6 +132,48 @@ describe('utils/index.js', () => {
         className: 'base default external',
         'aria-label': 'foo',
       });
+    });
+
+    it('merges callback refs for slot prop callbacks', () => {
+      let defaultRefValue: HTMLDivElement | null = null;
+      let externalRefValue: HTMLDivElement | null = null;
+
+      const merged = mergeSlotProps<
+        (ownerState: OwnerState) => { ref: React.Ref<HTMLDivElement> },
+        (ownerState: OwnerState) => { ref: React.Ref<HTMLDivElement> }
+      >(
+        () => ({
+          ref: (instance) => {
+            externalRefValue = instance;
+
+            return () => {
+              externalRefValue = null;
+            };
+          },
+        }),
+        () => ({
+          ref: (instance) => {
+            defaultRefValue = instance;
+
+            return () => {
+              defaultRefValue = null;
+            };
+          },
+        }),
+      )({ className: '' });
+
+      expect(merged.ref).to.be.a('function');
+
+      const instance = document.createElement('div');
+      const cleanup = (merged.ref as React.RefCallback<HTMLDivElement>)(instance);
+
+      expect(defaultRefValue).to.equal(instance);
+      expect(externalRefValue).to.equal(instance);
+
+      cleanup?.();
+
+      expect(defaultRefValue).to.equal(null);
+      expect(externalRefValue).to.equal(null);
     });
 
     it('both slot props are functions', () => {

--- a/packages/mui-material/src/utils/mergeSlotProps.ts
+++ b/packages/mui-material/src/utils/mergeSlotProps.ts
@@ -15,6 +15,47 @@ function isEventHandler(key: string, value: unknown) {
   );
 }
 
+function mergeRefs<Instance>(
+  defaultRef: React.Ref<Instance> | undefined,
+  externalRef: React.Ref<Instance> | undefined,
+) {
+  if (defaultRef == null) {
+    return externalRef;
+  }
+
+  if (externalRef == null) {
+    return defaultRef;
+  }
+
+  return (instance: Instance | null) => {
+    const cleanups = [defaultRef, externalRef].map((ref) => {
+      if (ref == null) {
+        return null;
+      }
+
+      if (typeof ref === 'function') {
+        const refCleanup = ref(instance);
+
+        return typeof refCleanup === 'function'
+          ? refCleanup
+          : () => {
+              ref(null);
+            };
+      }
+
+      ref.current = instance;
+
+      return () => {
+        ref.current = null;
+      };
+    });
+
+    return () => {
+      cleanups.forEach((cleanup) => cleanup?.());
+    };
+  };
+}
+
 export default function mergeSlotProps<
   T extends SlotComponentProps<React.ElementType, {}, {}>,
   K = T,
@@ -59,12 +100,14 @@ export default function mergeSlotProps<
         externalSlotPropsValue?.className,
       );
       const handlers = extractHandlers(externalSlotPropsValue, defaultSlotPropsValue);
+      const ref = mergeRefs(defaultSlotPropsValue?.ref, externalSlotPropsValue?.ref);
 
       return {
         ...defaultSlotPropsValue,
         ...externalSlotPropsValue,
         ...handlers,
         ...(!!className && { className }),
+        ...(!!ref && { ref }),
         ...(defaultSlotPropsValue?.style &&
           externalSlotPropsValue?.style && {
             style: { ...defaultSlotPropsValue.style, ...externalSlotPropsValue.style },
@@ -86,11 +129,13 @@ export default function mergeSlotProps<
   const typedDefaultSlotProps = defaultSlotProps as Record<string, any>;
   const handlers = extractHandlers(externalSlotProps, typedDefaultSlotProps);
   const className = clsx(typedDefaultSlotProps?.className, externalSlotProps?.className);
+  const ref = mergeRefs(typedDefaultSlotProps?.ref, externalSlotProps?.ref);
   return {
     ...defaultSlotProps,
     ...externalSlotProps,
     ...handlers,
     ...(!!className && { className }),
+    ...(!!ref && { ref }),
     ...(typedDefaultSlotProps?.style &&
       externalSlotProps?.style && {
         style: { ...typedDefaultSlotProps.style, ...externalSlotProps.style },


### PR DESCRIPTION
## Summary
- preserve both default and external refs when `mergeSlotProps()` merges slot props
- add utility coverage for object refs and callback refs
- add a `SwipeableDrawer` regression test that swipes closed with an external `paper` ref

## Testing
- `pnpm vitest run --config packages/mui-material/vitest.config.mts packages/mui-material/src/utils/mergeSlotProps.test.ts packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js`

Fixes #48009