### PR TITLE
[docs] Improve accessibility for select examples

### DIFF
--- a/docs/data/material/components/selects/SelectLabels.js
+++ b/docs/data/material/components/selects/SelectLabels.js
@@ -17,6 +17,7 @@ export default function SelectLabels() {
       <FormControl sx={{ m: 1, minWidth: 120 }}>
         <InputLabel id="demo-simple-select-helper-label">Age</InputLabel>
         <Select
+          aria-describedby="demo-simple-select-helper-text"
           labelId="demo-simple-select-helper-label"
           id="demo-simple-select-helper"
           value={age}
@@ -30,14 +31,17 @@ export default function SelectLabels() {
           <MenuItem value={20}>Twenty</MenuItem>
           <MenuItem value={30}>Thirty</MenuItem>
         </Select>
-        <FormHelperText>With label + helper text</FormHelperText>
+        <FormHelperText id="demo-simple-select-helper-text">
+          Visible label and helper text
+        </FormHelperText>
       </FormControl>
       <FormControl sx={{ m: 1, minWidth: 120 }}>
         <Select
+          aria-describedby="demo-no-label-select-helper-text"
           value={age}
           onChange={handleChange}
           displayEmpty
-          inputProps={{ 'aria-label': 'Without label' }}
+          inputProps={{ 'aria-label': 'Age' }}
         >
           <MenuItem value="">
             <em>None</em>
@@ -46,7 +50,9 @@ export default function SelectLabels() {
           <MenuItem value={20}>Twenty</MenuItem>
           <MenuItem value={30}>Thirty</MenuItem>
         </Select>
-        <FormHelperText>Without label</FormHelperText>
+        <FormHelperText id="demo-no-label-select-helper-text">
+          aria-label and helper text
+        </FormHelperText>
       </FormControl>
     </div>
   );

--- a/docs/data/material/components/selects/SelectLabels.tsx
+++ b/docs/data/material/components/selects/SelectLabels.tsx
@@ -17,6 +17,7 @@ export default function SelectLabels() {
       <FormControl sx={{ m: 1, minWidth: 120 }}>
         <InputLabel id="demo-simple-select-helper-label">Age</InputLabel>
         <Select
+          aria-describedby="demo-simple-select-helper-text"
           labelId="demo-simple-select-helper-label"
           id="demo-simple-select-helper"
           value={age}
@@ -30,14 +31,17 @@ export default function SelectLabels() {
           <MenuItem value={20}>Twenty</MenuItem>
           <MenuItem value={30}>Thirty</MenuItem>
         </Select>
-        <FormHelperText>With label + helper text</FormHelperText>
+        <FormHelperText id="demo-simple-select-helper-text">
+          Visible label and helper text
+        </FormHelperText>
       </FormControl>
       <FormControl sx={{ m: 1, minWidth: 120 }}>
         <Select
+          aria-describedby="demo-no-label-select-helper-text"
           value={age}
           onChange={handleChange}
           displayEmpty
-          inputProps={{ 'aria-label': 'Without label' }}
+          inputProps={{ 'aria-label': 'Age' }}
         >
           <MenuItem value="">
             <em>None</em>
@@ -46,7 +50,9 @@ export default function SelectLabels() {
           <MenuItem value={20}>Twenty</MenuItem>
           <MenuItem value={30}>Thirty</MenuItem>
         </Select>
-        <FormHelperText>Without label</FormHelperText>
+        <FormHelperText id="demo-no-label-select-helper-text">
+          aria-label and helper text
+        </FormHelperText>
       </FormControl>
     </div>
   );

--- a/docs/data/material/components/selects/SelectVariants.js
+++ b/docs/data/material/components/selects/SelectVariants.js
@@ -13,6 +13,23 @@ export default function SelectVariants() {
 
   return (
     <div>
+      <FormControl variant="outlined" sx={{ m: 1, minWidth: 120 }}>
+        <InputLabel id="demo-simple-select-outlined-label">Age</InputLabel>
+        <Select
+          labelId="demo-simple-select-outlined-label"
+          id="demo-simple-select-outlined"
+          value={age}
+          onChange={handleChange}
+          label="Age"
+        >
+          <MenuItem value="">
+            <em>None</em>
+          </MenuItem>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>
+      </FormControl>
       <FormControl variant="standard" sx={{ m: 1, minWidth: 120 }}>
         <InputLabel id="demo-simple-select-standard-label">Age</InputLabel>
         <Select
@@ -20,7 +37,6 @@ export default function SelectVariants() {
           id="demo-simple-select-standard"
           value={age}
           onChange={handleChange}
-          label="Age"
         >
           <MenuItem value="">
             <em>None</em>

--- a/docs/data/material/components/selects/SelectVariants.tsx
+++ b/docs/data/material/components/selects/SelectVariants.tsx
@@ -13,6 +13,23 @@ export default function SelectVariants() {
 
   return (
     <div>
+      <FormControl variant="outlined" sx={{ m: 1, minWidth: 120 }}>
+        <InputLabel id="demo-simple-select-outlined-label">Age</InputLabel>
+        <Select
+          labelId="demo-simple-select-outlined-label"
+          id="demo-simple-select-outlined"
+          value={age}
+          onChange={handleChange}
+          label="Age"
+        >
+          <MenuItem value="">
+            <em>None</em>
+          </MenuItem>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>
+      </FormControl>
       <FormControl variant="standard" sx={{ m: 1, minWidth: 120 }}>
         <InputLabel id="demo-simple-select-standard-label">Age</InputLabel>
         <Select
@@ -20,7 +37,6 @@ export default function SelectVariants() {
           id="demo-simple-select-standard"
           value={age}
           onChange={handleChange}
-          label="Age"
         >
           <MenuItem value="">
             <em>None</em>

--- a/docs/data/material/components/selects/selects.md
+++ b/docs/data/material/components/selects/selects.md
@@ -47,7 +47,7 @@ Note that when using FormControl with the outlined variant of the Select, you ne
 
 ### Labels and helper text
 
-Select always needs a label, either visible or through `aria-label`. If more information is needed, provide a helper text element and link it to the `Select` using `aria-describedby`.
+Select always needs an accessible name. This can come from an associated visible label, such as an `InputLabel` linked to the `Select` with `labelId` or from adding an `aria-label` prop to the `input` slot. If more information is needed, provide a helper text element and link it to the `Select` using `aria-describedby`.
 
 {{"demo": "SelectLabels.js"}}
 

--- a/docs/data/material/components/selects/selects.md
+++ b/docs/data/material/components/selects/selects.md
@@ -37,17 +37,19 @@ It shares the same styles and many of the same props. Refer to the respective co
 Unlike input components, the `placeholder` prop is not available in Select. To add a placeholder, refer to the [placeholder](#placeholder) section below.
 :::
 
-### Filled and standard variants
+### Variants
 
 {{"demo": "SelectVariants.js"}}
 
+:::warning
+Note that when using FormControl with the outlined variant of the Select, you need to provide a label in two places: in the InputLabel component and in the `label` prop of the Select component (see the above demo). This is needed for the label floating animation to work correctly.
+:::
+
 ### Labels and helper text
 
-{{"demo": "SelectLabels.js"}}
+Select always needs a label, either visible or through `aria-label`. If more information is needed, provide a helper text element and link it to the `Select` using `aria-describedby`.
 
-:::warning
-Note that when using FormControl with the outlined variant of the Select, you need to provide a label in two places: in the InputLabel component and in the `label` prop of the Select component (see the above demo).
-:::
+{{"demo": "SelectLabels.js"}}
 
 ### Auto width
 

--- a/docs/data/material/components/selects/selects.md
+++ b/docs/data/material/components/selects/selects.md
@@ -47,7 +47,7 @@ Note that when using FormControl with the outlined variant of the Select, you ne
 
 ### Labels and helper text
 
-Select always needs an accessible name. This can come from an associated visible label, such as an `InputLabel` linked to the `Select` with `labelId` or from adding an `aria-label` prop to the `input` slot. If more information is needed, provide a helper text element and link it to the `Select` using `aria-describedby`.
+Select always needs an accessible name. This can come from an associated visible label, such as an `InputLabel` linked to the `Select` with `labelId` or from adding an `aria-label` prop to the input element props (`inputProps`). If more information is needed, provide a helper text element and link it to the `Select` using `aria-describedby`.
 
 {{"demo": "SelectLabels.js"}}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

- link helper text elements with Select components.
- show an outline variant for the Select
- improve the label prop related text and move it to the right section
