### PR TITLE
[popover] Support visualViewport positioning

### DIFF
--- a/packages/mui-material/src/MenuList/MenuList.js
+++ b/packages/mui-material/src/MenuList/MenuList.js
@@ -66,7 +66,22 @@ function isItemFocusableWithTextCriteria(item, criteria) {
 // Menu auto-focus is not always keyboard-driven. On open we often move focus to the
 // active item programmatically so arrow-key navigation starts from the right place.
 function focusInitialItem(element, focusSource) {
-  focusWithVisible(element, focusSource);
+  const visualViewport = ownerWindow(element).visualViewport;
+  const preventScroll = visualViewport != null && visualViewport.scale !== 1;
+
+  if (!preventScroll) {
+    focusWithVisible(element, focusSource);
+    return;
+  }
+
+  try {
+    element.focus({
+      preventScroll: true,
+      ...(focusSource != null && { focusVisible: focusSource === 'keyboard' }),
+    });
+  } catch (error) {
+    focusWithVisible(element, focusSource);
+  }
 }
 
 /**

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { expect } from 'chai';
 import { spy } from 'sinon';
+import { vi } from 'vitest';
 import PropTypes from 'prop-types';
 import { act, createRenderer, fireEvent, within, screen, isJsdom } from '@mui/internal-test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
@@ -11,6 +12,54 @@ import describeConformance from '../../test/describeConformance';
 
 describe('<Modal />', () => {
   const { clock, render } = createRenderer();
+
+  function createVisualViewport({ scale = 1, offsetLeft = 0, offsetTop = 0 } = {}) {
+    return {
+      scale,
+      offsetLeft,
+      offsetTop,
+    };
+  }
+
+  function withVisualViewport(visualViewport, callback) {
+    vi.stubGlobal('visualViewport', visualViewport);
+
+    try {
+      callback();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  }
+
+  function withScrollTopSpy(callback) {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      window.HTMLDivElement.prototype,
+      'scrollTop',
+    );
+    const setSpy = spy();
+    let scrollTopValue = 0;
+
+    Object.defineProperty(window.HTMLDivElement.prototype, 'scrollTop', {
+      configurable: true,
+      get() {
+        return scrollTopValue;
+      },
+      set(value) {
+        scrollTopValue = value;
+        setSpy(value);
+      },
+    });
+
+    try {
+      callback(setSpy);
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(window.HTMLDivElement.prototype, 'scrollTop', originalDescriptor);
+      } else {
+        delete window.HTMLDivElement.prototype.scrollTop;
+      }
+    }
+  }
 
   let savedBodyStyle;
 
@@ -115,6 +164,35 @@ describe('<Modal />', () => {
 
       expect(screen.getByTestId('child')).not.to.have.attribute('role');
       expect(screen.getByTestId('child')).to.have.attribute('tabIndex', '-1');
+    });
+
+    it('resets the modal scroll position when the visual viewport is at the origin', () => {
+      withVisualViewport(createVisualViewport(), () => {
+        withScrollTopSpy((scrollTopSetSpy) => {
+          render(
+            <Modal open>
+              <div />
+            </Modal>,
+          );
+
+          expect(scrollTopSetSpy.callCount).to.equal(1);
+          expect(scrollTopSetSpy.firstCall.args[0]).to.equal(0);
+        });
+      });
+    });
+
+    it('does not reset the modal scroll position while the visual viewport is zoomed', () => {
+      withVisualViewport(createVisualViewport({ scale: 2, offsetLeft: 120, offsetTop: 80 }), () => {
+        withScrollTopSpy((scrollTopSetSpy) => {
+          render(
+            <Modal open>
+              <div />
+            </Modal>,
+          );
+
+          expect(scrollTopSetSpy.callCount).to.equal(0);
+        });
+      });
     });
   });
 

--- a/packages/mui-material/src/Modal/useModal.ts
+++ b/packages/mui-material/src/Modal/useModal.ts
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import ownerDocument from '@mui/utils/ownerDocument';
+import ownerWindow from '@mui/utils/ownerWindow';
 import useForkRef from '@mui/utils/useForkRef';
 import useEventCallback from '@mui/utils/useEventCallback';
 import createChainedFunction from '@mui/utils/createChainedFunction';
@@ -23,6 +24,18 @@ function getHasTransition(children: UseModalParameters['children']) {
 }
 
 const noop = () => {};
+
+function shouldResetModalScroll(modalElement: HTMLDivElement) {
+  const visualViewport = ownerWindow(modalElement).visualViewport;
+
+  if (!visualViewport) {
+    return true;
+  }
+
+  return (
+    visualViewport.scale === 1 && visualViewport.offsetLeft === 0 && visualViewport.offsetTop === 0
+  );
+}
 
 // A modal manager used to track and manage the state of open Modals.
 // Modals don't open on the server so this won't conflict with concurrent requests.
@@ -64,8 +77,9 @@ function useModal(parameters: UseModalParameters): UseModalReturnValue {
   const handleMounted = () => {
     manager.mount(getModal(), { disableScrollLock });
 
-    // Fix a bug on Chrome where the scroll isn't initially 0.
-    if (modalRef.current) {
+    // Fix a Chrome quirk where the modal root can mount with a stale scroll position.
+    // Skip this while the visual viewport is zoomed or panned away from the origin.
+    if (modalRef.current && shouldResetModalScroll(modalRef.current)) {
       modalRef.current.scrollTop = 0;
     }
   };

--- a/packages/mui-material/src/Popover/Popover.d.ts
+++ b/packages/mui-material/src/Popover/Popover.d.ts
@@ -96,6 +96,11 @@ export type PopoverReference = 'anchorEl' | 'anchorPosition' | 'none';
 interface PopoverVirtualElement {
   getBoundingClientRect: () => DOMRect;
   nodeType: Node['ELEMENT_NODE'];
+  /**
+   * Optional real DOM element that defines the same browsing context as the
+   * virtual anchor. Used to resolve the correct owner window.
+   */
+  contextElement?: Element | undefined;
 }
 
 export interface PopoverProps

