### PR TITLE
[codemod] Add --jsx option to `v9.0.0/system-props` codemod

### DIFF
--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -2272,7 +2272,7 @@ Use `--jsx` to specify extra JSX tags to migrate, bypassing import detection:
 npx @mui/codemod@latest v9.0.0/system-props <path/to/folder> -- --jsx=Box,Typography,Stack,Link,Grid,DialogContentText
 ```
 
-This is useful if your project uses auto-import plugins (for example `unplugin-auto-import`) where MUI components are available without explicit import statements.
+This is useful if your project uses auto-import plugins (for example `unplugin-auto-import`) where Material UI components are available without explicit import statements.
 
 The deprecated system props have been removed from the following components:
 

--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -2272,7 +2272,7 @@ Use `--jsx` to specify extra JSX tags to migrate, bypassing import detection:
 npx @mui/codemod@latest v9.0.0/system-props <path/to/folder> -- --jsx=Box,Typography,Stack,Link,Grid,DialogContentText
 ```
 
-This is useful if your project uses auto-import plugins (e.g. `unplugin-auto-import`) where MUI components are available without explicit import statements.
+This is useful if your project uses auto-import plugins (for example `unplugin-auto-import`) where MUI components are available without explicit import statements.
 
 The deprecated system props have been removed from the following components:
 

--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -2266,6 +2266,14 @@ Use the [system-props codemod](https://github.com/mui/material-ui/blob/master/pa
 npx @mui/codemod@latest v9.0.0/system-props <path/to/folder>
 ```
 
+Use `--jsx` to specify extra JSX tags to migrate, bypassing import detection:
+
+```bash
+npx @mui/codemod@latest v9.0.0/system-props <path/to/folder> -- --jsx=Box,Typography,Stack,Link,Grid,DialogContentText
+```
+
+This is useful if your project uses auto-import plugins (e.g. `unplugin-auto-import`) where MUI components are available without explicit import statements.
+
 The deprecated system props have been removed from the following components:
 
 - `Box`

--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -2546,7 +2546,7 @@ Compared to the v6 codemod, the v9 version also handles:
 ```
 
 You can also pass `--jsx` to specify JSX element names directly, bypassing import detection.
-This is useful for projects using auto-import plugins (e.g. `unplugin-auto-import`) where MUI components are available without explicit import statements:
+This is useful for projects using auto-import plugins (for example `unplugin-auto-import`) where MUI components are available without explicit import statements:
 
 ```bash
 npx @mui/codemod@latest v9.0.0/system-props <path> -- --jsx=Box,Typography,Stack,Link,Grid,DialogContentText

--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -2545,6 +2545,13 @@ Compared to the v6 codemod, the v9 version also handles:
 +<Link href="#" sx={{ color: "text.secondary" }} />
 ```
 
+You can also pass `--jsx` to specify JSX element names directly, bypassing import detection.
+This is useful for projects using auto-import plugins (e.g. `unplugin-auto-import`) where MUI components are available without explicit import statements:
+
+```bash
+npx @mui/codemod@latest v9.0.0/system-props <path> -- --jsx=Box,Typography,Stack,Link,Grid,DialogContentText
+```
+
 ### v7.0.0
 
 #### `theme-color-functions`

--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -2546,7 +2546,7 @@ Compared to the v6 codemod, the v9 version also handles:
 ```
 
 You can also pass `--jsx` to specify JSX element names directly, bypassing import detection.
-This is useful for projects using auto-import plugins (for example `unplugin-auto-import`) where MUI components are available without explicit import statements:
+This is useful for projects using auto-import plugins (for example `unplugin-auto-import`) where Material UI components are available without explicit import statements:
 
 ```bash
 npx @mui/codemod@latest v9.0.0/system-props <path> -- --jsx=Box,Typography,Stack,Link,Grid,DialogContentText

--- a/packages/mui-codemod/src/v9.0.0/system-props/removeSystemProps.js
+++ b/packages/mui-codemod/src/v9.0.0/system-props/removeSystemProps.js
@@ -180,6 +180,19 @@ export default function removeSystemProps(file, api, options) {
     },
   };
   const elementReplacement = {};
