### PR TITLE
[material-ui][Grow] Fix text shift on hover after animation ends (#40414)

### DIFF
--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -42,8 +42,6 @@ export const ButtonBaseRoot = styled('button', {
   position: 'relative',
   boxSizing: 'border-box',
   WebkitTapHighlightColor: 'transparent',
-  WebkitFontSmoothing: 'antialiased',
-  MozOsxFontSmoothing: 'grayscale',
   backgroundColor: 'transparent', // Reset default value
   // We disable the focus ring for mouse, touch and keyboard users.
   outline: 0,

--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -42,6 +42,8 @@ export const ButtonBaseRoot = styled('button', {
   position: 'relative',
   boxSizing: 'border-box',
   WebkitTapHighlightColor: 'transparent',
+  WebkitFontSmoothing: 'antialiased',
+  MozOsxFontSmoothing: 'grayscale',
   backgroundColor: 'transparent', // Reset default value
   // We disable the focus ring for mouse, touch and keyboard users.
   outline: 0,

--- a/packages/mui-material/src/Grow/Grow.js
+++ b/packages/mui-material/src/Grow/Grow.js
@@ -20,7 +20,7 @@ function getScale(value) {
 
 const styles = {
   entering: { opacity: 1, transform: getScale(1) },
-  entered: { opacity: 1, transform: 'none' },
+  entered: { opacity: 1, transform: getScale(1) },
   exiting: { opacity: 0, transform: getScale(0.75) },
   exited: { opacity: 0, transform: getScale(0.75) },
 };


### PR DESCRIPTION
Fixes #40414

## Problem

When hovering a `MenuItem` inside a `Menu`, the text shifts slightly on the first hover. It only affects menus that open with an animation (Grow transition) — a static always-open `MenuList` does not have this issue.

## Root cause

The `Grow` animation uses `transform: scale()` to animate the menu open. When the animation completes, the `entered` state sets `transform: 'none'`:

```js
const styles = {
  entering: { opacity: 1, transform: getScale(1) },
  entered: { opacity: 1, transform: 'none' },  // ← problem
  ...
};
```

Setting `transform: 'none'` causes the browser to **demote the element from its GPU compositing layer**. On the first hover after this, the `background-color` change triggers a CPU repaint where text is placed at slightly different subpixel positions — causing the visible 1px shift. After the first hover the element stays in that paint state, so subsequent hovers don't shift.

This explains why:
- It only happens on **first hover** (first repaint after demotion)
- It only happens in animated menus, **not** in always-visible `MenuList`
- It's more visible on Windows with 150% DPI scaling (subpixel differences are more noticeable)

## Fix

Use `getScale(1)` instead of `'none'` in the `entered` state. `scale(1, 1)` is visually identical to `none` but keeps the GPU compositing layer active, preventing the subpixel text shift on the first hover.

```js
entered: { opacity: 1, transform: getScale(1) },
```