### PR TITLE
[docs] Improve CSP guide with required directives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,7 @@ import { Button } from '@mui/material'; // Avoid in packages
 4. `pnpm test:unit` - Pass unit tests
 5. If API changed: `pnpm proptypes && pnpm docs:api`
 6. If demos changed: `pnpm docs:typescript:formatted`
+7. If `.md` files changed: `pnpm vale <file1> <file2> ...` - Check prose style and grammar
 
 ## PR Title Format
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,18 +162,6 @@ import Button from '@mui/material/Button'; // Good
 import { Button } from '@mui/material'; // Avoid in packages
 ```
 
-## Writing Style (Vale)
-
-Documentation prose is linted by [Vale](https://vale.sh/). Configuration:
-
-- **Config file:** `.vale.ini` (repo root)
-- **Custom styles:** `docs/mui-vale/styles/MUI/` (YAML rules)
-
-Key rules to follow when writing Markdown docs:
-
-- Use a **non-breaking space** (`\u00a0`, Option+Space on Mac) in brand names: `Material\u00a0UI`, `Base\u00a0UI`, `Joy\u00a0UI`, `MUI\u00a0X`
-- Run `pnpm vale docs/path/to/file.md` to check a specific file
-
 ## Pre-PR Checklist
 
 1. `pnpm prettier` - Format code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,18 @@ import Button from '@mui/material/Button'; // Good
 import { Button } from '@mui/material'; // Avoid in packages
 ```
 
