### PR TITLE
[docs] Fix Popover JSdoc

### DIFF
--- a/docs/data/material/components/popover/popover.md
+++ b/docs/data/material/components/popover/popover.md
@@ -13,7 +13,7 @@ githubSource: packages/mui-material/src/Popover
 Things to know when using the `Popover` component:
 
 - The component is built on top of the [`Modal`](/material-ui/react-modal/) component.
-- The scroll and click away are blocked unlike with the [`Popper`](/material-ui/react-popper/) component.
+- Unlike with the [`Popper`](/material-ui/react-popper/) component, scrolling is blocked, and click away is built-in.
 
 {{"component": "@mui/internal-core-docs/ComponentLinkHeader", "design": false}}
 

--- a/docs/data/material/components/popover/popover.md
+++ b/docs/data/material/components/popover/popover.md
@@ -13,7 +13,7 @@ githubSource: packages/mui-material/src/Popover
 Things to know when using the `Popover` component:
 
 - The component is built on top of the [`Modal`](/material-ui/react-modal/) component.
-- Unlike with the [`Popper`](/material-ui/react-popper/) component, scrolling is blocked, and click away is built-in.
+- `Popover` blocks scrolling and dismisses on click-away by default, unlike [`Popper`](/material-ui/react-popper/).
 
 {{"component": "@mui/internal-core-docs/ComponentLinkHeader", "design": false}}
 


### PR DESCRIPTION
hey, saw #39973 and took a look

the popover docs said "scroll and click away are blocked" which was misleading since click away isn't blocked the same way scroll is. updated the line to say scrolling is blocked and click away is built-in, which is more accurate and matches what the maintainer suggested in teh issue thread.

fixes #39973

---

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