+
+  if (options.jsx) {
+    options.jsx.split(',').forEach((name) => {
+      const trimmed = name.trim();
+      if (components.includes(trimmed)) {
+        deprecatedElements.push(trimmed);
+        if (customReplacement[trimmed]) {
+          elementReplacement[trimmed] = customReplacement[trimmed];
+        }
+      }
+    });
+  }
+
   const packageName = options.packageName;
   const importSources = ['@mui'];
 

--- a/packages/mui-codemod/src/v9.0.0/system-props/removeSystemProps.js
+++ b/packages/mui-codemod/src/v9.0.0/system-props/removeSystemProps.js
@@ -184,11 +184,12 @@ export default function removeSystemProps(file, api, options) {
   if (options.jsx) {
     options.jsx.split(',').forEach((name) => {
       const trimmed = name.trim();
-      if (components.includes(trimmed)) {
-        deprecatedElements.push(trimmed);
-        if (customReplacement[trimmed]) {
-          elementReplacement[trimmed] = customReplacement[trimmed];
-        }
+      if (!trimmed) {
+        return;
+      }
+      deprecatedElements.push(trimmed);
+      if (customReplacement[trimmed]) {
+        elementReplacement[trimmed] = customReplacement[trimmed];
       }
     });
   }

--- a/packages/mui-codemod/src/v9.0.0/system-props/removeSystemProps.test.js
+++ b/packages/mui-codemod/src/v9.0.0/system-props/removeSystemProps.test.js
@@ -43,6 +43,17 @@ describe('@mui/codemod', () => {
       expect(actual).to.equal(expected, 'The transformed version should be correct');
     });
 
+    it('transforms props for jsx option (auto-imported components)', () => {
+      const actual = transform(
+        { source: read('./test-cases/system-props-jsx.actual.js') },
+        { jscodeshift },
+        { jsx: 'Box,Typography,Stack,Link' },
+      );
+
+      const expected = read('./test-cases/system-props-jsx.expected.js');
+      expect(actual).to.equal(expected, 'The transformed version should be correct');
+    });
+
     it('does not transform similarly named packages', () => {
       const actual = transform(
         { source: read('./test-cases/system-props-package-name-similar.actual.js') },

--- a/packages/mui-codemod/src/v9.0.0/system-props/removeSystemProps.test.js
+++ b/packages/mui-codemod/src/v9.0.0/system-props/removeSystemProps.test.js
@@ -54,6 +54,17 @@ describe('@mui/codemod', () => {
       expect(actual).to.equal(expected, 'The transformed version should be correct');
     });
 
+    it('accepts arbitrary component names in jsx option', () => {
+      const actual = transform(
+        { source: read('./test-cases/system-props-jsx-custom.actual.js') },
+        { jscodeshift },
+        { jsx: 'DialogTitle,Skeleton,SvgIcon' },
+      );
+
+      const expected = read('./test-cases/system-props-jsx-custom.expected.js');
+      expect(actual).to.equal(expected, 'The transformed version should be correct');
+    });
+
     it('does not transform similarly named packages', () => {
       const actual = transform(
         { source: read('./test-cases/system-props-package-name-similar.actual.js') },

--- a/packages/mui-codemod/src/v9.0.0/system-props/test-cases/system-props-jsx-custom.actual.js
+++ b/packages/mui-codemod/src/v9.0.0/system-props/test-cases/system-props-jsx-custom.actual.js
@@ -1,0 +1,6 @@
+// --jsx accepts arbitrary component names (e.g. DialogTitle, Skeleton, SvgIcon)
+<DialogTitle display="flex" alignItems="center">Title</DialogTitle>;
+
+<Skeleton height={60} width={100} mb={2} />;
+
+<SvgIcon width="1rem" height="1rem" />;

--- a/packages/mui-codemod/src/v9.0.0/system-props/test-cases/system-props-jsx-custom.expected.js
+++ b/packages/mui-codemod/src/v9.0.0/system-props/test-cases/system-props-jsx-custom.expected.js
@@ -1,0 +1,19 @@
+// --jsx accepts arbitrary component names (e.g. DialogTitle, Skeleton, SvgIcon)
+<DialogTitle
+  sx={{
+    display: "flex",
+    alignItems: "center"
+  }}>Title</DialogTitle>;
+
+<Skeleton
+  sx={{
+    height: 60,
+    width: 100,
+    mb: 2
+  }} />;
+
+<SvgIcon
+  sx={{
+    width: "1rem",
+    height: "1rem"
+  }} />;

--- a/packages/mui-codemod/src/v9.0.0/system-props/test-cases/system-props-jsx.actual.js
+++ b/packages/mui-codemod/src/v9.0.0/system-props/test-cases/system-props-jsx.actual.js
@@ -1,0 +1,11 @@
+// No import statements — components are auto-imported
+<Box display="flex" gap={2} p={3}>
+  <Typography fontSize={14} fontWeight={600}>Hello</Typography>
+</Box>;
+
+<Stack direction="row" spacing={2} mt={1} />;
+
+<Link color="inherit" href="https://mui.com/" mb={2}>MUI</Link>;
+
+const sx = { display: 'flex' };
+<Box m={2} sx={sx} />;

--- a/packages/mui-codemod/src/v9.0.0/system-props/test-cases/system-props-jsx.expected.js
+++ b/packages/mui-codemod/src/v9.0.0/system-props/test-cases/system-props-jsx.expected.js
@@ -1,0 +1,27 @@
+// No import statements — components are auto-imported
+<Box
+  sx={{
+    display: "flex",
+    gap: 2,
+    p: 3
+  }}>
+  <Typography
+    sx={{
+      fontSize: 14,
+      fontWeight: 600
+    }}>Hello</Typography>
+</Box>;
+
+<Stack direction="row" spacing={2} sx={{
+  mt: 1
+}} />;
+
+<Link color="inherit" href="https://mui.com/" sx={{
+  mb: 2
+}}>MUI</Link>;
+
+const sx = { display: 'flex' };
+<Box
+  sx={[{
+    m: 2
+  }, ...(Array.isArray(sx) ? sx : [sx])]} />;


### PR DESCRIPTION
closes #48269

## Summary

The `v9.0.0/system-props` codemod relies on import detection to identify MUI components. This means it produces 0 changes in projects that use auto-import plugins (e.g. `unplugin-auto-import`) where components like `Box`, `Typography`, etc. are globally available without explicit import statements.

This PR adds a `--jsx` option that accepts a comma-separated list of JSX element names to treat as MUI components, bypassing import detection:

```bash
npx @mui/codemod@latest v9.0.0/system-props src/ -- --jsx=Box,Typography,Stack,Link,Grid,DialogContentText
```

## For Reviewers

The `--jsx` option is passed as a codemod-specific flag (via `--`) rather than a global CLI option, following the existing pattern used by `--component`, `--from`, `--to` flags (see [codemod.js L221](https://github.com/mui/material-ui/blob/master/packages/mui-codemod/src/codemod.js#L221)).

In [`removeSystemProps.js`](https://github.com/mui/material-ui/pull/48315/files#diff-4657d16044bd82ccad4b83db0ab766fd7095fb1eeecf113c272703951707caf2R183-R193), when `options.jsx` is provided, the comma-separated names are parsed and added directly to `deprecatedElements[]` (with `elementReplacement` for Typography/Link special color handling), before the import scanning phase runs. This means both mechanisms can work together — imports are still scanned normally, and `--jsx` adds additional targets.

Only names matching the known `components` list are accepted to avoid accidental transforms on unrelated elements.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).