### PR TITLE
[docs] Fix the dark mode footer row shadow for the Data Grid on the advanced components page

### DIFF
--- a/docs/src/components/productX/XHero.tsx
+++ b/docs/src/components/productX/XHero.tsx
@@ -240,6 +240,9 @@ export default function XHero() {
                       '& .MuiDataGrid-pinnedRows': {
                         backgroundColor: alpha(theme.palette.primaryDark[800], 1),
                         backgroundImage: 'none',
+                        '& .MuiDataGrid-footerCell': {
+                          color: 'primary.light',
+                        },
                       },
                     },
                   }),


### PR DESCRIPTION
Dark mode included a shadow that was added on top of the [default](https://mui.com/x/react-data-grid/row-pinning/#pinned-rows-appearance) that we have had for some time.

Before: https://mui.com/x/
After: https://deploy-preview-48149--material-ui.netlify.app/x/