--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -59,6 +59,47 @@ function resolveAnchorEl(anchorEl) {
   return typeof anchorEl === 'function' ? anchorEl() : anchorEl;
 }
 
+/**
+ * Resolves the browsing context for the anchor.
+ *
+ * Virtual anchors can expose a real DOM node through `contextElement`, which lets
+ * us attach listeners to the correct window without touching `document` during
+ * server rendering.
+ */
+function getAnchorWindow(anchorEl) {
+  const resolvedAnchorEl = resolveAnchorEl(anchorEl);
+
+  let anchorElement = null;
+
+  if (resolvedAnchorEl && resolvedAnchorEl.nodeType === 1) {
+    anchorElement = resolvedAnchorEl;
+  } else if (resolvedAnchorEl?.contextElement && resolvedAnchorEl.contextElement.nodeType === 1) {
+    anchorElement = resolvedAnchorEl.contextElement;
+  }
+
+  return anchorElement?.ownerDocument?.defaultView ?? null;
+}
+
+/**
+ * Converts the resolved anchor offset from viewport coordinates into the popover
+ * container's `offsetParent` coordinate space.
+ */
+function getAnchorOffsetRelativeToContainer(element, anchorOffset, elemTransformOrigin) {
+  // During pinch-zoom, some browsers report the fixed Modal root with a negative rect that
+  // tracks the visual viewport shift. Clamp positive values back to `0` so we preserve the
+  // default layout-viewport behavior and only compensate when the root is actually shifted.
+  const containerRect = element.offsetParent?.getBoundingClientRect();
+  const containerTop = Math.min(containerRect?.top ?? 0, 0);
+  const containerLeft = Math.min(containerRect?.left ?? 0, 0);
+
+  return {
+    top: anchorOffset.top - containerTop - elemTransformOrigin.vertical,
+    left: anchorOffset.left - containerLeft - elemTransformOrigin.horizontal,
+    containerTop,
+    containerLeft,
+  };
+}
+
 const useUtilityClasses = (ownerState) => {
   const { classes } = ownerState;
 
@@ -122,6 +163,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
   } = props;
 
   const paperRef = React.useRef();
