### PR TITLE
[input base] Place aria-label on the input element

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.d.ts
+++ b/packages/mui-material/src/InputBase/InputBase.d.ts
@@ -26,6 +26,7 @@ export interface InputBaseProps extends StandardProps<
   | 'onInvalid'
   | 'onKeyDown'
   | 'onKeyUp'
+  | 'aria-label'
 > {
   'aria-describedby'?: string | undefined;
   'aria-label'?: string | undefined;

--- a/packages/mui-material/src/InputBase/InputBase.d.ts
+++ b/packages/mui-material/src/InputBase/InputBase.d.ts
@@ -28,6 +28,7 @@ export interface InputBaseProps extends StandardProps<
   | 'onKeyUp'
 > {
   'aria-describedby'?: string | undefined;
+  'aria-label'?: string | undefined;
   /**
    * This prop helps users to fill forms faster, especially on mobile devices.
    * The name can be confusing, as it's more like an autofill.

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -602,6 +602,10 @@ InputBase.propTypes /* remove-proptypes */ = {
    */
   'aria-describedby': PropTypes.string,
   /**
+   * @ignore
+   */
+  'aria-label': PropTypes.string,
+  /**
    * This prop helps users to fill forms faster, especially on mobile devices.
    * The name can be confusing, as it's more like an autofill.
    * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -256,6 +256,7 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
   const props = useDefaultProps({ props: inProps, name: 'MuiInputBase' });
   const {
     'aria-describedby': ariaDescribedby,
+    'aria-label': ariaLabel,
     autoComplete,
     autoFocus,
     className,
@@ -544,6 +545,7 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
           <Input
             aria-invalid={fcs.error}
             aria-describedby={ariaDescribedby}
+            aria-label={ariaLabel}
             autoComplete={autoComplete}
             autoFocus={autoFocus}
             defaultValue={defaultValue}

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -49,6 +49,20 @@ describe('<InputBase />', () => {
     expect(input).not.to.have.attribute('required');
   });
 
+  it('should be aria-labelled and aria-describedby if props are provided', () => {
+    render(
+      <div>
+        <InputBase aria-label="label" aria-describedby="helper-text" />
+        <p id="helper-text">Helper text</p>
+      </div>,
+    );
+
+    const input = screen.getByRole('textbox');
+
+    expect(input).toHaveAccessibleName('label');
+    expect(input).toHaveAccessibleDescription('Helper text');
+  });
+
   it('should add the right class when size is small', () => {
     const { container } = render(<InputBase size="small" />);
     expect(container.firstChild).to.have.class(classes.sizeSmall);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Noticed this issue while working on https://github.com/mui/material-ui/pull/48251.

The aria-label was not parsed from the props, and ended up on the input wrapper. It should be added on the input element instead.
