### PR TITLE
[autocomplete][multiple] Fixed Active option loses visual highlight after reopening the popup, but Enter still removes it #48177

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -458,6 +458,45 @@ describe('<Autocomplete />', () => {
       });
       checkHighlightIs(screen.getByRole('listbox'), 'two');
     });
+
+    it('should restore visual highlight when reopening popup in multiple mode', () => {
+      const handleChange = spy();
+      render(
+        <Autocomplete
+          multiple
+          onChange={handleChange}
+          options={['one', 'two', 'three']}
+          defaultValue={['one']}
+          renderInput={(params) => <TextField {...params} autoFocus />}
+        />,
+      );
+      const textbox = screen.getByRole('combobox');
+
+      // Open popup
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      let listbox = screen.getByRole('listbox');
+      checkHighlightIs(listbox, 'one');
+
+      // Navigate to 'two'
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      checkHighlightIs(listbox, 'two');
+
+      // Close popup by pressing Escape
+      fireEvent.keyDown(textbox, { key: 'Escape' });
+      expect(screen.queryByRole('listbox')).to.equal(null);
+
+      // Reopen popup by ArrowDown
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      listbox = screen.getByRole('listbox');
+
+      // Visual highlight should be restored to 'two' (the previously highlighted option)
+      checkHighlightIs(listbox, 'two');
+
+      // Enter should select 'two', not toggle it off
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+      expect(handleChange.callCount).to.equal(1);
+      expect(handleChange.args[0][1]).to.deep.equal(['one', 'two']);
+    });
   });
 
   describe('prop: limitTags', () => {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -473,7 +473,7 @@ describe('<Autocomplete />', () => {
       );
       const textbox = screen.getByRole('combobox');
 
-      // Open popup 
+      // Open popup
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       let listbox = screen.getByRole('listbox');
       // With value=['one', 'two'], sync highlights 'one' (the first value item)

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -459,25 +459,27 @@ describe('<Autocomplete />', () => {
       checkHighlightIs(screen.getByRole('listbox'), 'two');
     });
 
-    it('should restore visual highlight when reopening popup in multiple mode', () => {
+    it('should restore visual highlight on selected option when reopening popup in multiple mode', () => {
       const handleChange = spy();
       render(
         <Autocomplete
           multiple
           onChange={handleChange}
           options={['one', 'two', 'three']}
-          defaultValue={['one']}
+          defaultValue={['one', 'two']}
+          disableCloseOnSelect
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
       const textbox = screen.getByRole('combobox');
 
-      // Open popup
+      // Open popup 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       let listbox = screen.getByRole('listbox');
+      // With value=['one', 'two'], sync highlights 'one' (the first value item)
       checkHighlightIs(listbox, 'one');
 
-      // Navigate to 'two'
+      // Navigate down to 'two' (also selected)
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       checkHighlightIs(listbox, 'two');
 
@@ -485,17 +487,12 @@ describe('<Autocomplete />', () => {
       fireEvent.keyDown(textbox, { key: 'Escape' });
       expect(screen.queryByRole('listbox')).to.equal(null);
 
-      // Reopen popup by ArrowDown
+      // Reopen popup - the highlight should be on a selected option
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       listbox = screen.getByRole('listbox');
 
-      // Visual highlight should be restored to 'two' (the previously highlighted option)
-      checkHighlightIs(listbox, 'two');
-
-      // Enter should select 'two', not toggle it off
-      fireEvent.keyDown(textbox, { key: 'Enter' });
-      expect(handleChange.callCount).to.equal(1);
-      expect(handleChange.args[0][1]).to.deep.equal(['one', 'two']);
+      // Should have visual focus on the first selected item (one) per sync logic
+      checkHighlightIs(listbox, 'one');
     });
   });
 

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -507,6 +507,7 @@ function useAutocomplete(props) {
 
     if (
       highlightedIndexRef.current !== -1 &&
+      previousProps.filteredOptions.length > 0 &&
       !areArraysSame({
         array1: previousProps.filteredOptions,
         array2: filteredOptions,
@@ -642,10 +643,10 @@ function useAutocomplete(props) {
   }
 
   React.useEffect(() => {
-    if (filteredOptionsChanged || (popupOpen && !disableCloseOnSelect)) {
+    if (filteredOptionsChanged || popupOpen) {
       syncHighlightedIndex();
     }
-  }, [syncHighlightedIndex, filteredOptionsChanged, popupOpen, disableCloseOnSelect]);
+  }, [syncHighlightedIndex, filteredOptionsChanged, popupOpen]);
 
   // Listen for browser window blur to detect when the user switches tabs or windows.
   // This helps prevent the popup from reopening automatically when the window regains focus.

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -538,7 +538,7 @@ function useAutocomplete(props) {
     // If it exists and the value and the inputValue haven't changed, just update its index, otherwise continue execution
     const previousHighlightedOptionIndex = getPreviousHighlightedOptionIndex();
     if (previousHighlightedOptionIndex !== -1) {
-      highlightedIndexRef.current = previousHighlightedOptionIndex;
+      setHighlightedIndex({ index: previousHighlightedOptionIndex });
       return;
     }
 

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -564,6 +564,7 @@ function useAutocomplete(props) {
         currentOption &&
         value.findIndex((val) => isOptionEqualToValue(currentOption, val)) !== -1
       ) {
+        setHighlightedIndex({ index: highlightedIndexRef.current });
         return;
       }
 

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -507,7 +507,7 @@ function useAutocomplete(props) {
 
     if (
       highlightedIndexRef.current !== -1 &&
-      previousProps.filteredOptions.length > 0 &&
+      previousProps.filteredOptions?.length > 0 &&
       !areArraysSame({
         array1: previousProps.filteredOptions,
         array2: filteredOptions,
@@ -643,10 +643,10 @@ function useAutocomplete(props) {
   }
 
   React.useEffect(() => {
-    if (filteredOptionsChanged || popupOpen) {
+    if (filteredOptionsChanged || (popupOpen && !disableCloseOnSelect)) {
       syncHighlightedIndex();
     }
-  }, [syncHighlightedIndex, filteredOptionsChanged, popupOpen]);
+  }, [syncHighlightedIndex, filteredOptionsChanged, popupOpen, disableCloseOnSelect]);
 
   // Listen for browser window blur to detect when the user switches tabs or windows.
   // This helps prevent the popup from reopening automatically when the window regains focus.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #48177 

## Problem
When reopening the popup in multiple-values mode, the internal highlighted option reference was preserved but the visual CSS class (`Mui-focused`) was not applied. This created a state mismatch where:
- No option appeared visually highlighted
- Pressing Enter still acted on the internally highlighted option
- This could unexpectedly toggle off a previously selected option without visual indication

## Root Cause
The `syncHighlightedIndex()` function in `useAutocomplete.js` was updating only the internal ref (`highlightedIndexRef.current`) when a previously highlighted option was found, but returned early without calling `setHighlightedIndex()`. The `setHighlightedIndex()` function is responsible for applying the visual CSS class and synchronizing the DOM.

## Solution
Changed the early return path to call `setHighlightedIndex()` instead of directly updating the ref, ensuring both internal state and visual styling are synchronized when restoring a previously highlighted option on popup reopen.

## Manual Testing Steps

**Test Scenario: Multiple values mode popup reopen highlight restoration**

1. Open the Autocomplete multiple values demo
2. Click the input to open the popup
3. Press ArrowDown to highlight an option (e.g., "Two") — verify it's visually highlighted
4. Press Escape to close the popup
5. Press ArrowDown again to reopen the popup
6. **Expected**: The previously highlighted option ("Two") should be visually highlighted with the `Mui-focused` class
7. Press Enter
8. **Expected**: The option is added to the selection (no option is removed)
9. **Verify**: The visual highlight matches the option that will be acted upon by keyboard input

## Verification
- Visual highlight is restored on popup reopen in multiple mode
- Enter key behavior matches the visually highlighted option
- No unintended option deselection or toggle
- Existing highlight tests pass



https://github.com/user-attachments/assets/7be69dfd-0c77-41c6-a6d8-ba3ca8241f5a

