### PR TITLE
[code-infra] Discover exports for bundle size report

### DIFF
--- a/test/bundle-size/bundle-size-checker.config.mjs
+++ b/test/bundle-size/bundle-size-checker.config.mjs
@@ -17,7 +17,7 @@ export default defineConfig(async () => {
       { id: '@mui/lab', expand: true },
       '@mui/private-theming',
       { id: '@mui/system', expand: true },
-      { id: '@mui/utils', expand: false },
+      { id: '@mui/utils', expand: true },
     ],
     upload: !!process.env.CI,
     comment: false,


### PR DESCRIPTION
We can use the existing exports fields to discover bundles to test.

This adds a bunch of new exports we check