### PR TITLE
[system] Fix theme mutation when using responsive typography shorthand in sx

### DIFF
--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.js
@@ -126,7 +126,7 @@ function setThemeValue(css, prop, value, theme, config) {
 
     if (cssProperty === false) {
       if (mediaKey) {
-        css[mediaKey] = finalValue;
+        merge(css[mediaKey], finalValue);
       } else {
         merge(css, finalValue);
       }

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
@@ -115,15 +115,81 @@ describe('styleFunctionSx', () => {
       });
     });
 
-    it('does not mutate theme.typography when using responsive typography shorthand', () => {
+    it('does not mutate theme.typography when using responsive typography shorthand (object syntax)', () => {
       const body1Before = { ...theme.typography.body1 };
 
-      styleFunctionSx({
+      const result = styleFunctionSx({
         theme,
         sx: { typography: { sm: 'body1' }, width: { sm: '80%' }, mt: { sm: 4 } },
       });
 
+      // Theme must not be mutated
       expect(theme.typography.body1).to.deep.equal(body1Before);
+
+      // Output must contain both typography and sibling sx properties
+      expect(result).to.deep.equal({
+        '@media (min-width:600px)': {
+          fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+          fontSize: '1rem',
+          letterSpacing: `${round(0.15 / 16)}em`,
+          fontWeight: 400,
+          lineHeight: 1.5,
+          width: '80%',
+          marginTop: '40px',
+        },
+      });
+    });
+
+    it('does not mutate theme.typography when using responsive typography shorthand (array syntax)', () => {
+      const body2Before = { ...theme.typography.body2 };
+      const body1Before = { ...theme.typography.body1 };
+
+      const result = styleFunctionSx({
+        theme,
+        sx: { typography: ['body2', 'body1'], width: ['50%', '80%'] },
+      });
+
+      // Theme must not be mutated
+      expect(theme.typography.body2).to.deep.equal(body2Before);
+      expect(theme.typography.body1).to.deep.equal(body1Before);
+
+      // Output must contain both typography and sibling sx properties
+      expect(result).to.deep.equal({
+        '@media (min-width:0px)': {
+          fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+          fontSize: `${14 / 16}rem`,
+          letterSpacing: `${round(0.15 / 14)}em`,
+          fontWeight: 400,
+          lineHeight: 1.43,
+          width: '50%',
+        },
+        '@media (min-width:600px)': {
+          fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+          fontSize: '1rem',
+          letterSpacing: `${round(0.15 / 16)}em`,
+          fontWeight: 400,
+          lineHeight: 1.5,
+          width: '80%',
+        },
+      });
+    });
+
+    it('preserves earlier responsive properties when typography shorthand targets the same breakpoint', () => {
+      const result = styleFunctionSx({
+        theme,
+        sx: { color: { sm: 'red' }, typography: { sm: 'body1' } },
+      });
+
+      expect(result).to.deep.equal({
+        '@media (min-width:600px)': {
+          color: 'red',
+          fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+          fontSize: '1rem',
+          letterSpacing: `${round(0.15 / 16)}em`,
+          fontWeight: 400,
+          lineHeight: 1.5,
+        },
+      });
     });
 
     it('allow values to be `null` or `undefined`', () => {

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
@@ -115,6 +115,17 @@ describe('styleFunctionSx', () => {
       });
     });
 
+    it('does not mutate theme.typography when using responsive typography shorthand', () => {
+      const body1Before = { ...theme.typography.body1 };
+
+      styleFunctionSx({
+        theme,
+        sx: { typography: { sm: 'body1' }, width: { sm: '80%' }, mt: { sm: 4 } },
+      });
+
+      expect(theme.typography.body1).to.deep.equal(body1Before);
+    });
+
     it('allow values to be `null` or `undefined`', () => {
       const result = styleFunctionSx({
         theme,


### PR DESCRIPTION
## Summary

Fixes #48265

`setThemeValue` in `styleFunctionSx.js` assigns `css[mediaKey] = finalValue` where `finalValue` is a theme typography variant object returned by reference from `getPath`. This replaces the breakpoint's CSS accumulator with the live theme object, so subsequent responsive sx keys targeting the same breakpoint write their CSS properties directly into `theme.typography.<variant>`.

For example, after rendering `<Box sx={{ typography: { md: 'h4' }, width: { md: '80%' } }}>`, `theme.typography.h4` permanently contains `width: '80%'`, affecting every component using that variant.

The non-responsive path already uses `merge(css, finalValue)` which copies properties without creating a reference. This PR makes the responsive path consistent by using `merge(css[mediaKey], finalValue)` instead of the direct assignment.

Regression from #44254.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).