### PR TITLE
[grid] Remove 'column' and 'column-reverse' directions

### DIFF
--- a/docs/pages/material-ui/api/grid.json
+++ b/docs/pages/material-ui/api/grid.json
@@ -18,7 +18,7 @@
     "direction": {
       "type": {
         "name": "union",
-        "description": "'column-reverse'<br>&#124;&nbsp;'column'<br>&#124;&nbsp;'row-reverse'<br>&#124;&nbsp;'row'<br>&#124;&nbsp;Array&lt;'column-reverse'<br>&#124;&nbsp;'column'<br>&#124;&nbsp;'row-reverse'<br>&#124;&nbsp;'row'&gt;<br>&#124;&nbsp;object"
+        "description": "'row-reverse'<br>&#124;&nbsp;'row'<br>&#124;&nbsp;Array&lt;'row-reverse'<br>&#124;&nbsp;'row'&gt;<br>&#124;&nbsp;object"
       },
       "default": "'row'"
     },

--- a/packages/mui-material/src/Grid/Grid.tsx
+++ b/packages/mui-material/src/Grid/Grid.tsx
@@ -10,7 +10,7 @@ import useTheme from '../styles/useTheme';
 
 type ResponsiveStyleValue<T> = T | Array<T | null> | { [key in Breakpoint]?: T | null };
 
-export type GridDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
+export type GridDirection = 'row' | 'row-reverse';
 
 export type GridSpacing = number | string;
 
@@ -178,8 +178,8 @@ Grid.propTypes /* remove-proptypes */ = {
    * @default 'row'
    */
   direction: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['column-reverse', 'column', 'row-reverse', 'row']),
-    PropTypes.arrayOf(PropTypes.oneOf(['column-reverse', 'column', 'row-reverse', 'row'])),
+    PropTypes.oneOf(['row-reverse', 'row']),
+    PropTypes.arrayOf(PropTypes.oneOf(['row-reverse', 'row'])),
     PropTypes.object,
   ]),
   /**

--- a/packages/mui-material/src/Grid/gridClasses.ts
+++ b/packages/mui-material/src/Grid/gridClasses.ts
@@ -15,7 +15,7 @@ export function getGridUtilityClass(slot: string): string {
 }
 
 const SPACINGS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
-const DIRECTIONS = ['column-reverse', 'column', 'row-reverse', 'row'] as const;
+const DIRECTIONS = ['row-reverse', 'row'] as const;
 const WRAPS = ['nowrap', 'wrap-reverse', 'wrap'] as const;
 const GRID_SIZES = ['auto', true, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
 

--- a/packages/mui-material/src/PigmentGrid/PigmentGrid.tsx
+++ b/packages/mui-material/src/PigmentGrid/PigmentGrid.tsx
@@ -17,7 +17,7 @@ import { Breakpoint, Theme } from '../styles';
 
 type ResponsiveStyleValue<T> = T | Array<T | null> | { [key in Breakpoint]?: T | null };
 
-export type GridDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
+export type GridDirection = 'row' | 'row-reverse';
 
 export type GridSpacing = number | string;
 
@@ -181,8 +181,8 @@ PigmentGrid.propTypes /* remove-proptypes */ = {
    * @default 'row'
    */
   direction: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['column', 'column-reverse', 'row', 'row-reverse']),
-    PropTypes.arrayOf(PropTypes.oneOf(['column', 'column-reverse', 'row', 'row-reverse'])),
+    PropTypes.oneOf(['row', 'row-reverse']),
+    PropTypes.arrayOf(PropTypes.oneOf(['row', 'row-reverse'])),
     PropTypes.object,
   ]),
   /**

--- a/packages/mui-system/src/Grid/Grid.tsx
+++ b/packages/mui-system/src/Grid/Grid.tsx
@@ -53,8 +53,8 @@ Grid.propTypes /* remove-proptypes */ = {
    * @default 'row'
    */
   direction: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['column-reverse', 'column', 'row-reverse', 'row']),
-    PropTypes.arrayOf(PropTypes.oneOf(['column-reverse', 'column', 'row-reverse', 'row'])),
+    PropTypes.oneOf(['row-reverse', 'row']),
+    PropTypes.arrayOf(PropTypes.oneOf(['row-reverse', 'row'])),
     PropTypes.object,
   ]),
   /**

--- a/packages/mui-system/src/Grid/GridProps.ts
+++ b/packages/mui-system/src/Grid/GridProps.ts
@@ -5,7 +5,7 @@ import { Theme, Breakpoint } from '../createTheme';
 
 type ResponsiveStyleValue<T> = T | Array<T | null> | { [key in Breakpoint]?: T | null };
 
-export type GridDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
+export type GridDirection = 'row' | 'row-reverse';
 
 export type GridSpacing = number | string;
 

--- a/packages/mui-system/src/Grid/createGrid.tsx
+++ b/packages/mui-system/src/Grid/createGrid.tsx
@@ -206,8 +206,8 @@ export default function createGrid(
     component: PropTypes.elementType,
     container: PropTypes.bool,
     direction: PropTypes.oneOfType([
-      PropTypes.oneOf(['column-reverse', 'column', 'row-reverse', 'row']),
-      PropTypes.arrayOf(PropTypes.oneOf(['column-reverse', 'column', 'row-reverse', 'row'])),
+      PropTypes.oneOf(['row-reverse', 'row']),
+      PropTypes.arrayOf(PropTypes.oneOf(['row-reverse', 'row'])),
       PropTypes.object,
     ]),
     offset: PropTypes.oneOfType([

--- a/packages/mui-system/src/Grid/gridClasses.ts
+++ b/packages/mui-system/src/Grid/gridClasses.ts
@@ -25,7 +25,7 @@ export function getGridUtilityClass(slot: string): string {
 }
 
 const SPACINGS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
-const DIRECTIONS = ['column-reverse', 'column', 'row-reverse', 'row'] as const;
+const DIRECTIONS = ['row-reverse', 'row'] as const;
 const WRAPS = ['nowrap', 'wrap-reverse', 'wrap'] as const;
 const GRID_SIZES = ['auto', 'grow', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/47563.

We should remove the 'column' and 'column-reverse' from the Grid docs.
