### PR TITLE
[all components] Fix `slotProps.transition` types

### DIFF
--- a/packages/mui-material/src/Accordion/Accordion.d.ts
+++ b/packages/mui-material/src/Accordion/Accordion.d.ts
@@ -58,7 +58,7 @@ export type AccordionSlotsAndSlotProps = CreateSlotsAndSlotProps<
      * By default, the available props are based on the [Collapse](https://mui.com/material-ui/api/collapse/#props) component.
      */
     transition: SlotComponentProps<
-      React.ElementType,
+      React.ElementType<TransitionProps>,
       TransitionProps & AccordionTransitionSlotPropsOverrides,
       AccordionOwnerState
     >;

--- a/packages/mui-material/src/Accordion/Accordion.spec.tsx
+++ b/packages/mui-material/src/Accordion/Accordion.spec.tsx
@@ -84,6 +84,16 @@ function Custom(props: AccordionProps) {
   );
 }
 
+// slotProps.transition should reject unknown props
+<Accordion
+  slotProps={{
+    // @ts-expect-error — unknown props should be rejected
+    transition: { randomInvalidProp: 'test' },
+  }}
+>
+  <div />
+</Accordion>;
+
 function Custom2(props: AccordionProps) {
   const { slotProps, ...other } = props;
   return (

--- a/packages/mui-material/src/Backdrop/Backdrop.d.ts
+++ b/packages/mui-material/src/Backdrop/Backdrop.d.ts
@@ -37,7 +37,7 @@ export type BackdropSlotsAndSlotProps = CreateSlotsAndSlotProps<
      * By default, the available props are based on the [Fade](https://mui.com/material-ui/api/fade/#props) component.
      */
     transition: SlotComponentProps<
-      React.ElementType,
+      React.ElementType<TransitionProps>,
       TransitionProps & BackdropTransitionSlotPropsOverrides,
       BackdropOwnerState
     >;

--- a/packages/mui-material/src/Backdrop/Backdrop.spec.tsx
+++ b/packages/mui-material/src/Backdrop/Backdrop.spec.tsx
@@ -1,0 +1,10 @@
+import Backdrop from '@mui/material/Backdrop';
+
+// slotProps.transition should reject unknown props
+<Backdrop
+  open
+  slotProps={{
+    // @ts-expect-error — unknown props should be rejected
+    transition: { randomInvalidProp: 'test' },
+  }}
+/>;

--- a/packages/mui-material/src/Dialog/Dialog.d.ts
+++ b/packages/mui-material/src/Dialog/Dialog.d.ts
@@ -68,7 +68,7 @@ export type DialogSlotsAndSlotProps = CreateSlotsAndSlotProps<
      * By default, the available props are based on the [Fade](https://mui.com/material-ui/api/fade/#props) component.
      */
     transition: SlotComponentProps<
-      React.ElementType,
+      React.ElementType<TransitionProps>,
       TransitionProps & DialogTransitionSlotPropsOverrides,
       DialogOwnerState
     >;

--- a/packages/mui-material/src/Dialog/Dialog.spec.tsx
+++ b/packages/mui-material/src/Dialog/Dialog.spec.tsx
@@ -15,6 +15,14 @@ function Test() {
     <React.Fragment>
       <Dialog open />;
       <Dialog open slotProps={{ paper: paperProps }} />;
+      <Dialog
+        open
+        slotProps={{
+          // @ts-expect-error — unknown props should be rejected
+          transition: { randomInvalidProp: 'test' },
+        }}
+      />
+      ;
     </React.Fragment>
   );
 }

--- a/packages/mui-material/src/Drawer/Drawer.d.ts
+++ b/packages/mui-material/src/Drawer/Drawer.d.ts
@@ -84,7 +84,7 @@ export type DrawerSlotsAndSlotProps = CreateSlotsAndSlotProps<
      * By default, the available props are based on the [Slide](https://mui.com/material-ui/api/slide/#props) component.
      */
     transition: SlotProps<
-      React.ElementType,
+      React.ElementType<TransitionProps>,
       TransitionProps & DrawerTransitionSlotPropsOverrides,
       DrawerOwnerState
     >;

--- a/packages/mui-material/src/Drawer/Drawer.spec.tsx
+++ b/packages/mui-material/src/Drawer/Drawer.spec.tsx
@@ -15,6 +15,14 @@ function Test() {
     <React.Fragment>
       <Drawer open />;
       <Drawer open slotProps={{ paper: paperProps }} />;
+      <Drawer
+        open
+        slotProps={{
+          // @ts-expect-error — unknown props should be rejected
+          transition: { randomInvalidProp: 'test' },
+        }}
+      />
+      ;
     </React.Fragment>
   );
 }

--- a/packages/mui-material/src/Menu/Menu.d.ts
+++ b/packages/mui-material/src/Menu/Menu.d.ts
@@ -73,7 +73,7 @@ export type MenuSlotsAndSlotProps = CreateSlotsAndSlotProps<
      */
     transition: SlotComponentProps<
       // use SlotComponentProps because transition slot does not support `component` and `sx` prop
-      React.ElementType,
+      React.ElementType<TransitionProps>,
       TransitionProps & MenuTransitionSlotPropsOverrides,
       MenuOwnerState
     >;

--- a/packages/mui-material/src/Menu/Menu.spec.tsx
+++ b/packages/mui-material/src/Menu/Menu.spec.tsx
@@ -1,5 +1,14 @@
 import Menu, { MenuProps } from '@mui/material/Menu';
 
+// slotProps.transition should reject unknown props
+<Menu
+  open
+  slotProps={{
+    // @ts-expect-error — unknown props should be rejected
+    transition: { randomInvalidProp: 'test' },
+  }}
+/>;
+
 <Menu
   open
   slotProps={{

--- a/packages/mui-material/src/Popover/Popover.d.ts
+++ b/packages/mui-material/src/Popover/Popover.d.ts
@@ -65,7 +65,7 @@ export type PopoverSlotsAndSlotProps = CreateSlotsAndSlotProps<
      */
     transition: SlotComponentProps<
       // use SlotComponentProps because transition slot does not support `component` and `sx` prop
-      React.ElementType,
+      React.ElementType<TransitionProps>,
       TransitionProps & PopoverTransitionSlotPropsOverrides,
       PopoverOwnerState
     >;

--- a/packages/mui-material/src/Popover/Popover.spec.tsx
+++ b/packages/mui-material/src/Popover/Popover.spec.tsx
@@ -13,7 +13,15 @@ function Test() {
   return (
     <React.Fragment>
       <Popover open />;
-      <Popover open slotProps={{ paper: paperProps }} />
+      <Popover open slotProps={{ paper: paperProps }} />;
+      <Popover
+        open
+        slotProps={{
+          // @ts-expect-error — unknown props should be rejected
+          transition: { randomInvalidProp: 'test' },
+        }}
+      />
+      ;
     </React.Fragment>
   );
 }

--- a/packages/mui-material/src/Snackbar/Snackbar.d.ts
+++ b/packages/mui-material/src/Snackbar/Snackbar.d.ts
@@ -69,7 +69,7 @@ export type SnackbarSlotsAndSlotProps = CreateSlotsAndSlotProps<
      * By default, the element is based on the [Grow](https://mui.com/material-ui/api/grow/#props) component.
      */
     transition: SlotComponentProps<
-      React.ElementType,
+      React.ElementType<TransitionProps>,
       TransitionProps & SnackbarTransitionSlotPropsOverrides,
       SnackbarOwnerState
     >;

--- a/packages/mui-material/src/Snackbar/Snackbar.spec.tsx
+++ b/packages/mui-material/src/Snackbar/Snackbar.spec.tsx
@@ -2,6 +2,14 @@ import { mergeSlotProps } from '@mui/material/utils';
 import Snackbar, { SnackbarProps } from '@mui/material/Snackbar';
 import { expectType } from '@mui/types';
 
+// slotProps.transition should reject unknown props
+<Snackbar
+  slotProps={{
+    // @ts-expect-error — unknown props should be rejected
+    transition: { randomInvalidProp: 'test' },
+  }}
+/>;
+
 <Snackbar
   slots={{
     root: 'dialog',

--- a/packages/mui-material/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.d.ts
@@ -36,7 +36,11 @@ export type SpeedDialSlotsAndSlotProps = CreateSlotsAndSlotProps<
      * Props forwarded to the transition slot.
      * By default, the available props are based on the [Zoom](https://mui.com/material-ui/api/zoom/#props) component.
      */
-    transition: SlotComponentProps<React.ElementType, TransitionProps, SpeedDialOwnerState>;
+    transition: SlotComponentProps<
+      React.ElementType<TransitionProps>,
+      TransitionProps,
+      SpeedDialOwnerState
+    >;
   }
 >;
 

--- a/packages/mui-material/src/SpeedDial/SpeedDial.spec.tsx
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.spec.tsx
@@ -1,0 +1,10 @@
+import SpeedDial from '@mui/material/SpeedDial';
+
+// slotProps.transition should reject unknown props
+<SpeedDial
+  ariaLabel="SpeedDial"
+  slotProps={{
+    // @ts-expect-error — unknown props should be rejected
+    transition: { randomInvalidProp: 'test' },
+  }}
+/>;

--- a/packages/mui-material/src/StepContent/StepContent.d.ts
+++ b/packages/mui-material/src/StepContent/StepContent.d.ts
@@ -25,7 +25,11 @@ export type StepContentSlotsAndSlotProps = CreateSlotsAndSlotProps<
      * Props forwarded to the transition slot.
      * By default, the available props are based on the [Collapse](https://mui.com/material-ui/api/collapse/#props) component
      */
-    transition: SlotComponentProps<React.ElementType, CollapseProps, StepContentOwnerState>;
+    transition: SlotComponentProps<
+      React.ElementType<CollapseProps>,
+      CollapseProps,
+      StepContentOwnerState
+    >;
   }
 >;
 

--- a/packages/mui-material/src/StepContent/StepContent.spec.tsx
+++ b/packages/mui-material/src/StepContent/StepContent.spec.tsx
@@ -7,6 +7,16 @@ import Grow from '@mui/material/Grow';
 import Slide from '@mui/material/Slide';
 import Zoom from '@mui/material/Zoom';
 
+// slotProps.transition should reject unknown props
+<StepContent
+  slotProps={{
+    // @ts-expect-error — unknown props should be rejected
+    transition: { randomInvalidProp: 'test' },
+  }}
+>
+  Step Content
+</StepContent>;
+
 <StepContent slots={{ transition: Fade }}>Step Content</StepContent>;
 <StepContent slots={{ transition: Collapse }}>Step Content</StepContent>;
 <StepContent slots={{ transition: Grow }}>Step Content</StepContent>;

--- a/packages/mui-material/src/Tooltip/Tooltip.d.ts
+++ b/packages/mui-material/src/Tooltip/Tooltip.d.ts
@@ -54,7 +54,7 @@ export type TooltipSlotsAndSlotProps = CreateSlotsAndSlotProps<
      * By default, the available props are based on the [Grow](https://mui.com/material-ui/api/grow/#props) component.
      */
     transition: SlotProps<
-      React.ElementType,
+      React.ElementType<TransitionProps>,
       TransitionProps & TooltipTransitionSlotPropsOverrides,
       TooltipOwnerState
     >;

--- a/packages/mui-material/src/Tooltip/Tooltip.spec.tsx
+++ b/packages/mui-material/src/Tooltip/Tooltip.spec.tsx
@@ -3,6 +3,17 @@ import { expectType } from '@mui/types';
 import { mergeSlotProps } from '@mui/material/utils';
 import Tooltip, { TooltipProps } from '@mui/material/Tooltip';
 
+// slotProps.transition should reject unknown props
+<Tooltip
+  title="Hello"
+  slotProps={{
+    // @ts-expect-error — unknown props should be rejected
+    transition: { randomInvalidProp: 'test' },
+  }}
+>
+  <button type="button">Hover or touch me</button>
+</Tooltip>;
+
 <Tooltip title="Hello">
   <button type="button">Hover or touch me</button>
 </Tooltip>;


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/48145

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
