### PR TITLE
[autocomplete] Fix helper text focusing input when clicked

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1340,6 +1340,18 @@ describe('<Autocomplete />', () => {
       expect(handleOpen.callCount).to.equal(1);
     });
 
+    it('should not focus the input when clicking helper text', async () => {
+      const { user } = render(
+        <Autocomplete
+          options={['one']}
+          renderInput={(params) => <TextField {...params} helperText="Some help" />}
+        />,
+      );
+
+      await user.click(screen.getByText('Some help'));
+      expect(screen.getByRole('combobox')).not.toHaveFocus();
+    });
+
     it('does not clear the textbox on Escape', () => {
       const handleChange = spy();
       render(

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -1151,6 +1151,10 @@ function useAutocomplete(props) {
     if (!event.currentTarget.contains(event.target)) {
       return;
     }
+    // Don't interfere with interactions outside the input area (e.g. helper text)
+    if (anchorEl && !anchorEl.contains(event.target)) {
+      return;
+    }
     if (event.target.getAttribute('id') !== id) {
       event.preventDefault();
     }
@@ -1160,6 +1164,10 @@ function useAutocomplete(props) {
   const handleClick = (event) => {
     // Prevent focusing the input if click is anywhere outside the Autocomplete
     if (!event.currentTarget.contains(event.target)) {
+      return;
+    }
+    // Don't interfere with interactions outside the input area (e.g. helper text)
+    if (anchorEl && !anchorEl.contains(event.target)) {
       return;
     }
     inputRef.current.focus();


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/26153

Testable here: https://deploy-preview-48156--material-ui.netlify.app/material-ui/react-autocomplete/ just add a `helperText` and click it, it no longer focuses the input

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