+  const anchorWindow = getAnchorWindow(anchorEl);
 
   const ownerState = {
     ...props,
@@ -217,22 +259,50 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
       // Get the offset of the anchoring element
       const anchorOffset = getAnchorOffset();
 
-      // Calculate element positioning
-      let top = anchorOffset.top - elemTransformOrigin.vertical;
-      let left = anchorOffset.left - elemTransformOrigin.horizontal;
+      const anchorOffsetRelativeToContainer = getAnchorOffsetRelativeToContainer(
+        element,
+        anchorOffset,
+        elemTransformOrigin,
+      );
+
+      // Calculate element positioning relative to the container.
+      let { top, left } = anchorOffsetRelativeToContainer;
       const bottom = top + elemRect.height;
       const right = left + elemRect.width;
 
-      // Use the parent window of the anchorEl if provided
+      // Use the parent window of the anchorEl if provided.
       const containerWindow = ownerWindow(resolveAnchorEl(anchorEl));
 
-      // Window thresholds taking required margin into account
-      const heightThreshold = containerWindow.innerHeight - marginThreshold;
-      const widthThreshold = containerWindow.innerWidth - marginThreshold;
+      // Pinch-zoom keeps anchor and modal coordinates in the layout viewport, so it should not
+      // change the margin clamping math. Only switch to the visual viewport when the visible area
+      // shrinks at the same page scale, for example when browser UI or a software keyboard opens.
+      const visualViewport = containerWindow.visualViewport;
+      const viewportMargin = marginThreshold ?? 0;
+      const useVisualViewport =
+        visualViewport != null &&
+        visualViewport.scale === 1 &&
+        (visualViewport.width < containerWindow.innerWidth ||
+          visualViewport.height < containerWindow.innerHeight);
+      const viewportWidth = useVisualViewport ? visualViewport.width : containerWindow.innerWidth;
+      const viewportHeight = useVisualViewport
+        ? visualViewport.height
+        : containerWindow.innerHeight;
+      const maxVisibleHeight = viewportHeight - viewportMargin;
+
+      // Convert the visible viewport edges into the same container-relative coordinates used by
+      // `top` and `left`, so all clamping math happens in one coordinate space.
+      const visibleTop = -anchorOffsetRelativeToContainer.containerTop;
+      const visibleLeft = -anchorOffsetRelativeToContainer.containerLeft;
+      const minVisibleTop = visibleTop + viewportMargin;
+      const minVisibleLeft = visibleLeft + viewportMargin;
+
+      // Maximum allowed position after applying the requested viewport margin.
+      const heightThreshold = visibleTop + viewportHeight - viewportMargin;
+      const widthThreshold = visibleLeft + viewportWidth - viewportMargin;
 
       // Check if the vertical axis needs shifting
-      if (marginThreshold != null && top < marginThreshold) {
-        const diff = top - marginThreshold;
+      if (marginThreshold != null && top < minVisibleTop) {
+        const diff = top - minVisibleTop;
 
         top -= diff;
 
@@ -246,12 +316,12 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
       }
 
       if (process.env.NODE_ENV !== 'production') {
-        if (elemRect.height > heightThreshold && elemRect.height && heightThreshold) {
+        if (elemRect.height > maxVisibleHeight && elemRect.height && maxVisibleHeight) {
           console.error(
             [
               'MUI: The popover component is too tall.',
               `Some part of it can not be seen on the screen (${
-                elemRect.height - heightThreshold
+                elemRect.height - maxVisibleHeight
               }px).`,
               'Please consider adding a `max-height` to improve the user-experience.',
             ].join('\n'),
@@ -260,8 +330,8 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
       }
 
       // Check if the horizontal axis needs shifting
-      if (marginThreshold != null && left < marginThreshold) {
-        const diff = left - marginThreshold;
+      if (marginThreshold != null && left < minVisibleLeft) {
+        const diff = left - minVisibleLeft;
         left -= diff;
         elemTransformOrigin.horizontal += diff;
       } else if (right > widthThreshold) {
@@ -301,11 +371,13 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
   }, [getPositioningStyle]);
 
   React.useEffect(() => {
+    const scrollWindow = anchorWindow ?? window;
+
     if (disableScrollLock) {
-      window.addEventListener('scroll', setPositioningStyles);
+      scrollWindow.addEventListener('scroll', setPositioningStyles);
     }
-    return () => window.removeEventListener('scroll', setPositioningStyles);
-  }, [anchorEl, disableScrollLock, setPositioningStyles]);
+    return () => scrollWindow.removeEventListener('scroll', setPositioningStyles);
+  }, [anchorWindow, disableScrollLock, setPositioningStyles]);
 
   const handleEntering = () => {
     setPositioningStyles();
@@ -343,13 +415,25 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
       setPositioningStyles();
     });
 
-    const containerWindow = ownerWindow(resolveAnchorEl(anchorEl));
-    containerWindow.addEventListener('resize', handleResize);
+    const resizeWindow = anchorWindow ?? window;
+    resizeWindow.addEventListener('resize', handleResize);
+
+    // Reposition when the visual viewport changes, e.g. pinch-zoom or mobile keyboard.
+    const { visualViewport } = resizeWindow;
+    if (visualViewport) {
+      visualViewport.addEventListener('resize', handleResize);
+      visualViewport.addEventListener('scroll', handleResize);
+    }
+
     return () => {
       handleResize.clear();
-      containerWindow.removeEventListener('resize', handleResize);
+      resizeWindow.removeEventListener('resize', handleResize);
+      if (visualViewport) {
+        visualViewport.removeEventListener('resize', handleResize);
+        visualViewport.removeEventListener('scroll', handleResize);
+      }
     };
-  }, [anchorEl, open, setPositioningStyles]);
+  }, [anchorWindow, open, setPositioningStyles]);
 
   let transitionDuration = transitionDurationProp;
 

