### PR TITLE
[docs-infra] Fix duplicate JSDoc in proptypes generation

### DIFF
--- a/packages-internal/scripts/typescript-to-proptypes/src/getPropTypesFromFile.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/src/getPropTypesFromFile.ts
@@ -34,7 +34,6 @@ function getSymbolDocumentation({
 }: {
   symbol: ts.Symbol | undefined;
   project: TypeScriptProject;
-  parentType?: ts.Type;
 }): string | undefined {
   if (symbol === undefined) {
     return undefined;
@@ -42,22 +41,21 @@ function getSymbolDocumentation({
 
   const decl = symbol.getDeclarations();
   if (decl && decl.length > 0) {
-    // This behavior tries to replicate how TypeScript itself merges JSDoc comments
-    // It is a complex logic that changes based on the kind of declarations
+    // This behavior tries to replicate how TypeScript itself merges JSDoc comments.
+    // It is a complex logic that changes based on the kind of declarations.
     // There is an open issue for it in: https://github.com/microsoft/TypeScript/issues/30901
     //
-    // For intersection types (A & B), the symbol may have multiple declarations.
-    // We need to handle three cases:
-    // 1. Intersection (type C = A & B): merge JSDoc from all declarations (deduplicated)
-    // 2. Interface extends (interface Z extends X, Y): use the (only) declaration's JSDoc
-    // 3. Interface override (interface W extends X { prop }): use the override's JSDoc (which is the only declaration)
+    // The symbol may have multiple declarations in several scenarios:
+    // 1. Intersection (type C = A & B): one declaration per constituent type
+    // 2. Interface extends (interface Z extends X, Y): single declaration from the original interface
+    // 3. Interface override (interface W extends X { prop }): single declaration from the overriding interface
+    // 4. Declaration merging / module augmentation: one declaration per interface opening
     //
-    // Note: TypeScript gives us:
-    // - Multiple declarations for intersection types (one from each constituent type)
-    // - Single declaration for interface extends (from the original interface)
-    // - Single declaration for interface override (from the overriding interface)
-
-    // Get JSDoc comments paired with their declarations
+    // In all cases we use the last declaration that has JSDoc. This is consistent with
+    // squashPropTypeDefinitions and avoids duplicated descriptions when multiple
+    // declarations carry different JSDoc (e.g. module augmentation overriding
+    // the original, or intersection types where the last constituent's JSDoc
+    // is the most specific).
     const declarationsWithComments = decl
       .map((d) => {
         const jsDocNodes = ts.getJSDocCommentsAndTags(d).filter((node) => ts.isJSDoc(node));
@@ -67,19 +65,17 @@ function getSymbolDocumentation({
             : undefined;
         return { declaration: d, comment };
       })
-      .filter((item) => item.comment !== undefined);
+      .filter(
+        (item): item is { declaration: ts.Declaration; comment: string } =>
+          item.comment !== undefined,
+      );
 
     if (declarationsWithComments.length > 0) {
-      // If there's only one declaration with a comment, use it
-      // This handles both interface extends and interface override cases
-      if (declarationsWithComments.length === 1) {
-        return declarationsWithComments[0].comment;
-      }
-
-      // Multiple declarations with comments - this is the intersection case (type C = A & B)
-      // Merge JSDoc comments, deduplicating identical ones
-      const uniqueComments = [...new Set(declarationsWithComments.map((d) => d.comment))];
-      return uniqueComments.join('\n');
+      // Use the last declaration that has JSDoc. This handles:
+      // - Declaration merging / module augmentation: augmentation wins
+      // - Intersection types: last constituent wins (consistent with squashPropTypeDefinitions)
+      // - Interface extends / override: override wins (single declaration)
+      return declarationsWithComments[declarationsWithComments.length - 1].comment;
     }
   }
 
@@ -428,18 +424,16 @@ function checkSymbol({
   symbol,
   location,
   typeStack,
-  parentType,
 }: {
   project: PropTypesProject;
   symbol: ts.Symbol;
   location: ts.Node;
   typeStack: readonly number[];
-  parentType?: ts.Type;
 }): PropTypeDefinition {
   const declarations = symbol.getDeclarations();
   const declaration = declarations && declarations[0];
   const symbolFilenames = getSymbolFileNames(symbol);
-  const jsDoc = getSymbolDocumentation({ symbol, project, parentType });
+  const jsDoc = getSymbolDocumentation({ symbol, project });
 
   // TypeChecker keeps the name for
   // { a: React.ElementType, b: React.ReactElement | boolean }
@@ -619,7 +613,6 @@ function generatePropTypesFromNode(
         project: params.project,
         location: parsedComponent.location,
         typeStack: [(componentType as any).id],
-        parentType: componentType,
       }),
     );
 

--- a/packages-internal/scripts/typescript-to-proptypes/src/getPropTypesFromFile.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/src/getPropTypesFromFile.ts
@@ -28,12 +28,108 @@ function getSymbolFileNames(symbol: ts.Symbol): Set<string> {
   return new Set(declarations.map((declaration) => declaration.getSourceFile().fileName));
 }
 
+/**
+ * Flatten UnionType into array of stringified constituent types.
+ */
+function flattenUnionTypes(type: any): string[] {
+  if (type?.type === 'UnionType') {
+    return type.elements.flatMap(flattenUnionTypes);
+  }
+  const s = stringifyDoctrineType(type);
+  return s ? [s] : [];
+}
+
+/**
+ * Stringifies a doctrine JSDoc type AST node back to source form.
+ * Output is consumed by `flattenUnionTypes` as a counter input for
+ * `pickCoveringJSDoc` — exact form does not reach generated output, only
+ * its presence/count matters. Empty string signals "unhandled" and is
+ * filtered upstream.
+ *
+ * TODO: extend to cover remaining doctrine node kinds when encountered in
+ * real-world JSDoc. Unhandled kinds currently collapse to ''.
+ */
+function stringifyDoctrineType(type: any): string {
+  if (!type) {
+    return '';
+  }
+  switch (type.type) {
+    case 'NameExpression':
+      return type.name;
+    case 'UnionType':
+      return type.elements.map(stringifyDoctrineType).join(' | ');
+    case 'TypeApplication':
+      return `${stringifyDoctrineType(type.expression)}<${type.applications.map(stringifyDoctrineType).join(', ')}>`;
+    case 'OptionalType':
+      return `${stringifyDoctrineType(type.expression)}=`;
+    case 'NullableType':
+      return `?${stringifyDoctrineType(type.expression)}`;
+    case 'NonNullableType':
+      return `!${stringifyDoctrineType(type.expression)}`;
+    case 'RestType':
+      return `...${stringifyDoctrineType(type.expression)}`;
+    case 'ArrayType':
+      return `[${type.elements.map(stringifyDoctrineType).join(', ')}]`;
+    case 'AllLiteral':
+      return '*';
+    case 'NullLiteral':
+      return 'null';
+    case 'UndefinedLiteral':
+      return 'undefined';
+    case 'VoidLiteral':
+      return 'void';
+    default:
+      return '';
+  }
+}
+
+/**
+ * Pick the most-covering JSDoc comment among several declarations.
+ * "Most covering" = highest count of union-constituent types across all `@param`
+ * tags. Matches VS Code hover semantics which displays the richer overload.
+ * Ties fall back to the first (for declaration merging) or last (for intersection).
+ */
+function pickCoveringJSDoc(comments: string[], tieBreak: 'first' | 'last'): string {
+  if (comments.length === 0) {
+    return '';
+  }
+  if (comments.length === 1) {
+    return comments[0];
+  }
+  const parsed = comments.map((c) =>
+    doctrine.parse(
+      `/**\n${c
+        .split('\n')
+        .map((l) => ` * ${l}`)
+        .join('\n')}\n */`,
+      { unwrap: true },
+    ),
+  );
+  const paramTypeCount = (p: (typeof parsed)[number]) =>
+    p.tags
+      .filter((t) => t.title === 'param')
+      .reduce((sum, t) => sum + (t.type ? flattenUnionTypes(t.type).length : 0), 0);
+
+  let bestIndex = 0;
+  let bestCount = paramTypeCount(parsed[0]);
+  for (let i = 1; i < parsed.length; i += 1) {
+    const count = paramTypeCount(parsed[i]);
+    if (tieBreak === 'last' ? count >= bestCount : count > bestCount) {
+      bestIndex = i;
+      bestCount = count;
+    }
+  }
+  return comments[bestIndex];
+}
+
 function getSymbolDocumentation({
   symbol,
   project,
+  parentType,
 }: {
   symbol: ts.Symbol | undefined;
   project: TypeScriptProject;
+  parentType?: ts.Type;
 }): string | undefined {
   if (symbol === undefined) {
     return undefined;
@@ -45,37 +141,31 @@ function getSymbolDocumentation({
     // It is a complex logic that changes based on the kind of declarations.
     // There is an open issue for it in: https://github.com/microsoft/TypeScript/issues/30901
     //
-    // The symbol may have multiple declarations in several scenarios:
-    // 1. Intersection (type C = A & B): one declaration per constituent type
-    // 2. Interface extends (interface Z extends X, Y): single declaration from the original interface
-    // 3. Interface override (interface W extends X { prop }): single declaration from the overriding interface
-    // 4. Declaration merging / module augmentation: one declaration per interface opening
-    //
-    // In all cases we use the last declaration that has JSDoc. This is consistent with
-    // squashPropTypeDefinitions and avoids duplicated descriptions when multiple
-    // declarations carry different JSDoc (e.g. module augmentation overriding
-    // the original, or intersection types where the last constituent's JSDoc
-    // is the most specific).
-    const declarationsWithComments = decl
+    // Matches VS Code hover behavior:
+    // 1. Intersection (type C = A & B): append unique JSDoc from all constituents
+    // 2. Interface extends (interface Z extends X, Y): single declaration, use it
+    // 3. Interface override (interface W extends X { prop }): single declaration, use it
+    // 4. Declaration merging / module augmentation: first declaration that has JSDoc wins
+    const comments = decl
       .map((d) => {
         const jsDocNodes = ts.getJSDocCommentsAndTags(d).filter((node) => ts.isJSDoc(node));
-        const comment =
-          jsDocNodes.length > 0
-            ? doctrine.unwrapComment(jsDocNodes[0].getText()).trim()
-            : undefined;
-        return { declaration: d, comment };
+        return jsDocNodes.length > 0
+          ? doctrine.unwrapComment(jsDocNodes[0].getText()).trim()
+          : undefined;
       })
-      .filter(
-        (item): item is { declaration: ts.Declaration; comment: string } =>
-          item.comment !== undefined,
-      );
+      .filter((c): c is string => c !== undefined);
 
-    if (declarationsWithComments.length > 0) {
-      // Use the last declaration that has JSDoc. This handles:
-      // - Declaration merging / module augmentation: augmentation wins
-      // - Intersection types: last constituent wins (consistent with squashPropTypeDefinitions)
-      // - Interface extends / override: override wins (single declaration)
-      return declarationsWithComments[declarationsWithComments.length - 1].comment;
+    if (comments.length > 0) {
+      if (comments.length === 1) {
+        return comments[0];
+      }
+
+      // Pick the declaration with the most-covering JSDoc (richest @param
+      // signature), matching how VS Code hover shows overloaded signatures.
+      // For intersections, ties resolve to the last constituent (override semantics);
+      // for declaration merging / extends, ties resolve to the first.
+      const tieBreak = parentType && parentType.isIntersection() ? 'last' : 'first';
+      return pickCoveringJSDoc(comments, tieBreak);
     }
   }
 
@@ -424,16 +514,18 @@ function checkSymbol({
   symbol,
   location,
   typeStack,
+  parentType,
 }: {
   project: PropTypesProject;
   symbol: ts.Symbol;
   location: ts.Node;
   typeStack: readonly number[];
+  parentType?: ts.Type;
 }): PropTypeDefinition {
   const declarations = symbol.getDeclarations();
   const declaration = declarations && declarations[0];
   const symbolFilenames = getSymbolFileNames(symbol);
-  const jsDoc = getSymbolDocumentation({ symbol, project });
+  const jsDoc = getSymbolDocumentation({ symbol, project, parentType });
 
   // TypeChecker keeps the name for
   // { a: React.ElementType, b: React.ReactElement | boolean }
@@ -613,6 +705,7 @@ function generatePropTypesFromNode(
         project: params.project,
         location: parsedComponent.location,
         typeStack: [(componentType as any).id],
+        parentType: componentType,
       }),
     );
 

--- a/packages-internal/scripts/typescript-to-proptypes/src/getPropTypesFromFile.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/src/getPropTypesFromFile.ts
@@ -30,13 +30,34 @@ function getSymbolFileNames(symbol: ts.Symbol): Set<string> {
 
 /**
  * Flatten UnionType into array of stringified constituent types.
+ * Recurses through doctrine wrapper/container nodes so unions nested in
+ * OptionalType / NullableType / NonNullableType / RestType / TypeApplication /
+ * ArrayType are counted by their actual constituent leaves.
  */
 function flattenUnionTypes(type: any): string[] {
-  if (type?.type === 'UnionType') {
-    return type.elements.flatMap(flattenUnionTypes);
+  if (!type) {
+    return [];
   }
-  const s = stringifyDoctrineType(type);
-  return s ? [s] : [];
+  switch (type.type) {
+    case 'UnionType':
+      return type.elements.flatMap(flattenUnionTypes);
+    case 'OptionalType':
+    case 'NullableType':
+    case 'NonNullableType':
+    case 'RestType':
+      return flattenUnionTypes(type.expression);
+    case 'TypeApplication':
+      return [
+        ...flattenUnionTypes(type.expression),
+        ...type.applications.flatMap(flattenUnionTypes),
+      ];
+    case 'ArrayType':
+      return type.elements.flatMap(flattenUnionTypes);
+    default: {
+      const s = stringifyDoctrineType(type);
+      return s ? [s] : [];
+    }
+  }
 }
 
 /**
@@ -96,24 +117,31 @@ function pickCoveringJSDoc(comments: string[], tieBreak: 'first' | 'last'): stri
   if (comments.length === 1) {
     return comments[0];
   }
-  const parsed = comments.map((c) =>
-    doctrine.parse(
-      `/**\n${c
-        .split('\n')
-        .map((l) => ` * ${l}`)
-        .join('\n')}\n */`,
-      { unwrap: true },
-    ),
-  );
-  const paramTypeCount = (p: (typeof parsed)[number]) =>
-    p.tags
-      .filter((t) => t.title === 'param')
-      .reduce((sum, t) => sum + (t.type ? flattenUnionTypes(t.type).length : 0), 0);
+
+  const getParamTypeCount = (comment: string) => {
+    if (!/@param\b/.test(comment)) {
+      return 0;
+    }
+    try {
+      const parsed = doctrine.parse(
+        `/**\n${comment
+          .split('\n')
+          .map((l) => ` * ${l.trim()}`)
+          .join('\n')}\n */`,
+        { unwrap: true },
+      );
+      return parsed.tags
+        .filter((t) => t.title === 'param')
+        .reduce((sum, t) => sum + (t.type ? flattenUnionTypes(t.type).length : 0), 0);
+    } catch {
+      return 0;
+    }
+  };
 
   let bestIndex = 0;
-  let bestCount = paramTypeCount(parsed[0]);
-  for (let i = 1; i < parsed.length; i += 1) {
-    const count = paramTypeCount(parsed[i]);
+  let bestCount = getParamTypeCount(comments[0]);
+  for (let i = 1; i < comments.length; i += 1) {
+    const count = getParamTypeCount(comments[i]);
     if (tieBreak === 'last' ? count >= bestCount : count > bestCount) {
       bestIndex = i;
       bestCount = count;
@@ -141,11 +169,13 @@ function getSymbolDocumentation({
     // It is a complex logic that changes based on the kind of declarations.
     // There is an open issue for it in: https://github.com/microsoft/TypeScript/issues/30901
     //
-    // Matches VS Code hover behavior:
-    // 1. Intersection (type C = A & B): append unique JSDoc from all constituents
-    // 2. Interface extends (interface Z extends X, Y): single declaration, use it
-    // 3. Interface override (interface W extends X { prop }): single declaration, use it
-    // 4. Declaration merging / module augmentation: first declaration that has JSDoc wins
+    // Selection strategy (matches VS Code hover behavior):
+    // 1. Collect at most one JSDoc block per declaration.
+    // 2. If only one declaration contributes JSDoc, use it.
+    // 3. If multiple declarations contribute JSDoc, select the most-covering one
+    //    via `pickCoveringJSDoc` (richest matching signature).
+    // 4. Ties resolve to the last declaration for intersections, otherwise to the first
+    //    declaration (for example in declaration merging / module augmentation).
     const comments = decl
       .map((d) => {
         const jsDocNodes = ts.getJSDocCommentsAndTags(d).filter((node) => ts.isJSDoc(node));

--- a/packages-internal/scripts/typescript-to-proptypes/test/declaration-merging/input.tsx
+++ b/packages-internal/scripts/typescript-to-proptypes/test/declaration-merging/input.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import type { ComponentProps } from './types';
+
+export default function Component(props: ComponentProps) {
+  const { name, onItemClick } = props;
+
+  return <button onClick={(e) => onItemClick?.(e.nativeEvent)}>{name}</button>;
+}

--- a/packages-internal/scripts/typescript-to-proptypes/test/declaration-merging/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/declaration-merging/output.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+function Component(props) {
+  const { name, onItemClick } = props;
+  return <button onClick={(e) => onItemClick?.(e.nativeEvent)}>{name}</button>;
+}
+
+Component.propTypes = {
+  /**
+   * A normal prop.
+   */
+  name: PropTypes.string.isRequired,
+  /**
+   * Augmented description of the callback.
+   * @param {MouseEvent | React.MouseEvent} event The event source (augmented).
+   */
+  onItemClick: PropTypes.func,
+};
+
+export default Component;

--- a/packages-internal/scripts/typescript-to-proptypes/test/declaration-merging/types.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/declaration-merging/types.ts
@@ -1,0 +1,20 @@
+export interface ComponentProps {
+  /**
+   * Original description of the callback.
+   * @param {MouseEvent} event The event source.
+   */
+  onItemClick?(event: MouseEvent): void;
+  /**
+   * A normal prop.
+   */
+  name: string;
+}
+
+// Module augmentation / declaration merging
+export interface ComponentProps {
+  /**
+   * Augmented description of the callback.
+   * @param {MouseEvent | React.MouseEvent} event The event source (augmented).
+   */
+  onItemClick?(event: MouseEvent | React.MouseEvent): void;
+}

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-declaration-merging-func/input.tsx
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-declaration-merging-func/input.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import type { ComponentProps } from './types';
+
+export default function Component(props: ComponentProps) {
+  const { label, onClick } = props;
+  return <button onClick={(e) => onClick?.(e.nativeEvent)}>{label}</button>;
+}

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-declaration-merging-func/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-declaration-merging-func/output.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+function Component(props) {
+  const { label, onClick } = props;
+  return <button onClick={(e) => onClick?.(e.nativeEvent)}>{label}</button>;
+}
+
+Component.propTypes = {
+  /**
+   * Regular prop.
+   */
+  label: PropTypes.string.isRequired,
+  /**
+   * Second declaration: fires on click (augmented).
+   * @param {MouseEvent | React.MouseEvent} event The event.
+   */
+  onClick: PropTypes.func,
+};
+
+export default Component;

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-declaration-merging-func/types.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-declaration-merging-func/types.ts
@@ -1,0 +1,20 @@
+export interface ComponentProps {
+  /**
+   * First declaration: fires on click.
+   * @param {MouseEvent} event The event.
+   */
+  onClick?(event: MouseEvent): void;
+  /**
+   * Regular prop.
+   */
+  label: string;
+}
+
+// Declaration merging: second opening overrides via augmentation
+export interface ComponentProps {
+  /**
+   * Second declaration: fires on click (augmented).
+   * @param {MouseEvent | React.MouseEvent} event The event.
+   */
+  onClick?(event: MouseEvent | React.MouseEvent): void;
+}

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-interface-extends/input.tsx
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-interface-extends/input.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+interface BaseProps {
+  /**
+   * The label from base.
+   * @default 'base'
+   */
+  label: string;
+  /**
+   * If true, the component is disabled.
+   */
+  disabled?: boolean;
+}
+
+interface ExtraProps {
+  /**
+   * The label from extra.
+   * @default 'extra'
+   */
+  label: string;
+  /**
+   * The size of the component.
+   */
+  size?: 'small' | 'medium' | 'large';
+}
+
+interface CombinedProps extends BaseProps, ExtraProps {}
+
+export default function Component(props: CombinedProps) {
+  const { label, disabled, size } = props;
+  return (
+    <button disabled={disabled} data-size={size}>
+      {label}
+    </button>
+  );
+}

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-interface-extends/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-interface-extends/output.js
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+function Component(props) {
+  const { label, disabled, size } = props;
+  return (
+    <button disabled={disabled} data-size={size}>
+      {label}
+    </button>
+  );
+}
+
+Component.propTypes = {
+  /**
+   * If true, the component is disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * The label from base.
+   * @default 'base'
+   */
+  label: PropTypes.string.isRequired,
+  /**
+   * The size of the component.
+   */
+  size: PropTypes.oneOf(['large', 'medium', 'small']),
+};
+
+export default Component;

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-interface-override/input.tsx
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-interface-override/input.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+interface BaseProps {
+  /**
+   * The label from base.
+   * @default 'base'
+   */
+  label: string;
+  /**
+   * If true, the component is disabled.
+   */
+  disabled?: boolean;
+}
+
+interface OverrideProps extends BaseProps {
+  /**
+   * The overridden label description.
+   * @default 'override'
+   */
+  label: string;
+}
+
+export default function Component(props: OverrideProps) {
+  const { label, disabled } = props;
+  return <button disabled={disabled}>{label}</button>;
+}

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-interface-override/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-interface-override/output.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+function Component(props) {
+  const { label, disabled } = props;
+  return <button disabled={disabled}>{label}</button>;
+}
+
+Component.propTypes = {
+  /**
+   * If true, the component is disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * The overridden label description.
+   * @default 'override'
+   */
+  label: PropTypes.string.isRequired,
+};
+
+export default Component;

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection-params/input.tsx
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection-params/input.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+type BaseProps = {
+  /**
+   * Callback fired when item clicked.
+   * @param {MouseEvent} event The event source.
+   * @param {string} id The item identifier.
+   */
+  onItemClick?(event: MouseEvent, id: string): void;
+};
+
+type ExtendedProps = {
+  /**
+   * Callback fired when item clicked.
+   * @param {MouseEvent | React.MouseEvent} event The event source (extended).
+   * @param {string} id The item identifier.
+   */
+  onItemClick?(event: MouseEvent | React.MouseEvent, id: string): void;
+};
+
+type CombinedProps = BaseProps & ExtendedProps;
+
+export default function Component(props: CombinedProps) {
+  const { onItemClick } = props;
+  return <button onClick={(e) => onItemClick?.(e.nativeEvent, '1')}>click</button>;
+}

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection-params/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection-params/output.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+function Component(props) {
+  const { onItemClick } = props;
+  return <button onClick={(e) => onItemClick?.(e.nativeEvent, '1')}>click</button>;
+}
+
+Component.propTypes = {
+  /**
+   * Callback fired when item clicked.
+   * @param {MouseEvent | React.MouseEvent} event The event source (extended).
+   * @param {string} id The item identifier.
+   */
+  onItemClick: PropTypes.func,
+};
+
+export default Component;

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection-partial/input.tsx
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection-partial/input.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+type BaseProps = {
+  /**
+   * Callback fired.
+   * @param {MouseEvent} event The event source.
+   */
+  onClick?(event: MouseEvent): void;
+};
+
+type ExtendedProps = {
+  onClick?(event: MouseEvent | React.MouseEvent): void;
+};
+
+type CombinedProps = BaseProps & ExtendedProps;
+
+export default function Component(props: CombinedProps) {
+  const { onClick } = props;
+  return <button onClick={(e) => onClick?.(e.nativeEvent)}>click</button>;
+}

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection-partial/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection-partial/output.js
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+function Component(props) {
+  const { onClick } = props;
+  return <button onClick={(e) => onClick?.(e.nativeEvent)}>click</button>;
+}
+
+Component.propTypes = {
+  /**
+   * Callback fired.
+   * @param {MouseEvent} event The event source.
+   */
+  onClick: PropTypes.func,
+};
+
+export default Component;

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection-same-type/input.tsx
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection-same-type/input.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+type BaseProps = {
+  /**
+   * Callback fired.
+   * @param {MouseEvent} event The event.
+   */
+  onClick?(event: MouseEvent): void;
+};
+
+type ExtendedProps = {
+  /**
+   * Callback fired (extended).
+   * @param {MouseEvent} event The event.
+   */
+  onClick?(event: MouseEvent): void;
+};
+
+type CombinedProps = BaseProps & ExtendedProps;
+
+export default function Component(props: CombinedProps) {
+  const { onClick } = props;
+  return <button onClick={(e) => onClick?.(e.nativeEvent)}>click</button>;
+}

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection-same-type/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection-same-type/output.js
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+function Component(props) {
+  const { onClick } = props;
+  return <button onClick={(e) => onClick?.(e.nativeEvent)}>click</button>;
+}
+
+Component.propTypes = {
+  /**
+   * Callback fired (extended).
+   * @param {MouseEvent} event The event.
+   */
+  onClick: PropTypes.func,
+};
+
+export default Component;

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection/input.tsx
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection/input.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+type BaseProps = {
+  /**
+   * The label of the component.
+   * @default 'base'
+   */
+  label: string;
+  /**
+   * If true, the component is disabled.
+   */
+  disabled?: boolean;
+};
+
+type ExtraProps = {
+  /**
+   * The label from extra props.
+   * @default 'extra'
+   */
+  label: string;
+  /**
+   * The size of the component.
+   */
+  size?: 'small' | 'medium' | 'large';
+};
+
+type CombinedProps = BaseProps & ExtraProps;
+
+export default function Component(props: CombinedProps) {
+  const { label, disabled, size } = props;
+  return (
+    <button disabled={disabled} data-size={size}>
+      {label}
+    </button>
+  );
+}

--- a/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection/output.js
+++ b/packages-internal/scripts/typescript-to-proptypes/test/jsdoc-intersection/output.js
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+function Component(props) {
+  const { label, disabled, size } = props;
+  return (
+    <button disabled={disabled} data-size={size}>
+      {label}
+    </button>
+  );
+}
+
+Component.propTypes = {
+  /**
+   * If true, the component is disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * The label from extra props.
+   * @default 'extra'
+   */
+  label: PropTypes.string.isRequired,
+  /**
+   * The size of the component.
+   */
+  size: PropTypes.oneOf(['large', 'medium', 'small']),
+};
+
+export default Component;


### PR DESCRIPTION
`getSymbolDocumentation` (introduced in #47685) concatenated JSDoc from
all declarations when a symbol had multiple (intersection, declaration
merging, module augmentation). This produced duplicated descriptions in
generated propTypes.

Fix: use "last declaration wins" for all multi-declaration cases,
consistent with `squashPropTypeDefinitions`.

Added tests for intersection, interface extends, interface override,
and declaration merging scenarios.

This change has no effect on this repo and affects around 7 api/proptypes generation in X repo.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
