### PR TITLE
[docs] Update menu examples to always have aria-expanded

### DIFF
--- a/docs/data/material/components/menus/AccountMenu.js
+++ b/docs/data/material/components/menus/AccountMenu.js
@@ -33,7 +33,7 @@ export default function AccountMenu() {
             sx={{ ml: 2 }}
             aria-controls={open ? 'account-menu' : undefined}
             aria-haspopup="true"
-            aria-expanded={open ? 'true' : undefined}
+            aria-expanded={open}
           >
             <Avatar sx={{ width: 32, height: 32 }}>M</Avatar>
           </IconButton>

--- a/docs/data/material/components/menus/AccountMenu.tsx
+++ b/docs/data/material/components/menus/AccountMenu.tsx
@@ -33,7 +33,7 @@ export default function AccountMenu() {
             sx={{ ml: 2 }}
             aria-controls={open ? 'account-menu' : undefined}
             aria-haspopup="true"
-            aria-expanded={open ? 'true' : undefined}
+            aria-expanded={open}
           >
             <Avatar sx={{ width: 32, height: 32 }}>M</Avatar>
           </IconButton>

--- a/docs/data/material/components/menus/BasicMenu.js
+++ b/docs/data/material/components/menus/BasicMenu.js
@@ -19,7 +19,7 @@ export default function BasicMenu() {
         id="basic-button"
         aria-controls={open ? 'basic-menu' : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open}
         onClick={handleClick}
       >
         Dashboard

--- a/docs/data/material/components/menus/BasicMenu.tsx
+++ b/docs/data/material/components/menus/BasicMenu.tsx
@@ -19,7 +19,7 @@ export default function BasicMenu() {
         id="basic-button"
         aria-controls={open ? 'basic-menu' : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open}
         onClick={handleClick}
       >
         Dashboard

--- a/docs/data/material/components/menus/CustomizedMenus.js
+++ b/docs/data/material/components/menus/CustomizedMenus.js
@@ -72,7 +72,7 @@ export default function CustomizedMenus() {
         id="demo-customized-button"
         aria-controls={open ? 'demo-customized-menu' : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open}
         variant="contained"
         disableElevation
         onClick={handleClick}

--- a/docs/data/material/components/menus/CustomizedMenus.tsx
+++ b/docs/data/material/components/menus/CustomizedMenus.tsx
@@ -72,7 +72,7 @@ export default function CustomizedMenus() {
         id="demo-customized-button"
         aria-controls={open ? 'demo-customized-menu' : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open}
         variant="contained"
         disableElevation
         onClick={handleClick}

--- a/docs/data/material/components/menus/FadeMenu.js
+++ b/docs/data/material/components/menus/FadeMenu.js
@@ -20,7 +20,7 @@ export default function FadeMenu() {
         id="fade-button"
         aria-controls={open ? 'fade-menu' : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open}
         onClick={handleClick}
       >
         Dashboard

--- a/docs/data/material/components/menus/FadeMenu.tsx
+++ b/docs/data/material/components/menus/FadeMenu.tsx
@@ -20,7 +20,7 @@ export default function FadeMenu() {
         id="fade-button"
         aria-controls={open ? 'fade-menu' : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open}
         onClick={handleClick}
       >
         Dashboard

--- a/docs/data/material/components/menus/GroupedMenu.js
+++ b/docs/data/material/components/menus/GroupedMenu.js
@@ -25,7 +25,7 @@ export default function GroupedMenu() {
         id="basic-button"
         aria-controls={open ? 'grouped-menu' : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open}
         onClick={handleClick}
       >
         Dashboard

--- a/docs/data/material/components/menus/GroupedMenu.tsx
+++ b/docs/data/material/components/menus/GroupedMenu.tsx
@@ -25,7 +25,7 @@ export default function GroupedMenu() {
         id="basic-button"
         aria-controls={open ? 'grouped-menu' : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open}
         onClick={handleClick}
       >
         Dashboard

--- a/docs/data/material/components/menus/LongMenu.js
+++ b/docs/data/material/components/menus/LongMenu.js
@@ -39,7 +39,7 @@ export default function LongMenu() {
         aria-label="more"
         id="long-button"
         aria-controls={open ? 'long-menu' : undefined}
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open}
         aria-haspopup="true"
         onClick={handleClick}
       >

--- a/docs/data/material/components/menus/LongMenu.tsx
+++ b/docs/data/material/components/menus/LongMenu.tsx
@@ -39,7 +39,7 @@ export default function LongMenu() {
         aria-label="more"
         id="long-button"
         aria-controls={open ? 'long-menu' : undefined}
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open}
         aria-haspopup="true"
         onClick={handleClick}
       >

--- a/docs/data/material/components/menus/MenuListComposition.js
+++ b/docs/data/material/components/menus/MenuListComposition.js
@@ -57,7 +57,7 @@ export default function MenuListComposition() {
           ref={anchorRef}
           id="composition-button"
           aria-controls={open ? 'composition-menu' : undefined}
-          aria-expanded={open ? 'true' : undefined}
+          aria-expanded={open}
           aria-haspopup="true"
           onClick={handleToggle}
         >

--- a/docs/data/material/components/menus/MenuListComposition.tsx
+++ b/docs/data/material/components/menus/MenuListComposition.tsx
@@ -60,7 +60,7 @@ export default function MenuListComposition() {
           ref={anchorRef}
           id="composition-button"
           aria-controls={open ? 'composition-menu' : undefined}
-          aria-expanded={open ? 'true' : undefined}
+          aria-expanded={open}
           aria-haspopup="true"
           onClick={handleToggle}
         >

--- a/docs/data/material/components/menus/PositionedMenu.js
+++ b/docs/data/material/components/menus/PositionedMenu.js
@@ -19,7 +19,7 @@ export default function PositionedMenu() {
         id="demo-positioned-button"
         aria-controls={open ? 'demo-positioned-menu' : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open}
         onClick={handleClick}
       >
         Dashboard

--- a/docs/data/material/components/menus/PositionedMenu.tsx
+++ b/docs/data/material/components/menus/PositionedMenu.tsx
@@ -19,7 +19,7 @@ export default function PositionedMenu() {
         id="demo-positioned-button"
         aria-controls={open ? 'demo-positioned-menu' : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open}
         onClick={handleClick}
       >
         Dashboard

--- a/docs/data/material/components/menus/SimpleListMenu.js
+++ b/docs/data/material/components/menus/SimpleListMenu.js
@@ -41,7 +41,7 @@ export default function SimpleListMenu() {
           aria-haspopup="listbox"
           aria-controls="lock-menu"
           aria-label="when device is locked"
-          aria-expanded={open ? 'true' : undefined}
+          aria-expanded={open}
           onClick={handleClickListItem}
         >
           <ListItemText

--- a/docs/data/material/components/menus/SimpleListMenu.tsx
+++ b/docs/data/material/components/menus/SimpleListMenu.tsx
@@ -44,7 +44,7 @@ export default function SimpleListMenu() {
           aria-haspopup="listbox"
           aria-controls="lock-menu"
           aria-label="when device is locked"
-          aria-expanded={open ? 'true' : undefined}
+          aria-expanded={open}
           onClick={handleClickListItem}
         >
           <ListItemText


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Partial improvement for https://github.com/mui/material-ui/issues/34074. The menu button will be announced as collapsed. We are also aligning with the a11y pattern and BaseUI.
