### PR TITLE
[docs] Remove incorrect message from experiments page and hide `/experiments` from crawlers

### DIFF
--- a/docs/pages/experiments/index.js
+++ b/docs/pages/experiments/index.js
@@ -52,15 +52,9 @@ export default function Experiments({ experiments }) {
               MUI <GradientText>Experiments</GradientText>
             </Typography>
             <Box sx={{ textAlign: 'left' }}>
-              <ul>
-                <Typography component="li">
-                  The files under <code>/experiments/*</code> are committed to git.
-                </Typography>
-                <Typography component="li">
-                  These URLs (start with <code>/experiments/*</code>) are not accessible in
-                  production.
-                </Typography>
-              </ul>
+              <Typography>
+                The files under <code>/experiments/*</code> are committed to git.
+              </Typography>
             </Box>
           </Box>
         </Container>

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -2,3 +2,5 @@
 
 User-agent: *
 Allow: /
+
+Disallow: /experiments/


### PR DESCRIPTION
Previews:
- https://deploy-preview-48297--material-ui.netlify.app/experiments/
- https://deploy-preview-48297--material-ui.netlify.app/robots.txt