### PR TITLE
[docs] Sync query parameter state with router updates

### DIFF
--- a/docs/src/modules/utils/useQueryParameterState.test.tsx
+++ b/docs/src/modules/utils/useQueryParameterState.test.tsx
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+import { act, renderHook } from '@mui/internal-test-utils';
+import { vi } from 'vitest';
+import useQueryParameterState from './useQueryParameterState';
+
+const useRouter = vi.fn();
+
+vi.mock('next/router', () => ({
+  useRouter: () => useRouter(),
+}));
+
+describe('useQueryParameterState', () => {
+  const originalLocation = window.location;
+
+  describe.skipIf(typeof navigator !== 'undefined' && !navigator.userAgent.includes('jsdom'))(
+    'jsdom-only',
+    () => {
+      afterEach(() => {
+        useRouter.mockReset();
+        window.history.replaceState({}, '', '/');
+      });
+
+      afterAll(() => {
+        Object.defineProperty(window, 'location', {
+          configurable: true,
+          value: originalLocation,
+        });
+      });
+
+      it('syncs the state when the query parameter is removed externally', () => {
+        const replace = vi.fn();
+        const router = {
+          pathname: '/material-ui/material-icons/',
+          query: { selected: 'AreaChartTwoTone' },
+          replace,
+        };
+
+        useRouter.mockImplementation(() => router);
+        window.history.replaceState({}, '', '/material-ui/material-icons/?selected=AreaChartTwoTone');
+
+        const { result, rerender } = renderHook(() => useQueryParameterState('selected', ''));
+
+        expect(result.current[0]).to.equal('AreaChartTwoTone');
+
+        act(() => {
+          result.current[1]('');
+        });
+
+        expect(result.current[0]).to.equal('');
+
+        act(() => {
+          router.query = {};
+          window.history.replaceState({}, '', '/material-ui/material-icons/');
+          rerender();
+        });
+
+        expect(result.current[0]).to.equal('');
+      });
+    },
+  );
+});

--- a/docs/src/modules/utils/useQueryParameterState.ts
+++ b/docs/src/modules/utils/useQueryParameterState.ts
@@ -25,6 +25,10 @@ export default function useQueryParameterState(
 
   const [state, setState] = React.useState(urlValue || initialValue);
 
+  React.useEffect(() => {
+    setState(urlValue || initialValue);
+  }, [initialValue, urlValue]);
+
   const setUrlValue = React.useMemo(
     () =>
       debounce((newValue = '') => {
@@ -69,7 +73,7 @@ export default function useQueryParameterState(
     [setUrlValue],
   );
 
-  // Make sure to initialize the state when route params are only available client-side
+  // Make sure to initialize the state when route params are only available client-side.
   const isInitialized = React.useRef(false);
   React.useEffect(() => {
     if (isInitialized.current) {


### PR DESCRIPTION
## Summary
- sync `useQueryParameterState` when the router query changes after shallow route updates
- keep the existing client-side initialization path for first render
- add a focused test covering external query-parameter removal

Closes #48312.

## Testing
- `pnpm test:unit docs/src/modules/utils/useQueryParameterState.test.tsx`
- `pnpm typescript`