### PR TITLE
[docs] Clarify how to access the documentation theme in console

### DIFF
--- a/docs/data/material/customization/default-theme/default-theme.md
+++ b/docs/data/material/customization/default-theme/default-theme.md
@@ -5,8 +5,8 @@
 If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createTheme.ts`](https://github.com/mui/material-ui/blob/-/packages/mui-material/src/styles/createTheme.ts),
 and the related imports which `createTheme()` uses.
 
-You can play with the documentation theme object in your browser console,
-as the `theme` variable is exposed on all the documentation pages.
+You can play with the documentation theme object in your browser console on mui.com,
+as `window.theme` is exposed on all the documentation pages.
 
 :::warning
 Please note that **the documentation site is using a custom theme** (the MUI's organization branding).

--- a/packages/mui-docs/src/DocsApp/consoleBanner.ts
+++ b/packages/mui-docs/src/DocsApp/consoleBanner.ts
@@ -20,7 +20,7 @@ export function printConsoleBanner(): void {
 ██║ ╚═╝ ██║ ╚██████╔╝ ██████╗
 ╚═╝     ╚═╝  ╚═════╝  ╚═════╝
 
-Tip: you can access the documentation \`theme\` object directly in the console.
+Tip: you can access the documentation theme object as \`window.theme\` in the console.
 `,
       'font-family:monospace;color:#1976d2;font-size:12px;',
     );


### PR DESCRIPTION
## Summary
- update the default theme viewer docs to refer to `window.theme` instead of `theme`
- make the console banner explicitly mention the docs-site-only `window.theme` global

Fixes #46580