### PR TITLE
[docs][select] Clarify placeholder omission on the API page

### DIFF
--- a/docs/translations/api-docs/select/select.json
+++ b/docs/translations/api-docs/select/select.json
@@ -1,5 +1,5 @@
 {
-  "componentDescription": "",
+  "componentDescription": "The Select component does not support the `placeholder` prop.\n\nTo display a placeholder, use the [placeholder pattern](/material-ui/react-select/#placeholder)\nwith the `displayEmpty` and `renderValue` props.",
   "propDescriptions": {
     "autoWidth": {
       "description": "If <code>true</code>, the width of the popover will automatically be set according to the items inside the menu, otherwise it will be at least the width of the select input."

--- a/packages/mui-material/src/Select/Select.js
+++ b/packages/mui-material/src/Select/Select.js
@@ -43,6 +43,12 @@ const StyledOutlinedInput = styled(OutlinedInput, styledRootConfig)('');
 
 const StyledFilledInput = styled(FilledInput, styledRootConfig)('');
 
+/**
+ * The Select component does not support the `placeholder` prop.
+ *
+ * To display a placeholder, use the [placeholder pattern](/material-ui/react-select/#placeholder)
+ * with the `displayEmpty` and `renderValue` props.
+ */
 const Select = React.forwardRef(function Select(inProps, ref) {
   const props = useDefaultProps({ name: 'MuiSelect', props: inProps });
   const {


### PR DESCRIPTION
## Summary
- add a Select API page note that `placeholder` is not supported
- point readers to the documented placeholder pattern using `displayEmpty` and `renderValue`
- update the generated Select API translation content

## Issue
Closes #44821

## Testing
- Not run (docs build dependencies are not installed in this temporary clone)