### PR TITLE
[accessibility] Make Slider and some docs examples visible in HighContrast Mode

### DIFF
--- a/docs/data/material/components/radio-buttons/CustomizedRadios.js
+++ b/docs/data/material/components/radio-buttons/CustomizedRadios.js
@@ -28,6 +28,12 @@ const BpIcon = styled('span')(({ theme }) => ({
     ...theme.applyStyles('dark', {
       background: 'rgba(57,75,89,.5)',
     }),
+    '@media (forced-colors: active)': {
+      outline: '1px solid GrayText',
+    },
+  },
+  '@media (forced-colors: active)': {
+    outline: '1px solid ButtonText',
   },
   ...theme.applyStyles('dark', {
     boxShadow: '0 0 0 1px rgb(16 22 26 / 40%)',
@@ -45,9 +51,20 @@ const BpCheckedIcon = styled(BpIcon)({
     height: 16,
     backgroundImage: 'radial-gradient(#fff,#fff 28%,transparent 32%)',
     content: '""',
+    '@media (forced-colors: active)': {
+      backgroundImage: 'none',
+      backgroundColor: 'ButtonText',
+      borderRadius: '50%',
+      width: 8,
+      height: 8,
+      margin: 4,
+    },
   },
   'input:hover ~ &': {
     backgroundColor: '#106ba3',
+  },
+  '@media (forced-colors: active)': {
+    outline: '2px solid ButtonText',
   },
 });
 

--- a/docs/data/material/components/radio-buttons/CustomizedRadios.tsx
+++ b/docs/data/material/components/radio-buttons/CustomizedRadios.tsx
@@ -28,6 +28,12 @@ const BpIcon = styled('span')(({ theme }) => ({
     ...theme.applyStyles('dark', {
       background: 'rgba(57,75,89,.5)',
     }),
+    '@media (forced-colors: active)': {
+      outline: '1px solid GrayText',
+    },
+  },
+  '@media (forced-colors: active)': {
+    outline: '1px solid ButtonText',
   },
   ...theme.applyStyles('dark', {
     boxShadow: '0 0 0 1px rgb(16 22 26 / 40%)',
@@ -45,9 +51,20 @@ const BpCheckedIcon = styled(BpIcon)({
     height: 16,
     backgroundImage: 'radial-gradient(#fff,#fff 28%,transparent 32%)',
     content: '""',
+    '@media (forced-colors: active)': {
+      backgroundImage: 'none',
+      backgroundColor: 'ButtonText',
+      borderRadius: '50%',
+      width: 8,
+      height: 8,
+      margin: 4,
+    },
   },
   'input:hover ~ &': {
     backgroundColor: '#106ba3',
+  },
+  '@media (forced-colors: active)': {
+    outline: '2px solid ButtonText',
   },
 });
 

--- a/docs/data/material/components/radio-buttons/ErrorRadios.js
+++ b/docs/data/material/components/radio-buttons/ErrorRadios.js
@@ -15,6 +15,7 @@ export default function ErrorRadios() {
   const handleRadioChange = (event) => {
     setValue(event.target.value);
     setError(false);
+    setHelperText('Choose wisely');
   };
 
   const handleSubmit = (event) => {

--- a/docs/data/material/components/radio-buttons/ErrorRadios.js
+++ b/docs/data/material/components/radio-buttons/ErrorRadios.js
@@ -14,7 +14,6 @@ export default function ErrorRadios() {
 
   const handleRadioChange = (event) => {
     setValue(event.target.value);
-    setHelperText(' ');
     setError(false);
   };
 

--- a/docs/data/material/components/radio-buttons/ErrorRadios.tsx
+++ b/docs/data/material/components/radio-buttons/ErrorRadios.tsx
@@ -15,6 +15,7 @@ export default function ErrorRadios() {
   const handleRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
     setError(false);
+    setHelperText('Choose wisely');
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {

--- a/docs/data/material/components/radio-buttons/ErrorRadios.tsx
+++ b/docs/data/material/components/radio-buttons/ErrorRadios.tsx
@@ -13,8 +13,7 @@ export default function ErrorRadios() {
   const [helperText, setHelperText] = React.useState('Choose wisely');
 
   const handleRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setValue((event.target as HTMLInputElement).value);
-    setHelperText(' ');
+    setValue(event.target.value);
     setError(false);
   };
 

--- a/docs/data/material/components/rating/RadioGroupRating.js
+++ b/docs/data/material/components/rating/RadioGroupRating.js
@@ -10,7 +10,7 @@ import SentimentVerySatisfiedIcon from '@mui/icons-material/SentimentVerySatisfi
 
 const StyledRating = styled(Rating)(({ theme }) => ({
   '& .MuiRating-iconEmpty .MuiSvgIcon-root': {
-    color: theme.palette.action.disabled,
+    color: (theme.vars || theme).palette.action.disabled,
   },
 }));
 

--- a/docs/data/material/components/rating/RadioGroupRating.tsx
+++ b/docs/data/material/components/rating/RadioGroupRating.tsx
@@ -9,7 +9,7 @@ import SentimentVerySatisfiedIcon from '@mui/icons-material/SentimentVerySatisfi
 
 const StyledRating = styled(Rating)(({ theme }) => ({
   '& .MuiRating-iconEmpty .MuiSvgIcon-root': {
-    color: theme.palette.action.disabled,
+    color: (theme.vars || theme).palette.action.disabled,
   },
 }));
 

--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -66,6 +66,10 @@ const AvatarRoot = styled('div', {
         props: { colorDefault: true },
         style: {
           color: (theme.vars || theme).palette.background.default,
+          '@media (forced-colors: active)': {
+            boxSizing: 'border-box',
+            border: '1px solid ButtonBorder',
+          },
           ...(theme.vars
             ? {
                 backgroundColor: theme.vars.palette.Avatar.defaultBg,

--- a/packages/mui-material/src/Badge/Badge.js
+++ b/packages/mui-material/src/Badge/Badge.js
@@ -85,6 +85,9 @@ const BadgeBadge = styled('span', {
     height: RADIUS_STANDARD * 2,
     borderRadius: RADIUS_STANDARD,
     zIndex: 1, // Render the badge on top of potential ripples.
+    '@media (forced-colors: active)': {
+      border: '1px solid ButtonBorder',
+    },
     transition: theme.transitions.create('transform', {
       easing: theme.transitions.easing.easeInOut,
       duration: theme.transitions.duration.enteringScreen,

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -131,8 +131,10 @@ export const SliderRail = styled('span', {
   borderRadius: 'inherit',
   backgroundColor: 'currentColor',
   opacity: 0.38,
-  border: '1px solid transparent',
-  boxSizing: 'border-box',
+  '@media (forced-colors: active)': {
+    border: '1px solid transparent',
+    boxSizing: 'border-box',
+  },
   variants: [
     {
       props: { orientation: 'horizontal' },

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -250,7 +250,7 @@ export const SliderThumb = styled('span', {
       duration: theme.transitions.duration.shortest,
     }),
     '@media (forced-colors: active)': {
-      border: '1px solid transparent',
+      border: '1px solid ButtonBorder',
     },
     '&::before': {
       position: 'absolute',

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -249,6 +249,9 @@ export const SliderThumb = styled('span', {
     transition: theme.transitions.create(['box-shadow', 'left', 'bottom'], {
       duration: theme.transitions.duration.shortest,
     }),
+    '@media (forced-colors: active)': {
+      border: '1px solid transparent',
+    },
     '&::before': {
       position: 'absolute',
       content: '""',
@@ -273,7 +276,6 @@ export const SliderThumb = styled('span', {
         boxShadow: 'none',
       },
     },
-    border: '1px solid transparent',
     variants: [
       {
         props: { size: 'small' },

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -179,7 +179,9 @@ export const SliderTrack = styled('span', {
         {
           props: { size: 'small' },
           style: {
-            border: 'none',
+            '@media (forced-colors: none)': {
+              border: 'none',
+            },
           },
         },
         {

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -131,6 +131,8 @@ export const SliderRail = styled('span', {
   borderRadius: 'inherit',
   backgroundColor: 'currentColor',
   opacity: 0.38,
+  border: '1px solid transparent',
+  boxSizing: 'border-box',
   variants: [
     {
       props: { orientation: 'horizontal' },
@@ -271,6 +273,7 @@ export const SliderThumb = styled('span', {
         boxShadow: 'none',
       },
     },
+    border: '1px solid transparent',
     variants: [
       {
         props: { size: 'small' },

--- a/packages/mui-material/src/Switch/Switch.js
+++ b/packages/mui-material/src/Switch/Switch.js
@@ -193,12 +193,14 @@ const SwitchTrack = styled('span', {
     height: '100%',
     width: '100%',
     borderRadius: 14 / 2,
-    boxSizing: 'border-box',
-    border: '1px solid transparent',
     zIndex: -1,
     transition: theme.transitions.create(['opacity', 'background-color'], {
       duration: theme.transitions.duration.shortest,
     }),
+    '@media (forced-colors: active)': {
+      boxSizing: 'border-box',
+      border: '1px solid ButtonBorder',
+    },
     backgroundColor: theme.vars
       ? theme.vars.palette.common.onBackground
       : `${theme.palette.mode === 'light' ? theme.palette.common.black : theme.palette.common.white}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Cherry picked some High Contrast improvements from [this PR](https://github.com/mui/material-ui/pull/48271) that were not part of the new High Contrast Theme.

Partial fix for https://github.com/mui/material-ui/issues/13174.

Improve Windows High Contrast Mode (forced-colors) support for Slider, Switch, and Avatar.

- **Slider**: Added a visible border to the rail and thumb in HCM. Scoped the small track's `border: none` to non-HCM so it stays visible.
- **Switch**: Replaced the always-on transparent track border with a HCM-only `ButtonBorder` border, avoiding a visual regression in normal mode.
- **Avatar**: Added a `ButtonBorder` border in HCM for letter/default color avatars.
- **Docs**: Fixed `CustomizedRadios`, `ErrorRadios`, and `RadioGroupRating` demos for correct HCM rendering.
- **Badge**: Added a `ButtonBorder` border in HCM to make the badge distinguishable without color.

|Component|Before|After|
|--|--|--|
|[Slider](https://deploy-preview-48320--material-ui.netlify.app/material-ui/react-slider)|<img width="248" height="100" alt="Screenshot 2026-04-16 at 16 13 46" src="https://github.com/user-attachments/assets/5f308912-2fdf-4281-8405-d3680243e740" />|<img width="282" height="100" alt="Screenshot 2026-04-16 at 16 14 43" src="https://github.com/user-attachments/assets/c5612041-f343-4314-a1e7-eac61acad53e" />|
|[Small and Medium Slider](https://deploy-preview-48320--material-ui.netlify.app/material-ui/react-slider/#sizes)|<img width="367" height="101" alt="Screenshot 2026-04-20 at 16 39 53" src="https://github.com/user-attachments/assets/6d46c3dc-2317-4436-986e-fa5ce3edb5fe" />|<img width="346" height="88" alt="Screenshot 2026-04-20 at 16 39 34" src="https://github.com/user-attachments/assets/2befeb91-11a7-4f8f-b776-0f6567e65147" />|
|[Customized Radio Example](https://deploy-preview-48320--material-ui.netlify.app/material-ui/react-radio-button/#customization)|<img width="239" height="201" alt="Screenshot 2026-04-15 at 20 49 00" src="https://github.com/user-attachments/assets/7b25f399-bfea-4a07-bd42-3d38a8610c86" />|<img width="216" height="175" alt="Screenshot 2026-04-15 at 20 49 04" src="https://github.com/user-attachments/assets/4342b9cf-e903-4734-964a-34a13b3a996a" />|
|[Rating Radio Example (Dark Mode)](https://deploy-preview-48320--material-ui.netlify.app/material-ui/react-rating/#radio-group)|<img width="147" height="49" alt="Screenshot 2026-04-15 at 20 45 33" src="https://github.com/user-attachments/assets/e6c2418e-5829-4581-9701-095192987791" />|<img width="147" height="58" alt="Screenshot 2026-04-15 at 20 45 15" src="https://github.com/user-attachments/assets/82920394-09db-41aa-bbc8-0c346222fe5e" />|
|[Avatar with letters](https://deploy-preview-48320--material-ui.netlify.app/material-ui/react-avatar/#letter-avatars)|<img width="217" height="72" alt="Screenshot 2026-04-20 at 16 56 24" src="https://github.com/user-attachments/assets/af9db81a-c7fa-4d41-b5f4-c834764c6c60" />|<img width="220" height="81" alt="Screenshot 2026-04-20 at 16 56 05" src="https://github.com/user-attachments/assets/642d21b0-5918-4aea-bf76-9936ea4b952a" />|
|[Badge](https://deploy-preview-48320--material-ui.netlify.app/material-ui/react-badge)|<img width="73" height="56" alt="Screenshot 2026-04-20 at 17 03 30" src="https://github.com/user-attachments/assets/4da3e61d-f317-4c28-9b16-65ac1022318c" />|<img width="68" height="53" alt="Screenshot 2026-04-20 at 17 03 21" src="https://github.com/user-attachments/assets/4edeb61c-81bf-4885-875f-135c6d645b92" />|