### PR TITLE
[docs] Update MUI X roadmap section

### DIFF
--- a/docs/src/components/productX/XRoadmap.tsx
+++ b/docs/src/components/productX/XRoadmap.tsx
@@ -10,10 +10,10 @@ import CalendarMonthRoundedIcon from '@mui/icons-material/CalendarMonthRounded';
 import AccountTreeRounded from '@mui/icons-material/AccountTreeRounded';
 import BarChartRounded from '@mui/icons-material/BarChartRounded';
 import FileUploadRounded from '@mui/icons-material/FileUploadRounded';
-import PendingActionsRounded from '@mui/icons-material/PendingActions';
 import FormatSizeRoundedIcon from '@mui/icons-material/FormatSizeRounded';
 import ViewTimelineIcon from '@mui/icons-material/ViewTimeline';
-import AssistantIcon from '@mui/icons-material/Assistant';
+import EventNoteRoundedIcon from '@mui/icons-material/EventNoteRounded';
+import ForumRoundedIcon from '@mui/icons-material/ForumRounded';
 import { alpha } from '@mui/material/styles';
 import { ROUTES } from '@mui/internal-core-docs/constants';
 import { Link } from '@mui/internal-core-docs/Link';
@@ -143,9 +143,9 @@ export default function XRoadmap() {
               </Typography>
               {renderList(
                 <React.Fragment>
-                  <PendingActionsRounded sx={{ fontSize: 16 }} />
+                  <EventNoteRoundedIcon sx={{ fontSize: 16 }} />
                   Scheduler
-                  <AssistantIcon sx={{ fontSize: 16 }} />
+                  <ForumRoundedIcon sx={{ fontSize: 16 }} />
                   Chat
                 </React.Fragment>,
               )}

--- a/docs/src/components/productX/XRoadmap.tsx
+++ b/docs/src/components/productX/XRoadmap.tsx
@@ -13,6 +13,7 @@ import FileUploadRounded from '@mui/icons-material/FileUploadRounded';
 import PendingActionsRounded from '@mui/icons-material/PendingActions';
 import FormatSizeRoundedIcon from '@mui/icons-material/FormatSizeRounded';
 import ViewTimelineIcon from '@mui/icons-material/ViewTimeline';
+import AssistantIcon from '@mui/icons-material/Assistant';
 import { alpha } from '@mui/material/styles';
 import { ROUTES } from '@mui/internal-core-docs/constants';
 import { Link } from '@mui/internal-core-docs/Link';
@@ -40,7 +41,7 @@ function RoadmapStatusDot({ color }: RoadmapStatusDotProps) {
 }
 
 export default function XRoadmap() {
-  function renderList(content: React.ReactElement<unknown>, nested?: boolean) {
+  function renderList(content: React.ReactElement<unknown>) {
     return (
       <Box
         sx={{
@@ -49,43 +50,13 @@ export default function XRoadmap() {
           alignItems: 'center',
           gap: 1.5,
           gridTemplateColumns: 'max-content 1fr',
-          position: 'relative',
           fontWeight: 'semiBold',
-          ...(nested && {
-            '&::before': {
-              content: '""',
-              display: 'block',
-              position: 'absolute',
-              width: 1.5,
-              bgcolor: 'primaryDark.600',
-              top: 24,
-              bottom: 10,
-              left: 8,
-            },
-          }),
         }}
       >
         {content}
       </Box>
     );
   }
-  const bullet = (
-    <Box
-      sx={{
-        ml: 1,
-        mr: -2,
-        display: 'flex',
-        alignItems: 'center',
-        '&::before': {
-          content: '""',
-          display: 'block',
-          height: 1.5,
-          width: 15,
-          bgcolor: 'primaryDark.600',
-        },
-      }}
-    />
-  );
   return (
     <Section
       cozy
@@ -167,44 +138,16 @@ export default function XRoadmap() {
                 variant="body2"
                 sx={{ fontWeight: 'bold', color: 'text.primary' }}
               >
-                Work in progress
+                Alpha
                 <RoadmapStatusDot color="warning.main" />
               </Typography>
               {renderList(
                 <React.Fragment>
-                  <Box sx={{ lineHeight: 0 }}>
-                    <PivotTableChartRoundedIcon sx={{ fontSize: 16 }} />
-                  </Box>
-                  Data Grid
-                  {bullet}
-                  <Typography
-                    variant="body2"
-                    sx={{ color: 'text.secondary', fontWeight: 'medium' }}
-                  >
-                    Charts integration
-                  </Typography>
-                  {bullet}
-                  <Link href={ROUTES.dataGridFeaturesComparison} sx={{ color: 'primary.300' }}>
-                    And more!
-                  </Link>
+                  <PendingActionsRounded sx={{ fontSize: 16 }} />
+                  Scheduler
+                  <AssistantIcon sx={{ fontSize: 16 }} />
+                  Chat
                 </React.Fragment>,
-                true,
-              )}
-              {renderList(
-                <React.Fragment>
-                  <Box sx={{ lineHeight: 0 }}>
-                    <AccountTreeRounded sx={{ fontSize: 16 }} />
-                  </Box>
-                  Tree View
-                  {bullet}
-                  <Typography
-                    variant="body2"
-                    sx={{ color: 'text.secondary', fontWeight: 'medium' }}
-                  >
-                    Virtualization
-                  </Typography>
-                </React.Fragment>,
-                true,
               )}
             </Paper>
           </Grid>
@@ -224,8 +167,6 @@ export default function XRoadmap() {
                   Rich Text Editor
                   <FileUploadRounded sx={{ fontSize: 16 }} />
                   Upload
-                  <PendingActionsRounded sx={{ fontSize: 16 }} />
-                  Scheduler
                   <ViewTimelineIcon sx={{ fontSize: 16 }} />
                   Gantt
                 </React.Fragment>,

--- a/docs/src/components/productX/XRoadmap.tsx
+++ b/docs/src/components/productX/XRoadmap.tsx
@@ -138,7 +138,7 @@ export default function XRoadmap() {
                 variant="body2"
                 sx={{ fontWeight: 'bold', color: 'text.primary' }}
               >
-                Alpha
+                Preview
                 <RoadmapStatusDot color="warning.main" />
               </Typography>
               {renderList(


### PR DESCRIPTION
## Summary

- Rename "Work in progress" column to "Alpha" on the MUI X landing page roadmap.
- Replace alpha column contents with Scheduler (`EventNoteRoundedIcon`) and Chat (`ForumRoundedIcon`), matching the megamenu icons.
- Remove Scheduler from the "Future components" column.


**Before**:

<img width="1250" height="418" alt="image" src="https://github.com/user-attachments/assets/8e5f5347-43e6-4af4-a7ec-8b3e2381052e" />


**After**:

<img width="1322" height="432" alt="image" src="https://github.com/user-attachments/assets/aa0a07eb-cb7e-472d-a958-006e4e9ebbb4" />

