### PR TITLE
[accessibility] Improve High Contrast Mode styles for some components

### DIFF
--- a/docs/data/material/components/radio-buttons/CustomizedRadios.js
+++ b/docs/data/material/components/radio-buttons/CustomizedRadios.js
@@ -28,6 +28,12 @@ const BpIcon = styled('span')(({ theme }) => ({
     ...theme.applyStyles('dark', {
       background: 'rgba(57,75,89,.5)',
     }),
+    '@media (forced-colors: active)': {
+      outline: '1px solid GrayText',
+    },
+  },
+  '@media (forced-colors: active)': {
+    outline: '1px solid ButtonText',
   },
   ...theme.applyStyles('dark', {
     boxShadow: '0 0 0 1px rgb(16 22 26 / 40%)',
@@ -45,9 +51,20 @@ const BpCheckedIcon = styled(BpIcon)({
     height: 16,
     backgroundImage: 'radial-gradient(#fff,#fff 28%,transparent 32%)',
     content: '""',
+    '@media (forced-colors: active)': {
+      backgroundImage: 'none',
+      backgroundColor: 'ButtonText',
+      borderRadius: '50%',
+      width: 8,
+      height: 8,
+      margin: 4,
+    },
   },
   'input:hover ~ &': {
     backgroundColor: '#106ba3',
+  },
+  '@media (forced-colors: active)': {
+    outline: '2px solid ButtonText',
   },
 });
 

--- a/docs/data/material/components/radio-buttons/CustomizedRadios.tsx
+++ b/docs/data/material/components/radio-buttons/CustomizedRadios.tsx
@@ -28,6 +28,12 @@ const BpIcon = styled('span')(({ theme }) => ({
     ...theme.applyStyles('dark', {
       background: 'rgba(57,75,89,.5)',
     }),
+    '@media (forced-colors: active)': {
+      outline: '1px solid GrayText',
+    },
+  },
+  '@media (forced-colors: active)': {
+    outline: '1px solid ButtonText',
   },
   ...theme.applyStyles('dark', {
     boxShadow: '0 0 0 1px rgb(16 22 26 / 40%)',
@@ -45,9 +51,20 @@ const BpCheckedIcon = styled(BpIcon)({
     height: 16,
     backgroundImage: 'radial-gradient(#fff,#fff 28%,transparent 32%)',
     content: '""',
+    '@media (forced-colors: active)': {
+      backgroundImage: 'none',
+      backgroundColor: 'ButtonText',
+      borderRadius: '50%',
+      width: 8,
+      height: 8,
+      margin: 4,
+    },
   },
   'input:hover ~ &': {
     backgroundColor: '#106ba3',
+  },
+  '@media (forced-colors: active)': {
+    outline: '2px solid ButtonText',
   },
 });
 

--- a/docs/data/material/components/radio-buttons/ErrorRadios.js
+++ b/docs/data/material/components/radio-buttons/ErrorRadios.js
@@ -14,7 +14,6 @@ export default function ErrorRadios() {
 
   const handleRadioChange = (event) => {
     setValue(event.target.value);
-    setHelperText(' ');
     setError(false);
   };
 

--- a/docs/data/material/components/radio-buttons/ErrorRadios.tsx
+++ b/docs/data/material/components/radio-buttons/ErrorRadios.tsx
@@ -13,8 +13,7 @@ export default function ErrorRadios() {
   const [helperText, setHelperText] = React.useState('Choose wisely');
 
   const handleRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setValue((event.target as HTMLInputElement).value);
-    setHelperText(' ');
+    setValue(event.target.value);
     setError(false);
   };
 

--- a/docs/data/material/components/rating/RadioGroupRating.js
+++ b/docs/data/material/components/rating/RadioGroupRating.js
@@ -10,7 +10,7 @@ import SentimentVerySatisfiedIcon from '@mui/icons-material/SentimentVerySatisfi
 
 const StyledRating = styled(Rating)(({ theme }) => ({
   '& .MuiRating-iconEmpty .MuiSvgIcon-root': {
-    color: theme.palette.action.disabled,
+    color: (theme.vars || theme).palette.action.disabled,
   },
 }));
 

--- a/docs/data/material/components/rating/RadioGroupRating.tsx
+++ b/docs/data/material/components/rating/RadioGroupRating.tsx
@@ -9,7 +9,7 @@ import SentimentVerySatisfiedIcon from '@mui/icons-material/SentimentVerySatisfi
 
 const StyledRating = styled(Rating)(({ theme }) => ({
   '& .MuiRating-iconEmpty .MuiSvgIcon-root': {
-    color: theme.palette.action.disabled,
+    color: (theme.vars || theme).palette.action.disabled,
   },
 }));
 

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -358,6 +358,10 @@ const AutocompleteListbox = styled('ul', {
       '&[aria-disabled="true"]': {
         opacity: (theme.vars || theme).palette.action.disabledOpacity,
         pointerEvents: 'none',
+        '@media (forced-colors: active)': {
+          color: 'GrayText',
+          opacity: 1,
+        },
       },
       [`&.${autocompleteClasses.focusVisible}`]: {
         backgroundColor: (theme.vars || theme).palette.action.focus,

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -387,6 +387,9 @@ const AutocompleteListbox = styled('ul', {
             `${(theme.vars || theme).palette.action.selectedOpacity} + ${(theme.vars || theme).palette.action.focusOpacity}`,
           ),
         },
+        '@media (forced-colors: active)': {
+          color: 'SelectedItem',
+        },
       },
     },
   })),

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -380,6 +380,9 @@ const AutocompleteListbox = styled('ul', {
           '@media (hover: none)': {
             backgroundColor: (theme.vars || theme).palette.action.selected,
           },
+          '@media (forced-colors: active)': {
+            backgroundColor: 'Highlight',
+          },
         },
         [`&.${autocompleteClasses.focusVisible}`]: {
           backgroundColor: theme.alpha(
@@ -388,7 +391,9 @@ const AutocompleteListbox = styled('ul', {
           ),
         },
         '@media (forced-colors: active)': {
-          color: 'SelectedItem',
+          forcedColorAdjust: 'none',
+          color: 'HighlightText',
+          backgroundColor: 'Highlight',
         },
       },
     },

--- a/packages/mui-material/src/Checkbox/Checkbox.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.js
@@ -89,6 +89,9 @@ const CheckboxRoot = styled(SwitchBase, {
             },
             [`&.${checkboxClasses.disabled}`]: {
               color: (theme.vars || theme).palette.action.disabled,
+              '@media (forced-colors: active)': {
+                color: 'GrayText',
+              },
             },
           },
         })),

--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -86,11 +86,6 @@ const FilledInputRoot = styled(InputBaseRoot, {
           ? theme.vars.palette.FilledInput.disabledBg
           : disabledBackground,
       },
-      '@media (forced-colors: active)': {
-        'input::placeholder': {
-          opacity: 1,
-        },
-      },
       variants: [
         {
           props: ({ ownerState }) => !ownerState.disableUnderline,
@@ -242,6 +237,11 @@ const FilledInputInput = styled(InputBaseInput, {
           WebkitTextFillColor: '#fff',
           caretColor: '#fff',
         })),
+    },
+    '@media (forced-colors: active)': {
+      '&::placeholder': {
+        opacity: 1,
+      },
     },
     variants: [
       {

--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -86,6 +86,11 @@ const FilledInputRoot = styled(InputBaseRoot, {
           ? theme.vars.palette.FilledInput.disabledBg
           : disabledBackground,
       },
+      '@media (forced-colors: active)': {
+        'input::placeholder': {
+          opacity: 1,
+        },
+      },
       variants: [
         {
           props: ({ ownerState }) => !ownerState.disableUnderline,
@@ -111,6 +116,9 @@ const FilledInputRoot = styled(InputBaseRoot, {
             [`&.${filledInputClasses.error}`]: {
               '&::before, &::after': {
                 borderBottomColor: (theme.vars || theme).palette.error.main,
+                '@media (forced-colors: active)': {
+                  borderBottomColor: 'mark',
+                },
               },
             },
             '&::before': {
@@ -137,6 +145,10 @@ const FilledInputRoot = styled(InputBaseRoot, {
             },
             [`&.${filledInputClasses.disabled}:before`]: {
               borderBottomStyle: 'dotted',
+              '@media (forced-colors: active)': {
+                borderBottomStyle: 'solid',
+                borderBottomColor: 'GrayText',
+              },
             },
           },
         },
@@ -191,6 +203,14 @@ const FilledInputRoot = styled(InputBaseRoot, {
           style: {
             paddingTop: 8,
             paddingBottom: 9,
+          },
+        },
+        {
+          props: { disabled: true },
+          style: {
+            '@media (forced-colors: active)': {
+              color: 'GrayText',
+            },
           },
         },
       ],

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.js
@@ -61,6 +61,9 @@ export const FormControlLabelRoot = styled('label', {
     [`& .${formControlLabelClasses.label}`]: {
       [`&.${formControlLabelClasses.disabled}`]: {
         color: (theme.vars || theme).palette.text.disabled,
+        '@media (forced-colors: active)': {
+          color: 'GrayText',
+        },
       },
     },
     variants: [

--- a/packages/mui-material/src/FormHelperText/FormHelperText.js
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.js
@@ -9,7 +9,7 @@ import { styled } from '../zero-styled';
 import memoTheme from '../utils/memoTheme';
 import { useDefaultProps } from '../DefaultPropsProvider';
 import capitalize from '../utils/capitalize';
-import { getFormHelperTextUtilityClasses } from './formHelperTextClasses';
+import formHelperTextClasses, { getFormHelperTextUtilityClasses } from './formHelperTextClasses';
 
 const useUtilityClasses = (ownerState) => {
   const { classes, contained, size, disabled, error, filled, focused, required } = ownerState;
@@ -51,25 +51,19 @@ const FormHelperTextRoot = styled('p', {
     marginRight: 0,
     marginBottom: 0,
     marginLeft: 0,
+    [`&.${formHelperTextClasses.error}`]: {
+      color: (theme.vars || theme).palette.error.main,
+      '@media (forced-colors: active)': {
+        color: 'mark',
+      },
+    },
+    [`&.${formHelperTextClasses.disabled}`]: {
+      color: (theme.vars || theme).palette.text.disabled,
+      '@media (forced-colors: active)': {
+        color: 'GrayText',
+      },
+    },
     variants: [
-      {
-        props: { disabled: true },
-        style: {
-          color: (theme.vars || theme).palette.text.disabled,
-          '@media (forced-colors: active)': {
-            color: 'GrayText',
-          },
-        },
-      },
-      {
-        props: { error: true },
-        style: {
-          color: (theme.vars || theme).palette.error.main,
-          '@media (forced-colors: active)': {
-            color: 'mark',
-          },
-        },
-      },
       {
         props: {
           size: 'small',

--- a/packages/mui-material/src/FormHelperText/FormHelperText.js
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.js
@@ -9,7 +9,7 @@ import { styled } from '../zero-styled';
 import memoTheme from '../utils/memoTheme';
 import { useDefaultProps } from '../DefaultPropsProvider';
 import capitalize from '../utils/capitalize';
-import formHelperTextClasses, { getFormHelperTextUtilityClasses } from './formHelperTextClasses';
+import { getFormHelperTextUtilityClasses } from './formHelperTextClasses';
 
 const useUtilityClasses = (ownerState) => {
   const { classes, contained, size, disabled, error, filled, focused, required } = ownerState;
@@ -51,13 +51,25 @@ const FormHelperTextRoot = styled('p', {
     marginRight: 0,
     marginBottom: 0,
     marginLeft: 0,
-    [`&.${formHelperTextClasses.disabled}`]: {
-      color: (theme.vars || theme).palette.text.disabled,
-    },
-    [`&.${formHelperTextClasses.error}`]: {
-      color: (theme.vars || theme).palette.error.main,
-    },
     variants: [
+      {
+        props: { disabled: true },
+        style: {
+          color: (theme.vars || theme).palette.text.disabled,
+          '@media (forced-colors: active)': {
+            color: 'GrayText',
+          },
+        },
+      },
+      {
+        props: { error: true },
+        style: {
+          color: (theme.vars || theme).palette.error.main,
+          '@media (forced-colors: active)': {
+            color: 'mark',
+          },
+        },
+      },
       {
         props: {
           size: 'small',

--- a/packages/mui-material/src/FormLabel/FormLabel.js
+++ b/packages/mui-material/src/FormLabel/FormLabel.js
@@ -62,16 +62,16 @@ export const FormLabelRoot = styled('label', {
       {
         props: {},
         style: {
-          [`&.${formLabelClasses.disabled}`]: {
-            color: (theme.vars || theme).palette.text.disabled,
-            '@media (forced-colors: active)': {
-              color: 'GrayText',
-            },
-          },
           [`&.${formLabelClasses.error}`]: {
             color: (theme.vars || theme).palette.error.main,
             '@media (forced-colors: active)': {
               color: 'mark',
+            },
+          },
+          [`&.${formLabelClasses.disabled}`]: {
+            color: (theme.vars || theme).palette.text.disabled,
+            '@media (forced-colors: active)': {
+              color: 'GrayText',
             },
           },
         },

--- a/packages/mui-material/src/FormLabel/FormLabel.js
+++ b/packages/mui-material/src/FormLabel/FormLabel.js
@@ -60,13 +60,20 @@ export const FormLabelRoot = styled('label', {
           },
         })),
       {
-        props: {},
+        props: { disabled: true },
         style: {
-          [`&.${formLabelClasses.disabled}`]: {
-            color: (theme.vars || theme).palette.text.disabled,
+          color: (theme.vars || theme).palette.text.disabled,
+          '@media (forced-colors: active)': {
+            color: 'GrayText',
           },
-          [`&.${formLabelClasses.error}`]: {
-            color: (theme.vars || theme).palette.error.main,
+        },
+      },
+      {
+        props: { error: true },
+        style: {
+          color: (theme.vars || theme).palette.error.main,
+          '@media (forced-colors: active)': {
+            color: 'mark',
           },
         },
       },

--- a/packages/mui-material/src/FormLabel/FormLabel.js
+++ b/packages/mui-material/src/FormLabel/FormLabel.js
@@ -60,20 +60,19 @@ export const FormLabelRoot = styled('label', {
           },
         })),
       {
-        props: { disabled: true },
+        props: {},
         style: {
-          color: (theme.vars || theme).palette.text.disabled,
-          '@media (forced-colors: active)': {
-            color: 'GrayText',
+          [`&.${formLabelClasses.disabled}`]: {
+            color: (theme.vars || theme).palette.text.disabled,
+            '@media (forced-colors: active)': {
+              color: 'GrayText',
+            },
           },
-        },
-      },
-      {
-        props: { error: true },
-        style: {
-          color: (theme.vars || theme).palette.error.main,
-          '@media (forced-colors: active)': {
-            color: 'mark',
+          [`&.${formLabelClasses.error}`]: {
+            color: (theme.vars || theme).palette.error.main,
+            '@media (forced-colors: active)': {
+              color: 'mark',
+            },
           },
         },
       },

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -59,11 +59,6 @@ const InputRoot = styled(InputBaseRoot, {
     }
     return {
       position: 'relative',
-      '@media (forced-colors: active)': {
-        'input::placeholder': {
-          opacity: 1,
-        },
-      },
       variants: [
         {
           props: ({ ownerState }) => ownerState.formControl,
@@ -157,7 +152,13 @@ const InputInput = styled(InputBaseInput, {
   name: 'MuiInput',
   slot: 'Input',
   overridesResolver: inputBaseInputOverridesResolver,
-})({});
+})({
+  '@media (forced-colors: active)': {
+    '&::placeholder': {
+      opacity: 1,
+    },
+  },
+});
 
 const Input = React.forwardRef(function Input(inProps, ref) {
   const props = useDefaultProps({ props: inProps, name: 'MuiInput' });

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -59,6 +59,11 @@ const InputRoot = styled(InputBaseRoot, {
     }
     return {
       position: 'relative',
+      '@media (forced-colors: active)': {
+        'input::placeholder': {
+          opacity: 1,
+        },
+      },
       variants: [
         {
           props: ({ ownerState }) => ownerState.formControl,
@@ -71,11 +76,6 @@ const InputRoot = styled(InputBaseRoot, {
         {
           props: ({ ownerState }) => !ownerState.disableUnderline,
           style: {
-            '@media (forced-colors: active)': {
-              'input::placeholder': {
-                opacity: 1,
-              },
-            },
             '&::after': {
               left: 0,
               bottom: 0,

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -71,6 +71,11 @@ const InputRoot = styled(InputBaseRoot, {
         {
           props: ({ ownerState }) => !ownerState.disableUnderline,
           style: {
+            '@media (forced-colors: active)': {
+              'input::placeholder': {
+                opacity: 1,
+              },
+            },
             '&::after': {
               left: 0,
               bottom: 0,
@@ -92,6 +97,9 @@ const InputRoot = styled(InputBaseRoot, {
             [`&.${inputClasses.error}`]: {
               '&::before, &::after': {
                 borderBottomColor: (theme.vars || theme).palette.error.main,
+                '@media (forced-colors: active)': {
+                  borderBottomColor: 'mark',
+                },
               },
             },
             '&::before': {
@@ -115,6 +123,10 @@ const InputRoot = styled(InputBaseRoot, {
             },
             [`&.${inputClasses.disabled}:before`]: {
               borderBottomStyle: 'dotted',
+              '@media (forced-colors: active)': {
+                borderBottomStyle: 'solid',
+                borderBottomColor: 'GrayText',
+              },
             },
           },
         },
@@ -128,6 +140,14 @@ const InputRoot = styled(InputBaseRoot, {
               },
             },
           })),
+        {
+          props: { disabled: true },
+          style: {
+            '@media (forced-colors: active)': {
+              color: 'GrayText',
+            },
+          },
+        },
       ],
     };
   }),

--- a/packages/mui-material/src/MenuItem/MenuItem.js
+++ b/packages/mui-material/src/MenuItem/MenuItem.js
@@ -91,7 +91,9 @@ const MenuItemRoot = styled(ButtonBase, {
         ),
       },
       '@media (forced-colors: active)': {
-        color: 'SelectedItem',
+        forcedColorAdjust: 'none',
+        color: 'HighlightText',
+        backgroundColor: 'Highlight',
       },
     },
     [`&.${menuItemClasses.selected}:hover`]: {
@@ -105,6 +107,9 @@ const MenuItemRoot = styled(ButtonBase, {
           (theme.vars || theme).palette.primary.main,
           (theme.vars || theme).palette.action.selectedOpacity,
         ),
+      },
+      '@media (forced-colors: active)': {
+        backgroundColor: 'Highlight',
       },
     },
     [`&.${menuItemClasses.focusVisible}`]: {

--- a/packages/mui-material/src/MenuItem/MenuItem.js
+++ b/packages/mui-material/src/MenuItem/MenuItem.js
@@ -90,6 +90,9 @@ const MenuItemRoot = styled(ButtonBase, {
           `${(theme.vars || theme).palette.action.selectedOpacity} + ${(theme.vars || theme).palette.action.focusOpacity}`,
         ),
       },
+      '@media (forced-colors: active)': {
+        color: 'SelectedItem',
+      },
     },
     [`&.${menuItemClasses.selected}:hover`]: {
       backgroundColor: theme.alpha(

--- a/packages/mui-material/src/NativeSelect/NativeSelectInput.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelectInput.js
@@ -115,6 +115,9 @@ export const StyledSelectIcon = styled('svg', {
   color: (theme.vars || theme).palette.action.active,
   [`&.${nativeSelectClasses.disabled}`]: {
     color: (theme.vars || theme).palette.action.disabled,
+    '@media (forced-colors: active)': {
+      color: 'GrayText',
+    },
   },
   variants: [
     {

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -79,9 +79,15 @@ const OutlinedInputRoot = styled(InputBaseRoot, {
           style: {
             [`&.${outlinedInputClasses.error} .${outlinedInputClasses.notchedOutline}`]: {
               borderColor: (theme.vars || theme).palette.error.main,
+              '@media (forced-colors: active)': {
+                borderColor: 'mark',
+              },
             },
             [`&.${outlinedInputClasses.disabled} .${outlinedInputClasses.notchedOutline}`]: {
               borderColor: (theme.vars || theme).palette.action.disabled,
+              '@media (forced-colors: active)': {
+                borderColor: 'GrayText',
+              },
             },
           },
         },
@@ -150,6 +156,11 @@ const OutlinedInputInput = styled(InputBaseInput, {
           caretColor: '#fff',
         })),
     },
+    '@media (forced-colors: active)': {
+      '&::placeholder': {
+        opacity: 1,
+      },
+    },
     variants: [
       {
         props: {
@@ -175,6 +186,14 @@ const OutlinedInputInput = styled(InputBaseInput, {
         props: ({ ownerState }) => ownerState.endAdornment,
         style: {
           paddingRight: 0,
+        },
+      },
+      {
+        props: { disabled: true },
+        style: {
+          '@media (forced-colors: active)': {
+            color: 'GrayText',
+          },
         },
       },
     ],

--- a/packages/mui-material/src/Radio/Radio.js
+++ b/packages/mui-material/src/Radio/Radio.js
@@ -48,6 +48,9 @@ const RadioRoot = styled(SwitchBase, {
     color: (theme.vars || theme).palette.text.secondary,
     [`&.${radioClasses.disabled}`]: {
       color: (theme.vars || theme).palette.action.disabled,
+      '@media (forced-colors: active)': {
+        color: 'GrayText',
+      },
     },
     variants: [
       {

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -174,10 +174,15 @@ export const SliderTrack = styled('span', {
       transition: theme.transitions.create(['left', 'width', 'bottom', 'height'], {
         duration: theme.transitions.duration.shortest,
       }),
-      '@media (forced-colors: active)': {
-        borderColor: 'GrayText',
-      },
       variants: [
+        {
+          props: { disabled: true },
+          style: {
+            '@media (forced-colors: active)': {
+              borderColor: 'GrayText',
+            },
+          },
+        },
         {
           props: { size: 'small' },
           style: {
@@ -276,10 +281,15 @@ export const SliderThumb = styled('span', {
       },
     },
     border: '1px solid transparent',
-    '@media (forced-colors: active)': {
-      borderColor: 'GrayText',
-    },
     variants: [
+      {
+        props: { disabled: true },
+        style: {
+          '@media (forced-colors: active)': {
+            borderColor: 'GrayText',
+          },
+        },
+      },
       {
         props: { size: 'small' },
         style: {

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -131,6 +131,7 @@ export const SliderRail = styled('span', {
   borderRadius: 'inherit',
   backgroundColor: 'currentColor',
   opacity: 0.38,
+  border: '1px solid transparent',
   variants: [
     {
       props: { orientation: 'horizontal' },
@@ -173,6 +174,9 @@ export const SliderTrack = styled('span', {
       transition: theme.transitions.create(['left', 'width', 'bottom', 'height'], {
         duration: theme.transitions.duration.shortest,
       }),
+      '@media (forced-colors: active)': {
+        borderColor: 'GrayText',
+      },
       variants: [
         {
           props: { size: 'small' },
@@ -270,6 +274,10 @@ export const SliderThumb = styled('span', {
       '&:hover': {
         boxShadow: 'none',
       },
+    },
+    border: '1px solid transparent',
+    '@media (forced-colors: active)': {
+      borderColor: 'GrayText',
     },
     variants: [
       {

--- a/packages/mui-material/src/Switch/Switch.js
+++ b/packages/mui-material/src/Switch/Switch.js
@@ -205,6 +205,16 @@ const SwitchTrack = styled('span', {
     opacity: theme.vars
       ? theme.vars.opacity.switchTrack
       : `${theme.palette.mode === 'light' ? 0.38 : 0.3}`,
+    variants: [
+      {
+        props: { disabled: true },
+        style: {
+          '@media (forced-colors: active)': {
+            borderColor: 'GrayText',
+          },
+        },
+      },
+    ],
   })),
 );
 
@@ -220,6 +230,16 @@ const SwitchThumb = styled('span', {
     width: 20,
     height: 20,
     borderRadius: '50%',
+    variants: [
+      {
+        props: { disabled: true },
+        style: {
+          '@media (forced-colors: active)': {
+            borderColor: 'GrayText',
+          },
+        },
+      },
+    ],
   })),
 );
 

--- a/packages/mui-material/src/ToggleButton/ToggleButton.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.js
@@ -74,6 +74,7 @@ const ToggleButtonRoot = styled(ButtonBase, {
               (theme.vars || theme).palette.action.selectedOpacity,
             ),
             '@media (forced-colors: active)': {
+              forcedColorAdjust: 'none',
               color: 'HighlightText',
               backgroundColor: 'Highlight',
               borderColor: 'Highlight',
@@ -91,6 +92,7 @@ const ToggleButtonRoot = styled(ButtonBase, {
                 ),
               },
               '@media (forced-colors: active)': {
+                color: 'HighlightText',
                 backgroundColor: 'Highlight',
                 borderColor: 'ButtonBorder',
               },
@@ -110,6 +112,7 @@ const ToggleButtonRoot = styled(ButtonBase, {
                 (theme.vars || theme).palette.action.selectedOpacity,
               ),
               '@media (forced-colors: active)': {
+                forcedColorAdjust: 'none',
                 color: 'HighlightText',
                 backgroundColor: 'Highlight',
                 borderColor: 'Highlight',

--- a/packages/mui-material/src/ToggleButton/ToggleButton.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.js
@@ -73,6 +73,11 @@ const ToggleButtonRoot = styled(ButtonBase, {
               (theme.vars || theme).palette.text.primary,
               (theme.vars || theme).palette.action.selectedOpacity,
             ),
+            '@media (forced-colors: active)': {
+              color: 'HighlightText',
+              backgroundColor: 'Highlight',
+              borderColor: 'Highlight',
+            },
             '&:hover': {
               backgroundColor: theme.alpha(
                 (theme.vars || theme).palette.text.primary,
@@ -84,6 +89,10 @@ const ToggleButtonRoot = styled(ButtonBase, {
                   (theme.vars || theme).palette.text.primary,
                   (theme.vars || theme).palette.action.selectedOpacity,
                 ),
+              },
+              '@media (forced-colors: active)': {
+                backgroundColor: 'Highlight',
+                borderColor: 'ButtonBorder',
               },
             },
           },
@@ -100,6 +109,11 @@ const ToggleButtonRoot = styled(ButtonBase, {
                 (theme.vars || theme).palette[color].main,
                 (theme.vars || theme).palette.action.selectedOpacity,
               ),
+              '@media (forced-colors: active)': {
+                color: 'HighlightText',
+                backgroundColor: 'Highlight',
+                borderColor: 'Highlight',
+              },
               '&:hover': {
                 backgroundColor: theme.alpha(
                   (theme.vars || theme).palette[color].main,
@@ -111,6 +125,10 @@ const ToggleButtonRoot = styled(ButtonBase, {
                     (theme.vars || theme).palette[color].main,
                     (theme.vars || theme).palette.action.selectedOpacity,
                   ),
+                },
+                '@media (forced-colors: active)': {
+                  backgroundColor: 'Highlight',
+                  borderColor: 'ButtonBorder',
                 },
               },
             },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/13174

Improves support for Dark High Contrast for our `Inputs` components. We should continue this effort with:
- Light High Contrast
- Focus / Hover improved support in both Dark and Light High Contrast
- The rest of the components, not just `Inputs`

For disabled, use `GrayText` for border, placeholder and text.
For error, use `mark` for border and text.
For selected, use `Highlight` for border, `HighlightText` for text, and `none` for `forcedColorAdjust`.
When both error and disabled are true, disabled wins, since there's no point in showing an error control if we can't do anything about it.
Some docs examples needed style changes since they did not support high contrast.
Slider received transparent border so it will become visible in HC.

|Use Case|Before|After|
|--|--|--|
|[Disabled Checkbox](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-checkbox/)|<img width="138" height="79" alt="Screenshot 2026-04-14 at 15 53 03" src="https://github.com/user-attachments/assets/6b18637e-967d-450d-a7f9-9849561c29bb" />|<img width="117" height="67" alt="Screenshot 2026-04-14 at 15 53 09" src="https://github.com/user-attachments/assets/cd8c0d92-6a1d-4d54-a876-15c1ccbb0088" />|
|[Disabled Radio](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-radio-button/)|<img width="136" height="95" alt="Screenshot 2026-04-14 at 15 53 57" src="https://github.com/user-attachments/assets/187986d9-426d-484f-a513-8caf1577dba9" />|<img width="136" height="90" alt="Screenshot 2026-04-14 at 15 53 53" src="https://github.com/user-attachments/assets/6a9bd14b-daec-404f-a4cf-169856bc2330" />|
|[Input Placeholder](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-text-field/#form-props)|<img width="247" height="92" alt="Screenshot 2026-04-14 at 15 57 49" src="https://github.com/user-attachments/assets/e75ea987-8220-42b8-a427-834787173e2b" />|<img width="246" height="77" alt="Screenshot 2026-04-14 at 15 57 54" src="https://github.com/user-attachments/assets/5ccb3b8d-651c-498e-9804-df2b11f373c3" />|
|[Disabled Inputs](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-text-field/#form-props)|<img width="729" height="94" alt="Screenshot 2026-04-15 at 21 02 31" src="https://github.com/user-attachments/assets/07a26c19-57e7-423b-b845-229584a34cdd" />|<img width="725" height="91" alt="Screenshot 2026-04-15 at 21 02 39" src="https://github.com/user-attachments/assets/7844b2a5-8ae2-4275-87dd-d4051425e2d5" />|
|[Error Inputs](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-text-field/#form-props)|<img width="744" height="104" alt="Screenshot 2026-04-15 at 21 03 59" src="https://github.com/user-attachments/assets/d2705644-7354-4584-8f09-e426d4ce3b7b" />|<img width="730" height="96" alt="Screenshot 2026-04-15 at 21 04 02" src="https://github.com/user-attachments/assets/af5c422f-e48a-4e52-9d02-1d7aeaec4aa6" />|
|[Autocomplete Disabled Options](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-autocomplete/#disabled-options)|<img width="328" height="222" alt="Screenshot 2026-04-14 at 16 01 44" src="https://github.com/user-attachments/assets/231b4479-4ec8-407d-96c6-9af3db0bebf6" />|<img width="317" height="252" alt="Screenshot 2026-04-14 at 16 01 28" src="https://github.com/user-attachments/assets/4c77b922-6896-4cbc-8eb8-c063719ef76a" />|
|[Rating Radio Example (Dark Mode + High Contrast)](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-rating/#radio-group)|<img width="185" height="52" alt="Screenshot 2026-04-15 at 20 45 40" src="https://github.com/user-attachments/assets/43db597e-3cf9-4ba8-ac17-bb73ce045a98" /><img width="147" height="49" alt="Screenshot 2026-04-15 at 20 45 33" src="https://github.com/user-attachments/assets/e6c2418e-5829-4581-9701-095192987791" />|<img width="155" height="52" alt="Screenshot 2026-04-15 at 20 45 20" src="https://github.com/user-attachments/assets/f5a7274d-bb32-4332-81a8-427e021f35dd" /><img width="147" height="58" alt="Screenshot 2026-04-15 at 20 45 15" src="https://github.com/user-attachments/assets/82920394-09db-41aa-bbc8-0c346222fe5e" />|
|[Customized Radio Example](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-radio-button/#customization)|<img width="239" height="201" alt="Screenshot 2026-04-15 at 20 49 00" src="https://github.com/user-attachments/assets/7b25f399-bfea-4a07-bd42-3d38a8610c86" />|<img width="216" height="175" alt="Screenshot 2026-04-15 at 20 49 04" src="https://github.com/user-attachments/assets/4342b9cf-e903-4734-964a-34a13b3a996a" />|
|[Error Radio Example](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-radio-button/#show-error)|<img width="199" height="206" alt="Screenshot 2026-04-15 at 20 50 15" src="https://github.com/user-attachments/assets/3324e120-1d2f-4ee1-b56e-32dfb4b9fdb4" />|<img width="195" height="208" alt="Screenshot 2026-04-15 at 20 50 07" src="https://github.com/user-attachments/assets/1924953b-00d9-4236-888e-7c371ae4e909" />|
|[Disabled Select](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-select/#other-props)|<img width="159" height="86" alt="Screenshot 2026-04-15 at 21 11 27" src="https://github.com/user-attachments/assets/791a0a09-4ffc-4e01-9cac-3c9350d7640e" />|<img width="159" height="88" alt="Screenshot 2026-04-15 at 21 10 45" src="https://github.com/user-attachments/assets/876e2c8c-4b21-49b4-8565-707969b5256e" />|
|[Selected Menu Item](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-menu/#selected-menu) (works also with [Select](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-select/#multiple-select) and [Autocomplete](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-autocomplete/#multiple-values))|<img width="332" height="357" alt="Screenshot 2026-04-16 at 16 01 07" src="https://github.com/user-attachments/assets/050807d8-b291-4f6c-bbf5-c3dc0ebb9680" />|<img width="529" height="519" alt="image" src="https://github.com/user-attachments/assets/de80ae2d-669c-45c6-86e0-49cfeb1bb430" />|
|[Slider](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-slider)|<img width="248" height="100" alt="Screenshot 2026-04-16 at 16 13 46" src="https://github.com/user-attachments/assets/5f308912-2fdf-4281-8405-d3680243e740" />|<img width="282" height="100" alt="Screenshot 2026-04-16 at 16 14 43" src="https://github.com/user-attachments/assets/c5612041-f343-4314-a1e7-eac61acad53e" />|
|[Disabled Slider](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-slider)|<img width="248" height="100" alt="Screenshot 2026-04-16 at 16 13 46" src="https://github.com/user-attachments/assets/b3303874-fd7b-45f4-9933-1261a5350215" />|<img width="264" height="90" alt="image" src="https://github.com/user-attachments/assets/016b6f4d-49c3-4cce-8bf2-37a129119089" />|
|[Toggle Button Selected](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-toggle-button)|<img width="236" height="89" alt="Screenshot 2026-04-16 at 16 45 42" src="https://github.com/user-attachments/assets/516e7391-1235-4c75-8056-e9c16f0184fe" />|<img width="237" height="80" alt="Screenshot 2026-04-16 at 16 45 52" src="https://github.com/user-attachments/assets/dc429aac-5767-4130-9ded-9249e383ca3b" />|
|[Toggle Button Selected + Hovered](https://deploy-preview-48271--material-ui.netlify.app/material-ui/react-toggle-button)|<img width="221" height="76" alt="Screenshot 2026-04-16 at 16 46 02" src="https://github.com/user-attachments/assets/44226314-8ef3-4507-9b41-7ab60df412ad" />|<img width="213" height="69" alt="Screenshot 2026-04-16 at 16 45 57" src="https://github.com/user-attachments/assets/1f8b18f1-f9dc-4aea-b0e0-c76bc567c719" />|