+## Writing Style (Vale)
+
+Documentation prose is linted by [Vale](https://vale.sh/). Configuration:
+
+- **Config file:** `.vale.ini` (repo root)
+- **Custom styles:** `docs/mui-vale/styles/MUI/` (YAML rules)
+
+Key rules to follow when writing Markdown docs:
+
+- Use a **non-breaking space** (`\u00a0`, Option+Space on Mac) in brand names: `Material\u00a0UI`, `Base\u00a0UI`, `Joy\u00a0UI`, `MUI\u00a0X`
+- Run `pnpm vale docs/path/to/file.md` to check a specific file
+
 ## Pre-PR Checklist
 
 1. `pnpm prettier` - Format code

--- a/docs/data/material/guides/content-security-policy/content-security-policy.md
+++ b/docs/data/material/guides/content-security-policy/content-security-policy.md
@@ -36,7 +36,7 @@ Content-Security-Policy:
 With a server, you can generate a unique nonce per request for tighter security. Material UI requires the following CSP directives:
 
 - **`style-src-elem 'nonce-<base64>'`** — Material UI uses [Emotion](https://emotion.sh/) to inject `<style>` tags. Each tag needs a matching nonce.
-- **`style-src-attr 'unsafe-inline'`** — Some components apply inline `style` attributes for dynamic values (CSS custom properties, dimensions, positioning). This is only needed with server-side rendering (SSR). In client-only apps, React uses the CSSOM API which is not subject to CSP.
+- **`style-src-attr 'unsafe-inline'`** — Some components apply inline `style` attributes for dynamic values (CSS custom properties, dimensions, positioning).
 - **`script-src 'nonce-<base64>'`** — Only needed if you use `InitColorSchemeScript`, which renders an inline `<script>`.
 
 A complete CSP header might look like this:

--- a/docs/data/material/guides/content-security-policy/content-security-policy.md
+++ b/docs/data/material/guides/content-security-policy/content-security-policy.md
@@ -22,7 +22,7 @@ CSP is optional. Material UI works without any CSP configuration. If your proje
 
 ## Static websites
 
-If you host your site statically (for example, GitHub Pages, S3, or any CDN-only setup), you cannot use nonces because there is no server to generate a unique value per request. In that case, `'unsafe-inline'` is the only option:
+If you host your site statically (for example, S3 or any CDN-only setup), you cannot use nonces because there is no server to generate a unique value per request. In that case, `'unsafe-inline'` is the only option:
 
 ```text
 Content-Security-Policy:
@@ -31,7 +31,7 @@ Content-Security-Policy:
   script-src 'self' 'unsafe-inline';
 ```
 
-## Dynamic websites
+## Server-Side Rendering (SSR)
 
 With a server, you can generate a unique nonce per request for tighter security. Material UI requires the following CSP directives:
 

--- a/docs/data/material/guides/content-security-policy/content-security-policy.md
+++ b/docs/data/material/guides/content-security-policy/content-security-policy.md
@@ -16,14 +16,42 @@ This vulnerability would allow the attacker to execute anything. However, with a
 
 You can read more about CSP on the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP).
 
-## How does one implement CSP?
+:::info
+CSP is optional. Material UI works without any CSP configuration. If your project doesn't require CSP, you can skip this guide entirely.
+:::
 
-### Server-Side Rendering (SSR)
+## Static websites
 
-To use CSP with Material UI (and Emotion), you need to use a nonce.
-A nonce is a randomly generated string that is only used once, therefore you need to add server middleware to generate one on each request.
+If you host your site statically (for example, GitHub Pages, S3, or any CDN-only setup), you cannot use nonces because there is no server to generate a unique value per request. In that case, `'unsafe-inline'` is the only option:
 
-A CSP nonce is a Base 64 encoded string. You can generate one like this:
+```text
+Content-Security-Policy:
+  default-src 'self';
+  style-src 'self' 'unsafe-inline';
+  script-src 'self' 'unsafe-inline';
+```
+
+## Dynamic websites
+
+With a server, you can generate a unique nonce per request for tighter security. Material UI requires the following CSP directives:
+
+- **`style-src-elem 'nonce-<base64>'`** — Material UI uses [Emotion](https://emotion.sh/) to inject `<style>` tags. Each tag needs a matching nonce.
+- **`style-src-attr 'unsafe-inline'`** — Some components apply inline `style` attributes for dynamic values (CSS custom properties, dimensions, positioning). This is only needed with server-side rendering (SSR). In client-only apps, React uses the CSSOM API which is not subject to CSP.
+- **`script-src 'nonce-<base64>'`** — Only needed if you use `InitColorSchemeScript`, which renders an inline `<script>`.
+
+A complete CSP header might look like this:
+
+```text
+Content-Security-Policy:
+  default-src 'self';
+  style-src-elem 'self' 'nonce-<base64>';
+  style-src-attr 'unsafe-inline';
+  script-src 'self' 'nonce-<base64>';
+```
+
+### Setting up the nonce
+
+A nonce is a randomly generated string that is only used once. You need to add server middleware to generate a new one on each request. A CSP nonce is a Base 64 encoded string. You can generate one like this:
 
 ```js
 import crypto from 'node:crypto';
@@ -33,11 +61,11 @@ const nonce = crypto.randomBytes(16).toString('base64'); // 128 bits of entropy
 
 This generates a value that satisfies the [W3C CSP specification](https://w3c.github.io/webappsec-csp/#security-nonces) guidelines.
 
-You then apply this nonce to the CSP header. A CSP header might look like this with the nonce applied:
+You then apply this nonce to the CSP header:
 
 ```js
 header('Content-Security-Policy').set(
-  `default-src 'self'; style-src 'self' 'nonce-${nonce}';`,
+  `default-src 'self'; style-src-elem 'self' 'nonce-${nonce}'; style-src-attr 'unsafe-inline'; script-src 'self' 'nonce-${nonce}';`,
 );
 ```
 
@@ -73,7 +101,7 @@ function App(props) {
 }
 ```
 
-### CSP in Vite
+### Vite
 
 When deploying a CSP using Vite, there are specific configurations you must set up due to Vite's internal handling of assets and modules.
 See [Vite Features—Content Security Policy](https://vite.dev/guide/features.html#content-security-policy-csp) for complete details.

--- a/docs/data/material/guides/content-security-policy/content-security-policy.md
+++ b/docs/data/material/guides/content-security-policy/content-security-policy.md
@@ -17,7 +17,7 @@ This vulnerability would allow the attacker to execute anything. However, with a
 You can read more about CSP on the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP).
 
 :::info
-CSP is optional. Material UI works without any CSP configuration. If your project doesn't require CSP, you can skip this guide entirely.
+CSP is optional. Material UI works without any CSP configuration. If your project doesn't require CSP, you can skip this guide entirely.
 :::
 
 ## Static websites
@@ -33,9 +33,9 @@ Content-Security-Policy:
 
 ## Dynamic websites
 
-With a server, you can generate a unique nonce per request for tighter security. Material UI requires the following CSP directives:
+With a server, you can generate a unique nonce per request for tighter security. Material UI requires the following CSP directives:
 
-- **`style-src-elem 'nonce-<base64>'`** — Material UI uses [Emotion](https://emotion.sh/) to inject `<style>` tags. Each tag needs a matching nonce.
+- **`style-src-elem 'nonce-<base64>'`** — Material UI uses [Emotion](https://emotion.sh/) to inject `<style>` tags. Each tag needs a matching nonce.
 - **`style-src-attr 'unsafe-inline'`** — Some components apply inline `style` attributes for dynamic values (CSS custom properties, dimensions, positioning).
 - **`script-src 'nonce-<base64>'`** — Only needed if you use `InitColorSchemeScript`, which renders an inline `<script>`.
 

--- a/docs/data/material/guides/content-security-policy/content-security-policy.md
+++ b/docs/data/material/guides/content-security-policy/content-security-policy.md
@@ -49,6 +49,10 @@ Content-Security-Policy:
   script-src 'self' 'nonce-<base64>';
 ```
 
+:::info
+Some security scanners flag `style-src-attr 'unsafe-inline'` as a vulnerability. While inline styles can theoretically be used for [CSS-based data exfiltration](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/style-src#unsafe_inline_styles), this requires an attacker to already be able to inject HTML into your page. If your application properly sanitizes user input, `style-src-attr 'unsafe-inline'` does not introduce a meaningful security risk on its own.
+:::
+
 ### Setting up the nonce
 
 A nonce is a randomly generated string that is only used once. You need to add server middleware to generate a new one on each request. A CSP nonce is a Base 64 encoded string. You can generate one like this:


### PR DESCRIPTION
## Summary

- Restructure the CSP guide around static vs. dynamic website setups
- Add a "Required directives" section explaining `style-src-elem`, `style-src-attr`, and `script-src`
- Clarify that `style-src-attr 'unsafe-inline'` is only needed for SSR (React's CSSOM API is CSP-safe in client-only apps)
- Add static hosting guidance (nonces require a server)
- Add "CSP is optional" callout