### PR TITLE
[test] Remove `componentsProp` from `describeConformance` tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@mui/internal-docs-utils": "workspace:^",
     "@mui/internal-netlify-cache": "0.0.3-canary.2",
     "@mui/internal-scripts": "workspace:^",
-    "@mui/internal-test-utils": "2.0.18-canary.16",
+    "@mui/internal-test-utils": "2.0.18-canary.17",
     "@mui/material": "workspace:^",
     "@mui/utils": "workspace:^",
     "@next/eslint-plugin-next": "15.5.14",

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -27,7 +27,7 @@ describe('<Masonry />', () => {
       refInstanceof: window.HTMLDivElement,
       testComponentPropWith: 'span',
       muiName: 'MuiMasonry',
-      skip: ['componentsProp', 'themeVariants'],
+      skip: ['themeVariants'],
     }),
   );
 

--- a/packages/mui-lab/src/TabList/TabList.test.js
+++ b/packages/mui-lab/src/TabList/TabList.test.js
@@ -18,13 +18,7 @@ describe('<TabList />', () => {
      */
     render: (node) => render(<TabContext value="0">{node}</TabContext>),
     refInstanceof: window.HTMLDivElement,
-    skip: [
-      'componentsProp',
-      'themeDefaultProps',
-      'themeStyleOverrides',
-      'themeVariants',
-      'rootClass',
-    ],
+    skip: ['themeDefaultProps', 'themeStyleOverrides', 'themeVariants', 'rootClass'],
   }));
 
   // outside of TabContext pass every test in Tabs

--- a/packages/mui-lab/src/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-lab/src/TabPanel/TabPanel.test.tsx
@@ -13,7 +13,7 @@ describe('<TabPanel />', () => {
     render: (node) => render(<TabContext value="0">{node}</TabContext>),
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiTabPanel',
-    skip: ['componentProp', 'componentsProp', 'themeDefaultProps', 'themeVariants'],
+    skip: ['componentProp', 'themeDefaultProps', 'themeVariants'],
   }));
 
   it('renders a [role="tabpanel"] and mounts children', () => {

--- a/packages/mui-lab/src/Timeline/Timeline.test.tsx
+++ b/packages/mui-lab/src/Timeline/Timeline.test.tsx
@@ -14,7 +14,7 @@ describe('<Timeline />', () => {
     refInstanceof: window.HTMLUListElement,
     testVariantProps: { position: 'left' },
     testStateOverrides: { prop: 'position', value: 'left', styleKey: 'positionLeft' },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('should have correct classname', () => {

--- a/packages/mui-lab/src/TimelineConnector/TimelineConnector.test.js
+++ b/packages/mui-lab/src/TimelineConnector/TimelineConnector.test.js
@@ -11,6 +11,6 @@ describe('<TimelineConnector />', () => {
     render,
     muiName: 'MuiTimelineConnector',
     refInstanceof: window.HTMLSpanElement,
-    skip: ['componentProp', 'componentsProp', 'themeVariants'],
+    skip: ['componentProp', 'themeVariants'],
   }));
 });

--- a/packages/mui-lab/src/TimelineContent/TimelineContent.test.js
+++ b/packages/mui-lab/src/TimelineContent/TimelineContent.test.js
@@ -15,7 +15,7 @@ describe('<TimelineContent />', () => {
     render,
     muiName: 'MuiTimelineContent',
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp', 'componentsProp', 'themeVariants'],
+    skip: ['componentProp', 'themeVariants'],
   }));
 
   it('should have positionLeft class when inside of a left-positioned timeline', () => {

--- a/packages/mui-lab/src/TimelineDot/TimelineDot.test.js
+++ b/packages/mui-lab/src/TimelineDot/TimelineDot.test.js
@@ -14,7 +14,7 @@ describe('<TimelineDot />', () => {
     muiName: 'MuiTimelineDot',
     refInstanceof: window.HTMLSpanElement,
     testVariantProps: { color: 'secondary', variant: 'outlined' },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('should render with color inherit', () => {

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
@@ -11,6 +11,6 @@ describe('<TimelineItem />', () => {
     render,
     muiName: 'MuiTimelineItem',
     refInstanceof: window.HTMLLIElement,
-    skip: ['componentProp', 'componentsProp', 'themeVariants'],
+    skip: ['componentProp', 'themeVariants'],
   }));
 });

--- a/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
+++ b/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
@@ -17,7 +17,7 @@ describe('<TimelineOppositeContent />', () => {
     render,
     muiName: 'MuiTimelineOppositeContent',
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp', 'componentsProp', 'themeVariants'],
+    skip: ['componentProp', 'themeVariants'],
   }));
 
   it('should have positionLeft class when inside of a left-positioned timeline', () => {

--- a/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.test.js
+++ b/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.test.js
@@ -11,6 +11,6 @@ describe('<TimelineSeparator />', () => {
     render,
     muiName: 'MuiTimelineSeparator',
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp', 'componentsProp', 'themeVariants'],
+    skip: ['componentProp', 'themeVariants'],
   }));
 });

--- a/packages/mui-material/src/Accordion/Accordion.test.js
+++ b/packages/mui-material/src/Accordion/Accordion.test.js
@@ -53,7 +53,6 @@ describe('<Accordion />', () => {
         testWithElement: 'div',
       },
     },
-    skip: ['componentProp', 'componentsProp'],
   }));
 
   it('should render and not be controlled', () => {

--- a/packages/mui-material/src/AccordionActions/AccordionActions.test.js
+++ b/packages/mui-material/src/AccordionActions/AccordionActions.test.js
@@ -16,7 +16,7 @@ describe('<AccordionActions />', () => {
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiAccordionActions',
     testVariantProps: { disableSpacing: true },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it.skipIf(isJsdom())('should apply margin to all children but the first one', function test() {

--- a/packages/mui-material/src/AccordionDetails/AccordionDetails.test.js
+++ b/packages/mui-material/src/AccordionDetails/AccordionDetails.test.js
@@ -14,7 +14,7 @@ describe('<AccordionDetails />', () => {
     render,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiAccordionDetails',
-    skip: ['componentProp', 'componentsProp', 'themeVariants'],
+    skip: ['componentProp', 'themeVariants'],
   }));
 
   it('should render a children element', () => {

--- a/packages/mui-material/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/mui-material/src/AccordionSummary/AccordionSummary.test.js
@@ -24,7 +24,6 @@ describe('<AccordionSummary />', () => {
     muiName: 'MuiAccordionSummary',
     testVariantProps: { disabled: true },
     testDeepOverrides: { slotName: 'content', slotClassName: classes.content },
-    skip: ['componentProp', 'componentsProp'],
     slots: {
       root: {
         expectedClassName: classes.root,

--- a/packages/mui-material/src/Alert/Alert.test.js
+++ b/packages/mui-material/src/Alert/Alert.test.js
@@ -40,7 +40,6 @@ describe('<Alert />', () => {
         expectedClassName: classes.closeIcon,
       },
     },
-    skip: ['componentsProp'],
   }));
 
   describe('prop: square', () => {

--- a/packages/mui-material/src/AlertTitle/AlertTitle.test.js
+++ b/packages/mui-material/src/AlertTitle/AlertTitle.test.js
@@ -13,6 +13,6 @@ describe('<AlertTitle />', () => {
     muiName: 'MuiAlertTitle',
     refInstanceof: window.HTMLDivElement,
     testStateOverrides: { styleKey: 'root' },
-    skip: ['componentsProp', 'themeVariants', 'themeDefaultProps'],
+    skip: ['themeVariants', 'themeDefaultProps'],
   }));
 });

--- a/packages/mui-material/src/AppBar/AppBar.test.js
+++ b/packages/mui-material/src/AppBar/AppBar.test.js
@@ -17,7 +17,6 @@ describe('<AppBar />', () => {
     refInstanceof: window.HTMLElement,
     testVariantProps: { position: 'relative' },
     testStateOverrides: { prop: 'color', value: 'secondary', styleKey: 'colorSecondary' },
-    skip: ['componentsProp'],
   }));
 
   it('should render with the root class and primary', () => {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -63,7 +63,7 @@ describe('<Autocomplete />', () => {
         paper: { expectedClassName: classes.paper },
         popper: { expectedClassName: classes.popper, testWithElement: null },
       },
-      skip: ['componentProp', 'componentsProp'],
+      skip: ['componentProp'],
     }),
   );
 

--- a/packages/mui-material/src/Avatar/Avatar.test.js
+++ b/packages/mui-material/src/Avatar/Avatar.test.js
@@ -27,7 +27,6 @@ describe('<Avatar />', () => {
         expectedClassName: classes.fallback,
       },
     },
-    skip: ['componentsProp'],
   }));
 
   // img slot only renders when src is provided

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.test.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.test.js
@@ -23,7 +23,6 @@ describe('<AvatarGroup />', () => {
       slots: {
         surplus: { expectedClassName: classes.avatar },
       },
-      skip: ['componentsProp'],
     }),
   );
 

--- a/packages/mui-material/src/Backdrop/Backdrop.test.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.test.js
@@ -23,7 +23,6 @@ describe('<Backdrop />', () => {
         testWithElement: null,
       },
     },
-    skip: ['componentsProp'],
   }));
 
   it('should render a backdrop div with content of nested children', () => {

--- a/packages/mui-material/src/Badge/Badge.test.js
+++ b/packages/mui-material/src/Badge/Badge.test.js
@@ -43,7 +43,6 @@ describe('<Badge />', () => {
           expectedClassName: classes.badge,
         },
       },
-      skip: ['componentsProp'],
     }),
   );
 

