### PR TITLE
[InputBase] Fix text cutoff in High Contrast mode

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -187,6 +187,11 @@ export const InputBaseInput = styled('input', {
         // Remove the padding when type=search.
         WebkitAppearance: 'none',
       },
+      // Fix text cutoff in High Contrast mode
+      '@media (forced-colors: active)': {
+        height: 'auto',
+        minHeight: '1.4375em',
+      },
       // Show and hide the placeholder logic
       [`label[data-shrink=false] + .${inputBaseClasses.formControl} &`]: {
         '&::-webkit-input-placeholder': placeholderHidden,


### PR DESCRIPTION
## Summary

This PR fixes the text cutoff issue in TextField with variant="standard" when High Contrast mode is enabled (Windows accessibility feature).

## Problem

In High Contrast mode, the text in Standard variant TextField gets cut off because the input has a fixed height of `1.4375em`. In forced-colors mode, text metrics can differ slightly, causing the content to overflow.

## Solution

Add a `@media (forced-colors: active)` media query to set `height: auto` with `minHeight: 1.4375em` instead of a fixed height. This ensures the input can grow if needed in High Contrast mode while maintaining the minimum expected height.

## Changes

- Added forced-colors media query in InputBaseInput styles

## Issue

Fixes #47967

## Testing

- Verified the fix works in browser DevTools by enabling "Emulate CSS forced-colors: active"