### PR TITLE
[docs] Restore wider maxWidth for `disableToc` pages

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -74,7 +74,7 @@ const StyledAppContainer = styled(AppContainer, {
         props: ({ disableToc, wideLayout }) => disableToc && !wideLayout,
         style: {
           // 105ch ≈ 930px
-          maxWidth: '105ch',
+          maxWidth: `calc(105ch + ${TOC_WIDTH / 2}px)`,
         },
       },
       {


### PR DESCRIPTION
- Adjusts the `maxWidth` calculation for pages with `disableToc` enabled
- Changes from fixed `105ch` to `calc(105ch + ${TOC_WIDTH / 2}px)` to accommodate the space previously occupied by the table of contents
- Improves layout consistency when the TOC is disabled

This is the particular change: https://github.com/mui/material-ui/pull/48159/changes#diff-887bd243079b0617f6c0b9125c7ef12adc7b06d155709b0ec775ea496de5e105R77

This also affected the Material Icons page:

| v7 | v9 |
|--------|--------|
| <img width="1017" height="1279" alt="Screenshot 2026-04-10 at 15 23 51" src="https://github.com/user-attachments/assets/1f70b37d-8781-412d-93d6-546185dc7af4" /> | <img width="850" height="1276" alt="Screenshot 2026-04-10 at 15 24 19" src="https://github.com/user-attachments/assets/ffcb6222-84ca-4e0f-a0f7-2f9c578c495e" /> | 