--- a/packages/mui-material/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/mui-material/src/BottomNavigation/BottomNavigation.test.js
@@ -27,7 +27,7 @@ describe('<BottomNavigation />', () => {
       muiName: 'MuiBottomNavigation',
       refInstanceof: window.HTMLDivElement,
       testComponentPropWith: 'span',
-      skip: ['componentsProp', 'themeVariants'],
+      skip: ['themeVariants'],
     }),
   );
 

--- a/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -23,7 +23,7 @@ describe('<BottomNavigationAction />', () => {
     refInstanceof: window.HTMLButtonElement,
     testVariantProps: { showLabel: true },
     testDeepOverrides: { slotName: 'label', slotClassName: classes.label },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
     slots: {
       root: {
         expectedClassName: classes.root,

--- a/packages/mui-material/src/Box/Box.test.js
+++ b/packages/mui-material/src/Box/Box.test.js
@@ -13,14 +13,7 @@ describe('<Box />', () => {
   describeConformance(<Box />, () => ({
     render,
     inheritComponent: 'div',
-    skip: [
-      'componentProp',
-      'componentsProp',
-      'rootClass',
-      'themeVariants',
-      'themeStyleOverrides',
-      'themeDefaultProps',
-    ],
+    skip: ['rootClass', 'themeVariants', 'themeStyleOverrides', 'themeDefaultProps'],
     refInstanceof: window.HTMLDivElement,
   }));
 

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.test.js
@@ -21,7 +21,6 @@ describe('<Breadcrumbs />', () => {
     refInstanceof: window.HTMLElement,
     testComponentPropWith: 'div',
     testVariantProps: { separator: '=' },
-    skip: ['componentsProp'],
   }));
 
   it('should render inaccessible separators between each listitem', () => {

--- a/packages/mui-material/src/Button/Button.test.js
+++ b/packages/mui-material/src/Button/Button.test.js
@@ -51,7 +51,6 @@ describe('<Button />', () => {
     testDeepOverrides: { slotName: 'startIcon', slotClassName: classes.startIcon },
     testVariantProps: { variant: 'contained', fullWidth: true },
     testStateOverrides: { prop: 'size', value: 'small', styleKey: 'sizeSmall' },
-    skip: ['componentsProp'],
   }));
 
   it('should render with the root, text, and colorPrimary classes but no others', () => {

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -45,7 +45,6 @@ describe('<ButtonBase />', () => {
     testComponentPropWith: 'a',
     muiName: 'MuiButtonBase',
     testVariantProps: { disabled: true },
-    skip: ['componentsProp'],
   }));
 
   describe('root node', () => {

--- a/packages/mui-material/src/ButtonBase/TouchRipple.test.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.test.js
@@ -48,13 +48,7 @@ describe('<TouchRipple />', () => {
     render,
     refInstanceof: Object,
     muiName: 'MuiTouchRipple',
-    skip: [
-      'componentProp',
-      'componentsProp',
-      'refForwarding',
-      'themeStyleOverrides',
-      'themeVariants',
-    ],
+    skip: ['componentProp', 'refForwarding', 'themeStyleOverrides', 'themeVariants'],
   }));
 
   describe('prop: center', () => {

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
@@ -22,7 +22,6 @@ describe('<ButtonGroup />', () => {
       testComponentPropWith: 'span',
       muiName: 'MuiButtonGroup',
       testVariantProps: { variant: 'contained' },
-      skip: ['componentsProp'],
     }),
   );
 

--- a/packages/mui-material/src/Card/Card.test.tsx
+++ b/packages/mui-material/src/Card/Card.test.tsx
@@ -14,7 +14,6 @@ describe('<Card />', () => {
     muiName: 'MuiCard',
     refInstanceof: window.HTMLDivElement,
     testVariantProps: { raised: true },
-    skip: ['componentsProp'],
   }));
 
   it('when raised should render Paper with 8dp', () => {

--- a/packages/mui-material/src/CardActionArea/CardActionArea.test.js
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.test.js
@@ -20,7 +20,6 @@ describe('<CardActionArea />', () => {
     testDeepOverrides: { slotName: 'focusHighlight', slotClassName: classes.focusHighlight },
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLButtonElement,
-    skip: ['componentProp', 'componentsProp'],
     slots: {
       root: {
         expectedClassName: classes.root,

--- a/packages/mui-material/src/CardActions/CardActions.test.js
+++ b/packages/mui-material/src/CardActions/CardActions.test.js
@@ -14,7 +14,7 @@ describe('<CardActions />', () => {
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiCardActions',
     testVariantProps: { disableSpacing: true },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it.skipIf(isJsdom())('should apply margin to all children but the first one', function test() {

--- a/packages/mui-material/src/CardContent/CardContent.test.js
+++ b/packages/mui-material/src/CardContent/CardContent.test.js
@@ -11,7 +11,7 @@ describe('<CardContent />', () => {
     render,
     muiName: 'MuiCardContent',
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentsProp', 'themeVariants'],
+    skip: ['themeVariants'],
     testComponentPropWith: 'span',
   }));
 });

--- a/packages/mui-material/src/CardHeader/CardHeader.test.js
+++ b/packages/mui-material/src/CardHeader/CardHeader.test.js
@@ -41,7 +41,6 @@ describe('<CardHeader />', () => {
           expectedClassName: classes.subheader,
         },
       },
-      skip: ['componentsProp'],
     }),
   );
 

--- a/packages/mui-material/src/CardMedia/CardMedia.test.js
+++ b/packages/mui-material/src/CardMedia/CardMedia.test.js
@@ -16,7 +16,6 @@ describe('<CardMedia />', () => {
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
     testVariantProps: { variant: 'foo' },
-    skip: ['componentsProp'],
   }));
 
   it('has the img role if `image` is defined', () => {

--- a/packages/mui-material/src/Checkbox/Checkbox.test.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.test.js
@@ -33,7 +33,7 @@ describe('<Checkbox />', () => {
         expectedClassName: classes.input,
       },
     },
-    skip: ['componentProp', 'componentsProp', 'rootClass'],
+    skip: ['componentProp', 'rootClass'],
   }));
 
   it('should have the classes required for Checkbox', () => {

--- a/packages/mui-material/src/Chip/Chip.test.js
+++ b/packages/mui-material/src/Chip/Chip.test.js
@@ -31,7 +31,6 @@ describe('<Chip />', () => {
     testStatOverrides: { prop: 'size', value: 'small', styleKey: 'sizeSmall' },
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
-    skip: ['componentsProp'],
     slots: {
       root: {
         expectedClassName: classes.root,

--- a/packages/mui-material/src/CircularProgress/CircularProgress.test.js
+++ b/packages/mui-material/src/CircularProgress/CircularProgress.test.js
@@ -16,7 +16,7 @@ describe('<CircularProgress />', () => {
     testDeepOverrides: { slotName: 'circle', slotClassName: classes.circle },
     testVariantProps: { variant: 'determinate' },
     refInstanceof: window.HTMLSpanElement,
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('should render with the primary color by default', () => {

--- a/packages/mui-material/src/Collapse/Collapse.test.js
+++ b/packages/mui-material/src/Collapse/Collapse.test.js
@@ -41,7 +41,6 @@ describe('<Collapse />', () => {
         testWithElement: CustomWrapperInner,
       },
     },
-    skip: ['componentsProp'],
   }));
 
   it('should render a container around the wrapper', () => {

--- a/packages/mui-material/src/Container/Container.test.js
+++ b/packages/mui-material/src/Container/Container.test.js
@@ -16,7 +16,6 @@ describe('<Container />', () => {
     render,
     refInstanceof: window.HTMLElement,
     muiName: 'MuiContainer',
-    skip: ['componentsProp'],
     testVariantProps: { fixed: true },
   }));
 

--- a/packages/mui-material/src/Dialog/Dialog.test.js
+++ b/packages/mui-material/src/Dialog/Dialog.test.js
@@ -74,7 +74,7 @@ describe('<Dialog />', () => {
           testWithElement: null,
         },
       },
-      skip: ['componentProp', 'componentsProp', 'themeVariants'],
+      skip: ['componentProp', 'themeVariants'],
     }),
   );
 

--- a/packages/mui-material/src/DialogActions/DialogActions.test.js
+++ b/packages/mui-material/src/DialogActions/DialogActions.test.js
@@ -14,7 +14,7 @@ describe('<DialogActions />', () => {
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiDialogActions',
     testVariantProps: { disableSpacing: true },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it.skipIf(isJsdom())('should apply margin to all children but the first one', function test() {

--- a/packages/mui-material/src/DialogContent/DialogContent.test.js
+++ b/packages/mui-material/src/DialogContent/DialogContent.test.js
@@ -12,7 +12,7 @@ describe('<DialogContent />', () => {
     muiName: 'MuiDialogContent',
     refInstanceof: window.HTMLDivElement,
     testVariantProps: { dividers: true },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('should render children', () => {

--- a/packages/mui-material/src/DialogContentText/DialogContentText.test.js
+++ b/packages/mui-material/src/DialogContentText/DialogContentText.test.js
@@ -14,7 +14,7 @@ describe('<DialogContentText />', () => {
     render,
     muiName: 'MuiDialogContentText',
     refInstanceof: window.HTMLParagraphElement,
-    skip: ['componentsProp', 'themeVariants'],
+    skip: ['themeVariants'],
   }));
 
   describe('prop: children', () => {

--- a/packages/mui-material/src/DialogTitle/DialogTitle.test.js
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.test.js
@@ -15,7 +15,6 @@ describe('<DialogTitle />', () => {
     muiName: 'MuiDialogTitle',
     refInstanceof: window.HTMLHeadingElement,
     testVariantProps: { 'data-color': 'red' },
-    skip: ['componentProp', 'componentsProp'],
   }));
 
   it('should render JSX children', () => {

--- a/packages/mui-material/src/Divider/Divider.test.js
+++ b/packages/mui-material/src/Divider/Divider.test.js
@@ -15,7 +15,6 @@ describe('<Divider />', () => {
     refInstanceof: window.HTMLHRElement,
     testComponentPropWith: 'div',
     testVariantProps: { orientation: 'vertical', flexItem: true, textAlign: 'left' },
-    skip: ['componentsProp'],
   }));
 
   it('should set the absolute class', () => {

--- a/packages/mui-material/src/Drawer/Drawer.test.js
+++ b/packages/mui-material/src/Drawer/Drawer.test.js
@@ -58,7 +58,7 @@ describe('<Drawer />', () => {
           testWithElement: CustomTransition,
         },
       },
-      skip: ['componentProp', 'componentsProp', 'themeVariants'],
+      skip: ['componentProp', 'themeVariants'],
     }),
   );
 
@@ -79,7 +79,7 @@ describe('<Drawer />', () => {
           expectedClassName: classes.docked,
         },
       },
-      skip: ['componentProp', 'componentsProp'],
+      skip: ['componentProp'],
     }),
   );
 

--- a/packages/mui-material/src/Fab/Fab.test.js
+++ b/packages/mui-material/src/Fab/Fab.test.js
@@ -18,7 +18,6 @@ describe('<Fab />', () => {
     testVariantProps: { variant: 'extended' },
     testStateOverrides: { prop: 'size', value: 'small', styleKey: 'sizeSmall' },
     refInstanceof: window.HTMLButtonElement,
-    skip: ['componentsProp'],
   }));
 
   it('should render with the root class but no others', () => {

--- a/packages/mui-material/src/Fade/Fade.test.js
+++ b/packages/mui-material/src/Fade/Fade.test.js
@@ -19,13 +19,7 @@ describe('<Fade />', () => {
     classes: {},
     inheritComponent: Transition,
     refInstanceof: window.HTMLDivElement,
-    skip: [
-      'componentProp',
-      'componentsProp',
-      'themeDefaultProps',
-      'themeStyleOverrides',
-      'themeVariants',
-    ],
+    skip: ['componentProp', 'themeDefaultProps', 'themeStyleOverrides', 'themeVariants'],
   }));
 
   describe('transition lifecycle', () => {

--- a/packages/mui-material/src/FilledInput/FilledInput.test.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.test.js
@@ -24,7 +24,6 @@ describe('<FilledInput />', () => {
     },
     skip: [
       'componentProp',
-      'componentsProp',
       'slotPropsCallback', // not supported yet
       'slotPropsCallbackWithPropsAsOwnerState', // not supported yet
     ],

--- a/packages/mui-material/src/FormControl/FormControl.test.js
+++ b/packages/mui-material/src/FormControl/FormControl.test.js
@@ -27,7 +27,6 @@ describe('<FormControl />', () => {
     testComponentPropWith: 'fieldset',
     muiName: 'MuiFormControl',
     testVariantProps: { margin: 'dense' },
-    skip: ['componentsProp'],
   }));
 
   describe('initial state', () => {

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.test.js
@@ -22,7 +22,7 @@ describe('<FormControlLabel />', () => {
     slots: {
       typography: { expectedClassName: classes.label },
     },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   describe('prop: label', () => {

--- a/packages/mui-material/src/FormGroup/FormGroup.test.js
+++ b/packages/mui-material/src/FormGroup/FormGroup.test.js
@@ -14,7 +14,7 @@ describe('<FormGroup />', () => {
     muiName: 'MuiFormGroup',
     refInstanceof: window.HTMLDivElement,
     testVariantProps: { row: true },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('should render a div with a div child', () => {

--- a/packages/mui-material/src/FormHelperText/FormHelperText.test.js
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.test.js
@@ -15,7 +15,6 @@ describe('<FormHelperText />', () => {
     testComponentPropWith: 'div',
     muiName: 'MuiFormHelperText',
     testVariantProps: { size: 'small' },
-    skip: ['componentsProp'],
   }));
 
   describe('prop: error', () => {

--- a/packages/mui-material/src/FormLabel/FormLabel.test.js
+++ b/packages/mui-material/src/FormLabel/FormLabel.test.js
@@ -19,7 +19,6 @@ describe('<FormLabel />', () => {
     testComponentPropWith: 'div',
     muiName: 'MuiFormLabel',
     testVariantProps: { color: 'secondary' },
-    skip: ['componentsProp'],
   }));
 
   describe('prop: required', () => {

--- a/packages/mui-material/src/Grid/Grid.test.js
+++ b/packages/mui-material/src/Grid/Grid.test.js
@@ -19,7 +19,7 @@ describe('<Grid />', () => {
     refInstanceof: window.HTMLElement,
     muiName: 'MuiGrid',
     testVariantProps: { container: true, spacing: 5 },
-    skip: ['componentsProp', 'classesRoot'],
+    skip: ['classesRoot'],
   }));
 
   it('should not crash with theme scoping', () => {

--- a/packages/mui-material/src/Grow/Grow.test.js
+++ b/packages/mui-material/src/Grow/Grow.test.js
@@ -25,13 +25,7 @@ describe('<Grow />', () => {
       classes: {},
       inheritComponent: Transition,
       refInstanceof: window.HTMLDivElement,
-      skip: [
-        'componentProp',
-        'componentsProp',
-        'themeDefaultProps',
-        'themeStyleOverrides',
-        'themeVariants',
-      ],
+      skip: ['componentProp', 'themeDefaultProps', 'themeStyleOverrides', 'themeVariants'],
     }),
   );
 

--- a/packages/mui-material/src/Icon/Icon.test.js
+++ b/packages/mui-material/src/Icon/Icon.test.js
@@ -13,7 +13,7 @@ describe('<Icon />', () => {
     muiName: 'MuiIcon',
     refInstanceof: window.HTMLSpanElement,
     testComponentPropWith: 'div',
-    skip: ['themeVariants', 'componentsProp'],
+    skip: ['themeVariants'],
   }));
 
   it('renders children by default', () => {

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -20,7 +20,7 @@ describe('<IconButton />', () => {
     refInstanceof: window.HTMLButtonElement,
     muiName: 'MuiIconButton',
     testVariantProps: { edge: 'end', disabled: true },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('should render Icon children with right classes', () => {

--- a/packages/mui-material/src/ImageList/ImageList.test.js
+++ b/packages/mui-material/src/ImageList/ImageList.test.js
@@ -31,7 +31,7 @@ describe('<ImageList />', () => {
       testComponentPropWith: 'li',
       muiName: 'MuiImageList',
       testVariantProps: { variant: 'masonry' },
-      skip: ['componentProp', 'componentsProp'],
+      skip: ['componentProp'],
     }),
   );
 

--- a/packages/mui-material/src/ImageListItem/ImageListItem.test.js
+++ b/packages/mui-material/src/ImageListItem/ImageListItem.test.js
@@ -16,7 +16,7 @@ describe('<ImageListItem />', () => {
     testComponentPropWith: 'div',
     muiName: 'MuiImageListItem',
     testVariantProps: { variant: 'masonry' },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   const itemData = {

--- a/packages/mui-material/src/ImageListItemBar/ImageListItemBar.test.js
+++ b/packages/mui-material/src/ImageListItemBar/ImageListItemBar.test.js
@@ -16,7 +16,7 @@ describe('<ImageListItemBar />', () => {
     muiName: 'MuiImageListItemBar',
     testDeepOverrides: { slotName: 'titleWrap', slotClassName: classes.titleWrap },
     testVariantProps: { position: 'top', actionPosition: 'left' },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   const itemData = {

--- a/packages/mui-material/src/Input/Input.test.js
+++ b/packages/mui-material/src/Input/Input.test.js
@@ -23,7 +23,6 @@ describe('<Input />', () => {
     },
     skip: [
       'componentProp',
-      'componentsProp',
       'slotPropsCallback', // not supported yet
       'slotPropsCallbackWithPropsAsOwnerState', // not supported yet
     ],

--- a/packages/mui-material/src/InputAdornment/InputAdornment.test.js
+++ b/packages/mui-material/src/InputAdornment/InputAdornment.test.js
@@ -21,7 +21,6 @@ describe('<InputAdornment />', () => {
     muiName: 'MuiInputAdornment',
     testVariantProps: { color: 'primary' },
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentsProp'],
     testComponentPropWith: 'span',
   }));
 

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -36,7 +36,6 @@ describe('<InputBase />', () => {
     },
     skip: [
       'componentProp',
-      'componentsProp',
       'slotPropsCallback', // not supported yet
       'slotPropsCallbackWithPropsAsOwnerState', // not supported yet
     ],

--- a/packages/mui-material/src/InputLabel/InputLabel.test.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.test.js
@@ -19,7 +19,6 @@ describe('<InputLabel />', () => {
     refInstanceof: window.HTMLLabelElement,
     muiName: 'MuiInputLabel',
     testVariantProps: { size: 'small' },
-    skip: ['componentsProp'],
   }));
 
   it('should render a label with text', () => {

--- a/packages/mui-material/src/LinearProgress/LinearProgress.test.js
+++ b/packages/mui-material/src/LinearProgress/LinearProgress.test.js
@@ -18,7 +18,7 @@ describe('<LinearProgress />', () => {
     testDeepOverrides: { slotName: 'bar', slotClassName: classes.bar },
     testVariantProps: { variant: 'determinate', value: 25 },
     refInstanceof: window.HTMLSpanElement,
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('should render indeterminate variant by default', () => {

--- a/packages/mui-material/src/Link/Link.test.js
+++ b/packages/mui-material/src/Link/Link.test.js
@@ -24,7 +24,6 @@ describe('<Link />', () => {
     refInstanceof: window.HTMLAnchorElement,
     testVariantProps: { color: 'secondary', variant: 'h1' },
     testStateOverrides: { prop: 'underline', value: 'always', styleKey: 'underlineAlways' },
-    skip: ['componentsProp'],
   }));
 
   it('should render children', () => {

--- a/packages/mui-material/src/List/List.test.js
+++ b/packages/mui-material/src/List/List.test.js
@@ -16,7 +16,6 @@ describe('<List />', () => {
     muiName: 'MuiList',
     refInstanceof: window.HTMLUListElement,
     testVariantProps: { disablePadding: true },
-    skip: ['componentsProp'],
   }));
 
   it('should render with padding classes', () => {

--- a/packages/mui-material/src/ListItem/ListItem.test.js
+++ b/packages/mui-material/src/ListItem/ListItem.test.js
@@ -18,7 +18,6 @@ describe('<ListItem />', () => {
       root: { expectedClassName: classes.root },
       secondaryAction: { expectedClassName: classes.secondaryAction },
     },
-    skip: ['componentsProp'],
   }));
 
   it('should render with gutters classes', () => {

--- a/packages/mui-material/src/ListItemAvatar/ListItemAvatar.test.js
+++ b/packages/mui-material/src/ListItemAvatar/ListItemAvatar.test.js
@@ -15,7 +15,7 @@ describe('<ListItemAvatar />', () => {
       render,
       muiName: 'MuiListItemAvatar',
       refInstanceof: window.HTMLDivElement,
-      skip: ['componentProp', 'componentsProp', 'themeVariants'],
+      skip: ['componentProp', 'themeVariants'],
     }),
   );
 });

--- a/packages/mui-material/src/ListItemButton/ListItemButton.test.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.test.js
@@ -18,7 +18,6 @@ describe('<ListItemButton />', () => {
     testComponentPropWith: 'a',
     muiName: 'MuiListItemButton',
     testVariantProps: { dense: true },
-    skip: ['componentsProp'],
   }));
 
   it('should render with gutters classes', () => {

--- a/packages/mui-material/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/mui-material/src/ListItemIcon/ListItemIcon.test.js
@@ -15,7 +15,7 @@ describe('<ListItemIcon />', () => {
       render,
       muiName: 'MuiListItemIcon',
       refInstanceof: window.HTMLDivElement,
-      skip: ['componentProp', 'componentsProp', 'themeVariants'],
+      skip: ['componentProp', 'themeVariants'],
     }),
   );
 });

--- a/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
+++ b/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
@@ -15,7 +15,7 @@ describe('<ListItemSecondaryAction />', () => {
     render,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiListItemSecondaryAction',
-    skip: ['componentsProp', 'themeVariants'],
+    skip: ['themeVariants'],
   }));
 
   it('should render without classes that disable gutters', () => {

--- a/packages/mui-material/src/ListItemText/ListItemText.test.js
+++ b/packages/mui-material/src/ListItemText/ListItemText.test.js
@@ -26,7 +26,7 @@ describe('<ListItemText />', () => {
         expectedClassName: classes.root,
       },
     },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('should render with inset class', () => {

--- a/packages/mui-material/src/ListSubheader/ListSubheader.test.js
+++ b/packages/mui-material/src/ListSubheader/ListSubheader.test.js
@@ -13,7 +13,6 @@ describe('<ListSubheader />', () => {
     muiName: 'MuiListSubheader',
     refInstanceof: window.HTMLLIElement,
     testVariantProps: { disableGutters: true },
-    skip: ['componentsProp'],
   }));
 
   it('should display primary color', () => {

--- a/packages/mui-material/src/Menu/Menu.test.js
+++ b/packages/mui-material/src/Menu/Menu.test.js
@@ -71,7 +71,6 @@ describe('<Menu />', () => {
     skip: [
       'rootClass', // portal, can't determine the root
       'componentProp',
-      'componentsProp',
       'themeDefaultProps', // portal, can't determine the root
     ],
   }));

--- a/packages/mui-material/src/MenuItem/MenuItem.test.js
+++ b/packages/mui-material/src/MenuItem/MenuItem.test.js
@@ -18,7 +18,6 @@ describe('<MenuItem />', () => {
     testComponentPropWith: 'a',
     muiName: 'MuiMenuItem',
     testVariantProps: { dense: true },
-    skip: ['componentsProp'],
   }));
 
   it('should render a focusable menuitem', () => {

--- a/packages/mui-material/src/MenuList/MenuList.test.js
+++ b/packages/mui-material/src/MenuList/MenuList.test.js
@@ -27,13 +27,7 @@ describe('<MenuList />', () => {
     classes: {},
     inheritComponent: List,
     refInstanceof: window.HTMLUListElement,
-    skip: [
-      'componentProp',
-      'componentsProp',
-      'themeDefaultProps',
-      'themeStyleOverrides',
-      'themeVariants',
-    ],
+    skip: ['componentProp', 'themeDefaultProps', 'themeStyleOverrides', 'themeVariants'],
   }));
 
   it('should render a list with role menu and tabIndex -1', () => {

--- a/packages/mui-material/src/MobileStepper/MobileStepper.test.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.test.js
@@ -57,7 +57,7 @@ describe('<MobileStepper />', () => {
         testWithElement: CustomDot,
       },
     },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   describeConformance(<MobileStepper {...defaultProps} steps={1} variant="progress" />, () => ({

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -39,7 +39,6 @@ describe('<Modal />', () => {
       },
       skip: [
         'rootClass', // portal, can't determine the root
-        'componentsProp', // TODO isRTL is leaking, why do we even have it in the first place?
         'themeDefaultProps', // portal, can't determine the root
         'themeStyleOverrides', // portal, can't determine the root
       ],

--- a/packages/mui-material/src/NativeSelect/NativeSelect.test.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.test.js
@@ -25,7 +25,7 @@ describe('<NativeSelect />', () => {
     render,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiNativeSelect',
-    skip: ['componentProp', 'componentsProp', 'themeVariants', 'themeStyleOverrides'],
+    skip: ['componentProp', 'themeVariants', 'themeStyleOverrides'],
   }));
 
   it('should render a native select', () => {

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
@@ -33,7 +33,6 @@ describe('<OutlinedInput />', () => {
     },
     skip: [
       'componentProp',
-      'componentsProp',
       'slotPropsCallback', // not supported yet
       'slotPropsCallbackWithPropsAsOwnerState', // not supported yet
     ],

--- a/packages/mui-material/src/Pagination/Pagination.test.js
+++ b/packages/mui-material/src/Pagination/Pagination.test.js
@@ -18,7 +18,7 @@ describe('<Pagination />', () => {
     testDeepOverrides: { slotName: 'ul', slotClassName: classes.ul },
     testVariantProps: { variant: 'foo' },
     testStateOverrides: { prop: 'variant', value: 'outlined', styleKey: 'outlined' },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('should render', () => {

--- a/packages/mui-material/src/PaginationItem/PaginationItem.test.js
+++ b/packages/mui-material/src/PaginationItem/PaginationItem.test.js
@@ -28,7 +28,6 @@ describe('<PaginationItem />', () => {
       next: {},
     },
     skip: [
-      'componentsProp',
       // Icon slots (first, last, previous, next) only render when `type` matches
       // (e.g. type="first" for the first slot). The conformance test renders
       // <PaginationItem /> which defaults to type="page", so icon slots are absent.

--- a/packages/mui-material/src/Paper/Paper.test.js
+++ b/packages/mui-material/src/Paper/Paper.test.js
@@ -22,7 +22,6 @@ describe('<Paper />', () => {
     testComponentPropWith: 'header',
     testVariantProps: { variant: 'rounded' },
     testStateOverrides: { prop: 'elevation', value: 10, styleKey: 'elevation10' },
-    skip: ['componentsProp'],
   }));
 
   describe('prop: square', () => {

--- a/packages/mui-material/src/Popover/Popover.test.js
+++ b/packages/mui-material/src/Popover/Popover.test.js
@@ -94,7 +94,6 @@ describe('<Popover />', () => {
     skip: [
       'rootClass', // portal, can't determine the root
       'componentProp',
-      'componentsProp',
       'themeDefaultProps', // portal, can't determine the root
       'themeStyleOverrides', // portal, can't determine the root
       'themeVariants',

--- a/packages/mui-material/src/Popper/Popper.test.js
+++ b/packages/mui-material/src/Popper/Popper.test.js
@@ -41,7 +41,6 @@ describe('<Popper />', () => {
     },
     skip: [
       'componentProp',
-      'componentsProp',
       'themeDefaultProps',
       'themeStyleOverrides',
       'themeVariants',

--- a/packages/mui-material/src/Radio/Radio.test.js
+++ b/packages/mui-material/src/Radio/Radio.test.js
@@ -30,7 +30,7 @@ describe('<Radio />', () => {
         expectedClassName: switchBaseClasses.input,
       },
     },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   describe('styleSheet', () => {

--- a/packages/mui-material/src/RadioGroup/RadioGroup.test.js
+++ b/packages/mui-material/src/RadioGroup/RadioGroup.test.js
@@ -16,13 +16,7 @@ describe('<RadioGroup />', () => {
     classes: {},
     inheritComponent: FormGroup,
     refInstanceof: window.HTMLDivElement,
-    skip: [
-      'componentProp',
-      'componentsProp',
-      'themeDefaultProps',
-      'themeStyleOverrides',
-      'themeVariants',
-    ],
+    skip: ['componentProp', 'themeDefaultProps', 'themeStyleOverrides', 'themeVariants'],
   }));
 
   it('the root component has the radiogroup role', () => {

--- a/packages/mui-material/src/Rating/Rating.test.js
+++ b/packages/mui-material/src/Rating/Rating.test.js
@@ -25,7 +25,6 @@ describe('<Rating />', () => {
         expectedClassName: classes.label,
       },
     },
-    skip: ['componentsProp'],
   }));
 
   describeConformance(<Rating max={1} />, () => ({

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -33,7 +33,7 @@ describe('<Select />', () => {
     render,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiSelect',
-    skip: ['componentProp', 'componentsProp', 'themeVariants', 'themeStyleOverrides'],
+    skip: ['componentProp', 'themeVariants', 'themeStyleOverrides'],
   }));
 
   describe('prop: inputProps', () => {

--- a/packages/mui-material/src/Skeleton/Skeleton.test.js
+++ b/packages/mui-material/src/Skeleton/Skeleton.test.js
@@ -13,7 +13,6 @@ describe('<Skeleton />', () => {
     refInstanceof: window.HTMLSpanElement,
     muiName: 'MuiSkeleton',
     testVariantProps: { variant: 'circular', animation: 'wave' },
-    skip: ['componentsProp'],
   }));
 
   it('should render', () => {

--- a/packages/mui-material/src/Slide/Slide.test.js
+++ b/packages/mui-material/src/Slide/Slide.test.js
@@ -27,13 +27,7 @@ describe('<Slide />', () => {
       classes: {},
       inheritComponent: Transition,
       refInstanceof: window.HTMLDivElement,
-      skip: [
-        'componentProp',
-        'componentsProp',
-        'themeDefaultProps',
-        'themeStyleOverrides',
-        'themeVariants',
-      ],
+      skip: ['componentProp', 'themeDefaultProps', 'themeStyleOverrides', 'themeVariants'],
     }),
   );
 

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -65,7 +65,6 @@ describe.skipIf(!supportsTouch())('<Slider />', () => {
         },
       },
       skip: [
-        'componentsProp',
         'slotPropsCallback', // not supported yet
         'slotPropsCallbackWithPropsAsOwnerState', // not supported yet
       ],

--- a/packages/mui-material/src/Snackbar/Snackbar.test.js
+++ b/packages/mui-material/src/Snackbar/Snackbar.test.js
@@ -47,7 +47,7 @@ describe('<Snackbar />', () => {
     render,
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiSnackbar',
-    skip: ['componentProp', 'componentsProp', 'themeVariants'],
+    skip: ['componentProp', 'themeVariants'],
     slots: {
       root: {
         expectedClassName: classes.root,

--- a/packages/mui-material/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/mui-material/src/SnackbarContent/SnackbarContent.test.js
@@ -14,7 +14,7 @@ describe('<SnackbarContent />', () => {
     render,
     muiName: 'MuiSnackbarContent',
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp', 'componentsProp', 'themeVariants'],
+    skip: ['componentProp', 'themeVariants'],
   }));
 
   describe('prop: action', () => {

--- a/packages/mui-material/src/SpeedDial/SpeedDial.test.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.test.js
@@ -38,7 +38,6 @@ describe('<SpeedDial />', () => {
     slots: { transition: { testWithElement: null }, root: { expectedClassName: classes.root } },
     skip: [
       'componentProp', // react-transition-group issue
-      'componentsProp',
     ],
   }));
 

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
@@ -27,7 +27,7 @@ describe('<SpeedDialAction />', () => {
       refInstanceof: window.HTMLButtonElement,
       muiName: 'MuiSpeedDialAction',
       testRootOverrides: { slotName: 'fab' },
-      skip: ['componentProp', 'componentsProp', 'themeVariants'],
+      skip: ['componentProp', 'themeVariants'],
       slots: {
         fab: {
           expectedClassName: classes.fab,

--- a/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.test.js
+++ b/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.test.js
@@ -15,7 +15,7 @@ describe('<SpeedDialIcon />', () => {
     refInstanceof: window.HTMLSpanElement,
     muiName: 'MuiSpeedDialIcon',
     testVariantProps: { icon },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('should render the Add icon by default', () => {

--- a/packages/mui-material/src/Stack/Stack.test.js
+++ b/packages/mui-material/src/Stack/Stack.test.js
@@ -17,6 +17,6 @@ describe('<Stack />', () => {
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiStack',
     testVariantProps: { direction: 'row' },
-    skip: ['componentsProp', 'classesRoot'],
+    skip: ['classesRoot'],
   }));
 });

--- a/packages/mui-material/src/Step/Step.test.js
+++ b/packages/mui-material/src/Step/Step.test.js
@@ -29,7 +29,6 @@ describe('<Step />', () => {
     muiName: 'MuiStep',
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLLIElement,
-    skip: ['componentsProp'],
   }));
 
   it('merges styles and other props into the root node', () => {

--- a/packages/mui-material/src/StepButton/StepButton.test.js
+++ b/packages/mui-material/src/StepButton/StepButton.test.js
@@ -19,7 +19,7 @@ describe('<StepButton />', () => {
       muiName: 'MuiStepButton',
       refInstanceof: window.HTMLButtonElement,
       render,
-      skip: ['componentProp', 'componentsProp', 'themeVariants'],
+      skip: ['componentProp', 'themeVariants'],
     }));
 
     it('should receive the correct aria attributes', () => {

--- a/packages/mui-material/src/StepConnector/StepConnector.test.js
+++ b/packages/mui-material/src/StepConnector/StepConnector.test.js
@@ -13,7 +13,7 @@ describe('<StepConnector />', () => {
     render,
     muiName: 'MuiStepConnector',
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp', 'componentsProp', 'themeVariants'],
+    skip: ['componentProp', 'themeVariants'],
   }));
 
   describe('rendering', () => {

--- a/packages/mui-material/src/StepContent/StepContent.test.js
+++ b/packages/mui-material/src/StepContent/StepContent.test.js
@@ -22,7 +22,7 @@ describe('<StepContent />', () => {
       );
       return { container: container.firstChild.firstChild, ...other };
     },
-    skip: ['componentProp', 'componentsProp', 'themeVariants'],
+    skip: ['componentProp', 'themeVariants'],
     slots: {
       transition: {
         expectedClassName: classes.transition,

--- a/packages/mui-material/src/StepIcon/StepIcon.test.js
+++ b/packages/mui-material/src/StepIcon/StepIcon.test.js
@@ -14,7 +14,7 @@ describe('<StepIcon />', () => {
     muiName: 'MuiStepIcon',
     testVariantProps: { completed: true },
     refInstanceof: window.SVGSVGElement,
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('renders <CheckCircle> when completed', () => {

--- a/packages/mui-material/src/StepLabel/StepLabel.test.js
+++ b/packages/mui-material/src/StepLabel/StepLabel.test.js
@@ -21,7 +21,7 @@ describe('<StepLabel />', () => {
       label: { expectedClassName: classes.label },
       root: { expectedClassName: classes.root },
     },
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   describe('label content', () => {

--- a/packages/mui-material/src/Stepper/Stepper.test.tsx
+++ b/packages/mui-material/src/Stepper/Stepper.test.tsx
@@ -23,7 +23,6 @@ describe('<Stepper />', () => {
       refInstanceof: window.HTMLOListElement,
       testVariantProps: { variant: 'foo' },
       testStateOverrides: { prop: 'alternativeLabel', value: true, styleKey: 'alternativeLabel' },
-      skip: ['componentsProp'],
     }),
   );
 

--- a/packages/mui-material/src/SvgIcon/SvgIcon.test.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.test.js
@@ -33,7 +33,7 @@ describe('<SvgIcon />', () => {
           {props.children}
         </svg>
       ),
-      skip: ['themeVariants', 'componentsProp'],
+      skip: ['themeVariants'],
     }),
   );
 

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -72,13 +72,7 @@ describe('<SwipeableDrawer />', () => {
     classes: {},
     inheritComponent: Drawer,
     refInstanceof: window.HTMLDivElement,
-    skip: [
-      'componentProp',
-      'themeDefaultProps',
-      'themeStyleOverrides',
-      'themeVariants',
-      'componentsProp',
-    ],
+    skip: ['componentProp', 'themeDefaultProps', 'themeStyleOverrides', 'themeVariants'],
   }));
 
   it('should render a Drawer and a SwipeArea', () => {

--- a/packages/mui-material/src/Switch/Switch.test.js
+++ b/packages/mui-material/src/Switch/Switch.test.js
@@ -40,7 +40,6 @@ describe('<Switch />', () => {
     refInstanceof: window.HTMLSpanElement,
     skip: [
       'componentProp',
-      'componentsProp',
       'themeDefaultProps',
       'themeVariants',
       // Props are spread to the root's child but className is added to the root

--- a/packages/mui-material/src/Tab/Tab.test.js
+++ b/packages/mui-material/src/Tab/Tab.test.js
@@ -18,7 +18,7 @@ describe('<Tab />', () => {
     muiName: 'MuiTab',
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLButtonElement,
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('should have a ripple', async () => {

--- a/packages/mui-material/src/TabScrollButton/TabScrollButton.test.js
+++ b/packages/mui-material/src/TabScrollButton/TabScrollButton.test.js
@@ -21,7 +21,7 @@ describe('<TabScrollButton />', () => {
     muiName: 'MuiTabScrollButton',
     testVariantProps: { orientation: 'vertical' },
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('should render as a button with the root class', () => {

--- a/packages/mui-material/src/Table/Table.test.js
+++ b/packages/mui-material/src/Table/Table.test.js
@@ -19,7 +19,6 @@ describe('<Table />', () => {
       refInstanceof: window.HTMLTableElement,
       // can't test another component with tbody as a child
       testComponentPropWith: 'table',
-      skip: ['componentsProp'],
     }),
   );
 

--- a/packages/mui-material/src/TableBody/TableBody.test.js
+++ b/packages/mui-material/src/TableBody/TableBody.test.js
@@ -22,7 +22,6 @@ describe('<TableBody />', () => {
     refInstanceof: window.HTMLTableSectionElement,
     // can't test with custom `component` with `renderInTable`
     testComponentPropWith: 'tbody',
-    skip: ['componentsProp'],
   }));
 
   it('should render children', () => {

--- a/packages/mui-material/src/TableCell/TableCell.test.js
+++ b/packages/mui-material/src/TableCell/TableCell.test.js
@@ -36,7 +36,6 @@ describe('<TableCell />', () => {
     refInstanceof: window.HTMLTableCellElement,
     // invalid nesting otherwise
     testComponentPropWith: 'td',
-    skip: ['componentsProp'],
   }));
 
   describe('prop: padding', () => {

--- a/packages/mui-material/src/TableContainer/TableContainer.test.js
+++ b/packages/mui-material/src/TableContainer/TableContainer.test.js
@@ -13,6 +13,5 @@ describe('<TableContainer />', () => {
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
-    skip: ['componentsProp'],
   }));
 });

--- a/packages/mui-material/src/TableFooter/TableFooter.test.js
+++ b/packages/mui-material/src/TableFooter/TableFooter.test.js
@@ -21,7 +21,6 @@ describe('<TableFooter />', () => {
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLTableSectionElement,
     testComponentPropWith: 'thead',
-    skip: ['componentsProp'],
   }));
 
   it('should render children', () => {

--- a/packages/mui-material/src/TableHead/TableHead.test.js
+++ b/packages/mui-material/src/TableHead/TableHead.test.js
@@ -20,7 +20,6 @@ describe('<TableHead />', () => {
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLTableSectionElement,
     testComponentPropWith: 'tbody',
-    skip: ['componentsProp'],
   }));
 
   it('should render children', () => {

--- a/packages/mui-material/src/TablePagination/TablePagination.test.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.test.js
@@ -69,7 +69,7 @@ describe('<TablePagination />', () => {
         selectLabel: { expectedClassName: classes.selectLabel },
         displayedRows: { expectedClassName: classes.displayedRows },
       },
-      skip: ['themeVariants', 'componentsProps'],
+      skip: ['themeVariants'],
     }),
   );
 

--- a/packages/mui-material/src/TablePaginationActions/TablePaginationActions.test.js
+++ b/packages/mui-material/src/TablePaginationActions/TablePaginationActions.test.js
@@ -34,7 +34,7 @@ describe('<TablePaginationActions />', () => {
       classes,
       muiName: 'MuiTablePaginationActions',
       refInstanceof: window.HTMLDivElement,
-      skip: ['componentsProp', 'componentProp', 'themeVariants'],
+      skip: ['componentProp', 'themeVariants'],
     }),
   );
 });

--- a/packages/mui-material/src/TableRow/TableRow.test.js
+++ b/packages/mui-material/src/TableRow/TableRow.test.js
@@ -29,7 +29,6 @@ describe('<TableRow />', () => {
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLTableRowElement,
     testComponentPropWith: 'tr',
-    skip: ['componentsProp'],
   }));
 
   it('should render children', () => {

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.test.js
@@ -18,7 +18,7 @@ describe('<TableSortLabel />', () => {
     testVariantProps: { variant: 'foo' },
     testDeepOverrides: { slotName: 'icon', slotClassName: classes.icon },
     refInstanceof: window.HTMLSpanElement,
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
     slots: {
       icon: {
         expectedClassName: classes.icon,

--- a/packages/mui-material/src/Tabs/Tabs.test.js
+++ b/packages/mui-material/src/Tabs/Tabs.test.js
@@ -76,7 +76,7 @@ describe.skipIf(isSafari)('<Tabs />', () => {
         expectedClassName: classes.indicator,
       },
     },
-    skip: ['componentsProp', 'themeVariants'],
+    skip: ['themeVariants'],
   }));
 
   it('can be named via `aria-label`', () => {

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -54,7 +54,7 @@ describe('<TextField />', () => {
           testWithElement: TestFormControl,
         },
       },
-      skip: ['componentProp', 'componentsProp'],
+      skip: ['componentProp'],
     }),
   );
 

--- a/packages/mui-material/src/ToggleButton/ToggleButton.test.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.test.js
@@ -18,7 +18,7 @@ describe('<ToggleButton />', () => {
     testStateOverrides: { prop: 'size', value: 'large', styleKey: 'sizeLarge' },
     refInstanceof: window.HTMLButtonElement,
     testComponentPropWith: 'div',
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
   }));
 
   it('adds the `selected` class to the root element if selected={true}', () => {

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -17,7 +17,7 @@ describe('<ToggleButtonGroup />', () => {
     render,
     muiName: 'MuiToggleButtonGroup',
     refInstanceof: window.HTMLDivElement,
-    skip: ['componentProp', 'componentsProp'],
+    skip: ['componentProp'],
     testVariantProps: { size: 'small' },
     testStateOverrides: { prop: 'orientation', value: 'vertical', styleKey: 'vertical' },
   }));

--- a/packages/mui-material/src/Toolbar/Toolbar.test.js
+++ b/packages/mui-material/src/Toolbar/Toolbar.test.js
@@ -14,7 +14,6 @@ describe('<Toolbar />', () => {
     refInstanceof: window.HTMLDivElement,
     testVariantProps: { variant: 'foo' },
     testStateOverrides: { prop: 'variant', value: 'foo', styleKey: 'foo' },
-    skip: ['componentsProp'],
   }));
 
   it('should render with gutters class', () => {

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -82,7 +82,7 @@ describe('<Tooltip />', () => {
         },
         arrow: { expectedClassName: classes.arrow },
       },
-      skip: ['componentProp', 'componentsProp', 'themeVariants'],
+      skip: ['componentProp', 'themeVariants'],
     }),
   );
 

--- a/packages/mui-material/src/Typography/Typography.test.js
+++ b/packages/mui-material/src/Typography/Typography.test.js
@@ -14,7 +14,6 @@ describe('<Typography />', () => {
     muiName: 'MuiTypography',
     testVariantProps: { variant: 'dot' },
     testStateOverrides: { prop: 'variant', value: 'h2', styleKey: 'h2' },
-    skip: ['componentsProp'],
   }));
 
   it('should render the text', () => {

--- a/packages/mui-material/src/Zoom/Zoom.test.js
+++ b/packages/mui-material/src/Zoom/Zoom.test.js
@@ -18,13 +18,7 @@ describe('<Zoom />', () => {
       classes: {},
       inheritComponent: Transition,
       refInstanceof: window.HTMLDivElement,
-      skip: [
-        'componentProp',
-        'componentsProp',
-        'themeDefaultProps',
-        'themeStyleOverrides',
-        'themeVariants',
-      ],
+      skip: ['componentProp', 'themeDefaultProps', 'themeStyleOverrides', 'themeVariants'],
     }),
   );
 

--- a/packages/mui-material/src/internal/SwitchBase.test.js
+++ b/packages/mui-material/src/internal/SwitchBase.test.js
@@ -34,7 +34,7 @@ describe('<SwitchBase />', () => {
           expectedClassName: classes.input,
         },
       },
-      skip: ['componentsProp', 'themeDefaultProps', 'themeStyleOverrides', 'themeVariants'],
+      skip: ['themeDefaultProps', 'themeStyleOverrides', 'themeVariants'],
     }),
   );
 

--- a/packages/mui-system/src/Box/Box.test.js
+++ b/packages/mui-system/src/Box/Box.test.js
@@ -14,7 +14,6 @@ describe('<Box />', () => {
     inheritComponent: 'div',
     skip: [
       'componentProp',
-      'componentsProp',
       'rootClass',
       'themeVariants',
       'themeStyleOverrides',

--- a/packages/mui-system/src/Container/Container.test.js
+++ b/packages/mui-system/src/Container/Container.test.js
@@ -16,7 +16,6 @@ describe('<Container />', () => {
     render,
     refInstanceof: window.HTMLElement,
     muiName: 'MuiContainer',
-    skip: ['componentsProp'],
     testVariantProps: { fixed: true },
   }));
 

--- a/packages/mui-system/src/Grid/Grid.test.js
+++ b/packages/mui-system/src/Grid/Grid.test.js
@@ -20,7 +20,7 @@ describe('System <Grid />', () => {
     refInstanceof: window.HTMLElement,
     muiName: 'MuiGrid',
     testVariantProps: { container: true, spacing: 5 },
-    skip: ['componentsProp', 'classesRoot'],
+    skip: ['classesRoot'],
   }));
 
   describe('prop: container', () => {

--- a/packages/mui-system/src/Stack/Stack.test.js
+++ b/packages/mui-system/src/Stack/Stack.test.js
@@ -13,7 +13,7 @@ describe('<Stack />', () => {
     inheritComponent: 'div',
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiStack',
-    skip: ['componentProp', 'componentsProp', 'rootClass', 'themeVariants', 'themeStyleOverrides'],
+    skip: ['componentProp', 'rootClass', 'themeVariants', 'themeStyleOverrides'],
   }));
 
   const theme = createTheme();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,8 +101,8 @@ importers:
         specifier: workspace:^
         version: link:packages-internal/scripts
       '@mui/internal-test-utils':
-        specifier: 2.0.18-canary.16
-        version: 2.0.18-canary.16(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@playwright/test@1.58.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vitest/utils@4.0.15)(chai@6.2.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))(vitest@4.0.13)
+        specifier: 2.0.18-canary.17
+        version: 2.0.18-canary.17(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@playwright/test@1.58.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vitest/utils@4.0.15)(chai@6.2.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))(vitest@4.0.13)
       '@mui/material':
         specifier: workspace:^
         version: link:packages/mui-material/build
@@ -3639,8 +3639,8 @@ packages:
   '@mui/internal-netlify-cache@0.0.3-canary.2':
     resolution: {integrity: sha512-RpHfVoqsIRqQ44UL/q9gSNOiHqZpri25SlnfWGmuvIUTSBWx+A1G7zhTKmasGel5bNBSnMEgBG5/MkW0mkrMRw==}
 
-  '@mui/internal-test-utils@2.0.18-canary.16':
-    resolution: {integrity: sha512-4AK1qNkxTJYq6/gXXy7DeQrvnkwbnOnmV78gb5LE5eGfYSs96p5Q0gCs8snPeibJLFZlnJiFGiIFhMYMtzDBVA==}
+  '@mui/internal-test-utils@2.0.18-canary.17':
+    resolution: {integrity: sha512-gT5QeW8mrtbc9RUBPi+HB6Hbfj1qclZMcEpUl1xz5DIUjITR0B6IYO1nHNWZVvtRo3X79NIQ3Qm5hx8gGwLxrw==}
     peerDependencies:
       '@emotion/cache': '11'
       '@emotion/react': '11'
@@ -14824,7 +14824,7 @@ snapshots:
 
   '@mui/internal-netlify-cache@0.0.3-canary.2': {}
 
-  '@mui/internal-test-utils@2.0.18-canary.16(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@playwright/test@1.58.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vitest/utils@4.0.15)(chai@6.2.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))(vitest@4.0.13)':
+  '@mui/internal-test-utils@2.0.18-canary.17(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@playwright/test@1.58.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vitest/utils@4.0.15)(chai@6.2.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))(vitest@4.0.13)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@playwright/test': 1.58.2


### PR DESCRIPTION
Test was removed in https://github.com/mui/mui-public/pull/1244.

Closes https://github.com/mui/material-ui/issues/48070.

Also, removed `skip: ['componentProp']` in components that support `component` prop.