--- a/packages/mui-material/src/Popover/Popover.test.js
+++ b/packages/mui-material/src/Popover/Popover.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, match } from 'sinon';
+import { vi } from 'vitest';
 import { act, createRenderer, screen } from '@mui/internal-test-utils';
 import PropTypes from 'prop-types';
 import Modal, { modalClasses } from '@mui/material/Modal';
@@ -490,6 +491,72 @@ describe('<Popover />', () => {
         top: `${top}px`,
         left: `${left}px`,
       });
+    });
+
+    it('should reposition on scroll in the anchor window when scroll lock is disabled', () => {
+      const iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+
+      const iframeWindow = iframe.contentWindow;
+      const iframeDocument = iframe.contentDocument;
+      const anchorEl = iframeDocument.createElement('div');
+      iframeDocument.body.appendChild(anchorEl);
+
+      let anchorTop = 40;
+      stub(anchorEl, 'getBoundingClientRect').callsFake(() => ({
+        x: 0,
+        y: 0,
+        top: anchorTop,
+        left: 100,
+        bottom: anchorTop,
+        right: 100,
+        height: 0,
+        width: 0,
+      }));
+
+      let style;
+      let unmount = () => {};
+
+      try {
+        const view = render(
+          <Popover
+            anchorEl={anchorEl}
+            disableScrollLock
+            marginThreshold={null}
+            open
+            transitionDuration={0}
+            slotProps={{
+              transition: {
+                onEntering: (node) => {
+                  style = node.style;
+                },
+              },
+              paper: { component: FakePaper },
+            }}
+          >
+            <div />
+          </Popover>,
+        );
+        unmount = view.unmount;
+
+        expect(style.top).to.equal('40px');
+
+        anchorTop = 80;
+        act(() => {
+          window.dispatchEvent(new Event('scroll'));
+        });
+
+        expect(style.top).to.equal('40px');
+
+        act(() => {
+          iframeWindow.dispatchEvent(new iframeWindow.Event('scroll'));
+        });
+
+        expect(style.top).to.equal('80px');
+      } finally {
+        unmount();
+        iframe.remove();
+      }
     });
   });
 
@@ -987,6 +1054,360 @@ describe('<Popover />', () => {
         expect(style.left).to.equal(`${valueOutsideWindow}px`);
         expect(style.transformOrigin).to.match(/0px 0px( 0px)?/);
       });
