### PR TITLE
[docs] Fix incorrect import statement for legacy Outline icons

### DIFF
--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -397,7 +397,7 @@ const DialogDetails = React.memo(function DialogDetails(props) {
             <Markdown
               copyButtonHidden
               onClick={handleClick(2)}
-              code={`import ${selectedIcon.importName}Icon from '@mui/icons-material/${selectedIcon.importName}';`}
+              code={`import ${selectedIcon.importName}Icon from '@mui/icons-material/${getCorrectImportName(selectedIcon.importName)}';`}
               language="js"
             />
           </Tooltip>
@@ -521,6 +521,24 @@ const Input = styled(InputBase)({
 const searchIndex = new FlexSearchIndex({
   tokenize: 'full',
 });
+
+/**
+ * Maps legacy icon names to their correct import names.
+ * Some icons have both "Outline" (legacy) and "Outlined" (correct) variants.
+ * We should use the "Outlined" variant for imports.
+ */
+function getCorrectImportName(importName) {
+  // Map legacy "Outline" suffix to "Outlined" if the icon ends with "Outline"
+  // but not "Outlined" (e.g., "InfoOutline" -> "InfoOutlined")
+  if (
+    importName.endsWith('Outline') &&
+    !importName.endsWith('Outlined') &&
+    `${importName}d` in mui
+  ) {
+    return `${importName}d`;
+  }
+  return importName;
+}
 
 const allIconsMap = {};
 const allIcons = Object.keys(mui)


### PR DESCRIPTION
## Problem

When clicking on icons with legacy 'Outline' suffix (e.g., InfoOutline) in the Material Icons search page, the click-to-copy import statement shows the wrong import path.

For example, for the InfoOutline icon:
- **Current (incorrect):** `import InfoOutlineIcon from '@mui/icons-material/InfoOutline';`
- **Should be:** `import InfoOutlineIcon from '@mui/icons-material/InfoOutlined';`

## Solution

Added a helper function `getCorrectImportName` that maps legacy icon names ending with 'Outline' (but not 'Outlined') to their correct 'Outlined' variants for the import path.

## Affected Icons

This fix applies to all icons that have both legacy 'Outline' and correct 'Outlined' variants, including:
- InfoOutline → InfoOutlined
- ErrorOutline → ErrorOutlined  
- HelpOutline → HelpOutlined
- StarOutline → StarOutlined
- And 20+ other icons

Fixes #47941