+    });
+  });
+
+  describe('visual viewport positioning', () => {
+    function createVisualViewport({
+      width = window.innerWidth,
+      height = window.innerHeight,
+      scale = 1,
+    } = {}) {
+      const listeners = new Map();
+
+      return {
+        width,
+        height,
+        scale,
+        addEventListener(type, listener) {
+          if (!listeners.has(type)) {
+            listeners.set(type, new Set());
+          }
+
+          listeners.get(type).add(listener);
+        },
+        removeEventListener(type, listener) {
+          listeners.get(type)?.delete(listener);
+        },
+        dispatchEvent(type) {
+          listeners.get(type)?.forEach((listener) => {
+            listener();
+          });
+        },
+      };
+    }
+
+    function withVisualViewport(visualViewport, callback) {
+      vi.stubGlobal('visualViewport', visualViewport);
+
+      try {
+        callback(visualViewport);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    }
+
+    // FakePaper with controllable size and offsetParent rect for jsdom.
+    function createVisualViewportFakePaper(containerRect = { top: 0, left: 0 }, size = {}) {
+      const { width = 0, height = 0 } = size;
+
+      return React.forwardRef(function VisualViewportFakePaper(props, ref) {
+        const handleMocks = (paperInstance) => {
+          if (paperInstance) {
+            Object.defineProperty(paperInstance, 'offsetWidth', { value: width });
+            Object.defineProperty(paperInstance, 'offsetHeight', { value: height });
+            Object.defineProperty(paperInstance, 'offsetParent', {
+              value: {
+                getBoundingClientRect: () => ({
+                  top: containerRect.top,
+                  left: containerRect.left,
+                  width: 0,
+                  height: 0,
+                  right: containerRect.left,
+                  bottom: containerRect.top,
+                }),
+              },
+              configurable: true,
+            });
+          }
+        };
+        const handleRef = useForkRef(ref, handleMocks);
+        return <div tabIndex={-1} ref={handleRef} style={{ width, height }} {...props} />;
+      });
+    }
+
+    it('should position relative to the offsetParent when zoomed', () => {
+      const ZoomedPaper = createVisualViewportFakePaper({ top: -200, left: -150 });
+      const mockedAnchor = document.createElement('div');
+      stub(mockedAnchor, 'getBoundingClientRect').callsFake(() => ({
+        top: 50,
+        left: 100,
+      }));
+
+      let style;
+      render(
+        <Popover
+          anchorEl={mockedAnchor}
+          open
+          marginThreshold={null}
+          slotProps={{
+            transition: {
+              onEntering: (node) => {
+                style = node.style;
+              },
+            },
+            paper: { component: ZoomedPaper },
+          }}
+        >
+          <div />
+        </Popover>,
+      );
+
+      expect(style.top).to.equal('250px');
+      expect(style.left).to.equal('250px');
+    });
+
+    it('should not affect positioning when the container is at the viewport origin', () => {
+      // Baseline case: offsetParent at the viewport origin.
+      const NonZoomedPaper = createVisualViewportFakePaper({ top: 0, left: 0 });
+      const mockedAnchor = document.createElement('div');
+      stub(mockedAnchor, 'getBoundingClientRect').callsFake(() => ({
+        top: 50,
+        left: 100,
+      }));
+
+      let style;
+      render(
+        <Popover
+          anchorEl={mockedAnchor}
+          open
+          marginThreshold={null}
+          slotProps={{
+            transition: {
+              onEntering: (node) => {
+                style = node.style;
+              },
+            },
+            paper: { component: NonZoomedPaper },
+          }}
+        >
+          <div />
+        </Popover>,
+      );
+
+      expect(style.top).to.equal('50px');
+      expect(style.left).to.equal('100px');
+    });
+
+    it('should ignore positive offsetParent rect values', () => {
+      withVisualViewport(createVisualViewport({ width: 400, height: 300, scale: 2 }), () => {
+        const PositiveRectPaper = createVisualViewportFakePaper({ top: 200, left: 150 });
+        const mockedAnchor = document.createElement('div');
+        stub(mockedAnchor, 'getBoundingClientRect').callsFake(() => ({
+          top: 50,
+          left: 100,
+        }));
+
+        let style;
+        render(
+          <Popover
+            anchorEl={mockedAnchor}
+            open
+            marginThreshold={null}
+            slotProps={{
+              transition: {
+                onEntering: (node) => {
+                  style = node.style;
+                },
+              },
+              paper: { component: PositiveRectPaper },
+            }}
+          >
+            <div />
+          </Popover>,
+        );
+
+        expect(style.top).to.equal('50px');
+        expect(style.left).to.equal('100px');
+      });
+    });
+
+    it('should keep layout viewport thresholds when pinch-zoomed', () => {
+      withVisualViewport(createVisualViewport({ width: 400, height: 300, scale: 2 }), () => {
+        const mockedAnchor = document.createElement('div');
+        stub(mockedAnchor, 'getBoundingClientRect').callsFake(() => ({
+          top: 700,
+          left: 500,
+        }));
+
+        let style;
+        render(
+          <Popover
+            anchorEl={mockedAnchor}
+            open
+            marginThreshold={16}
+            slotProps={{
+              transition: {
+                onEntering: (node) => {
+                  style = node.style;
+                },
+              },
+              paper: { component: FakePaper },
+            }}
+          >
+            <div />
+          </Popover>,
+        );
+
+        expect(style.top).to.equal('700px');
+        expect(style.left).to.equal('500px');
+      });
+    });
+
+    it('should update positioning when visualViewport height changes at scale 1', () => {
+      withVisualViewport(
+        createVisualViewport({
+          width: window.innerWidth,
+          height: window.innerHeight,
+          scale: 1,
+        }),
+        (visualViewport) => {
+          const mockedAnchor = document.createElement('div');
+          stub(mockedAnchor, 'getBoundingClientRect').callsFake(() => ({
+            top: 700,
+            left: 0,
+          }));
+
+          let element;
+          render(
+            <Popover
+              anchorEl={mockedAnchor}
+              open
+              marginThreshold={16}
+              slotProps={{
+                transition: {
+                  onEntering: (node) => {
+                    element = node;
+                  },
+                },
+                paper: { component: FakePaper },
+              }}
+              transitionDuration={0}
+            >
+              <div />
+            </Popover>,
+          );
+
+          const beforeStyle = {
+            top: element.style.top,
+            left: element.style.left,
+            transformOrigin: element.style.transformOrigin,
+          };
+
+          visualViewport.height = 400;
+          act(() => {
+            visualViewport.dispatchEvent('resize');
+          });
+          clock.tick(166);
+
+          const afterStyle = {
+            top: element.style.top,
+            left: element.style.left,
+            transformOrigin: element.style.transformOrigin,
+          };
+
+          expect(beforeStyle).not.to.deep.equal(afterStyle);
+          expect(afterStyle.top).to.equal('384px');
+        },
+      );
+    });
+
+    it('should keep scroll lock enabled when pinch-zoomed', () => {
+      withVisualViewport(
+        createVisualViewport({
+          width: window.innerWidth,
+          height: window.innerHeight,
+          scale: 2,
+        }),
+        () => {
+          render(
+            <Popover anchorEl={defaultAnchorEl} open>
+              <div />
+            </Popover>,
+          );
+
+          expect(document.body.style.overflow).to.equal('hidden');
+        },
+      );
+    });
+
+    it('should reposition on visualViewport scroll when pinch-zoomed', () => {
+      withVisualViewport(
+        createVisualViewport({
+          width: window.innerWidth,
+          height: window.innerHeight,
+          scale: 2,
+        }),
+        (visualViewport) => {
+          const mockedAnchor = document.createElement('div');
+          let anchorTop = 50;
+          stub(mockedAnchor, 'getBoundingClientRect').callsFake(() => ({
+            top: anchorTop,
+            left: 100,
+          }));
+
+          let style;
+          render(
+            <Popover
+              anchorEl={mockedAnchor}
+              open
+              marginThreshold={null}
+              transitionDuration={0}
+              slotProps={{
+                transition: {
+                  onEntering: (node) => {
+                    style = node.style;
+                  },
+                },
+                paper: { component: FakePaper },
+              }}
+            >
+              <div />
+            </Popover>,
+          );
+
+          anchorTop = 80;
+          act(() => {
+            visualViewport.dispatchEvent('scroll');
+          });
+          clock.tick(166);
+
+          expect(style.top).to.equal('80px');
+        },
+      );
+    });
+
+    it('should warn when the popover is taller than the smaller visual viewport', () => {
+      withVisualViewport(
+        createVisualViewport({ width: window.innerWidth, height: 600, scale: 1 }),
+        () => {
+          const WarningPaper = createVisualViewportFakePaper(
+            { top: -200, left: 0 },
+            { height: 700 },
+          );
+          const mockedAnchor = document.createElement('div');
+          stub(mockedAnchor, 'getBoundingClientRect').callsFake(() => ({
+            top: 5,
+            left: 0,
+          }));
+
+          expect(() => {
+            render(
+              <Popover
+                anchorEl={mockedAnchor}
+                open
+                marginThreshold={16}
+                slotProps={{
+                  paper: { component: WarningPaper },
+                }}
+                transitionDuration={0}
+              >
+                <div />
+              </Popover>,
+            );
+          }).toErrorDev('MUI: The popover component is too tall.');
+        },
+      );
     });
   });
 

--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { expect } from 'chai';
+import { vi } from 'vitest';
 import { act, createRenderer, reactMajor, screen } from '@mui/internal-test-utils';
 import FocusTrap from '@mui/material/Unstable_TrapFocus';
 import Portal from '@mui/material/Portal';
@@ -170,6 +171,45 @@ describe('<FocusTrap />', () => {
     });
 
     expect(screen.getByTestId('root')).toHaveFocus();
+  });
+
+  it('should prevent scrolling when focusing the trap while zoomed', () => {
+    vi.stubGlobal('visualViewport', { scale: 2 });
+    const focusCalls: Array<FocusOptions | undefined> = [];
+    let isFocusStubInstalled = false;
+    let restoreFocusSpy = () => {};
+    const handleRootRef = (rootElement: HTMLDivElement | null) => {
+      if (!rootElement || isFocusStubInstalled) {
+        return;
+      }
+
+      isFocusStubInstalled = true;
+      const originalFocus = rootElement.focus;
+      const focusSpy = vi
+        .spyOn(rootElement, 'focus')
+        .mockImplementation((options?: FocusOptions) => {
+          focusCalls.push(options);
+          originalFocus.call(rootElement, options);
+        });
+      restoreFocusSpy = () => {
+        focusSpy.mockRestore();
+      };
+    };
+
+    try {
+      render(
+        <FocusTrap open>
+          <div tabIndex={-1} data-testid="root" ref={handleRootRef}>
+            <div>Title</div>
+          </div>
+        </FocusTrap>,
+      );
+
+      expect(focusCalls.some((options) => options?.preventScroll === true)).to.equal(true);
+    } finally {
+      restoreFocusSpy();
+      vi.unstubAllGlobals();
+    }
   });
 
   it('does not steal focus from a portaled element if any prop but open changes', async () => {

--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import useForkRef from '@mui/utils/useForkRef';
 import ownerDocument from '@mui/utils/ownerDocument';
+import ownerWindow from '@mui/utils/ownerWindow';
 import getReactElementRef from '@mui/utils/getReactElementRef';
 import exactProp from '@mui/utils/exactProp';
 import elementAcceptingRef from '@mui/utils/elementAcceptingRef';
@@ -123,6 +124,21 @@ function defaultIsEnabled(): boolean {
   return true;
 }
 
+function focusWithoutScrolling(element: HTMLElement): void {
+  const visualViewport = ownerWindow(element).visualViewport;
+
+  if (visualViewport?.scale !== 1) {
+    try {
+      element.focus({ preventScroll: true });
+      return;
+    } catch {
+      // Ignore unsupported focus options and fall back to the default behavior.
+    }
+  }
+
+  element.focus();
+}
+
 /**
  * @ignore - internal component.
  */
@@ -190,7 +206,7 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
       }
 
       if (activated.current) {
-        focusTarget.focus();
+        focusWithoutScrolling(focusTarget);
       }
     }
 
@@ -294,14 +310,14 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
 
         if (typeof focusNext !== 'string' && typeof focusPrevious !== 'string') {
           if (isShiftTab) {
-            focusPrevious.focus();
+            focusWithoutScrolling(focusPrevious);
           } else {
-            focusNext.focus();
+            focusWithoutScrolling(focusNext);
           }
         }
         // no tabbable elements in the trap focus or the focus was outside of the focus trap
       } else {
-        rootElement.focus();
+        focusWithoutScrolling(rootElement);
       }
     };
 


### PR DESCRIPTION
This ensures the popup stays anchored correctly when (pinch)zoomed

Components:
- [Menu](https://deploy-preview-48288--material-ui.netlify.app/material-ui/react-menu/)
- [Popover](https://deploy-preview-48288--material-ui.netlify.app/material-ui/react-popover/)
- [Select](https://deploy-preview-48288--material-ui.netlify.app/material-ui/react-select/)

Tested with Chrome, Safari, Firefox (there are some cross-browser differences), iOS Safari & Chrome - open while zoomed, and also open then zoom/pan around

Fixes https://github.com/mui/material-ui/issues/17636
Fixes https://github.com/mui/material-ui/issues/23919
Fixes https://github.com/mui/material-ui/issues/39538

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
