### PR TITLE
[docs] Remove esm.sh references and endorsement (#44649)

### DIFF
--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -132,30 +132,6 @@ The Accordion component then derives the necessary `aria-labelledby` and `id` fr
 </Accordion>
 ```
 
-## Troubleshooting
-
-### Accordion is unresponsive when using esm.sh or importmaps
-
-If you are loading Material UI directly from a CDN using [esm.sh](https://esm.sh/) or native [import maps](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap), avoid using subpath imports for components that communicate with each other through React Context:
-
-```jsx
-// ❌ Breaks — each URL is a separate module bundle with its own copy of AccordionContext
-import Accordion from 'https://esm.sh/@mui/material/Accordion';
-import AccordionSummary from 'https://esm.sh/@mui/material/AccordionSummary';
-import AccordionDetails from 'https://esm.sh/@mui/material/AccordionDetails';
-```
-
-`Accordion` passes state to `AccordionSummary` via React Context. When each component is loaded from a different URL, they each get their own isolated copy of `AccordionContext`. The provider and consumer end up using different context objects, so the state never connects — leaving the Accordion frozen.
-
-Instead, import from the root package so all components share the same module instance:
-
-```jsx
-// ✅ Works — one bundle, one shared AccordionContext
-import { Accordion, AccordionSummary, AccordionDetails } from 'https://esm.sh/@mui/material';
-```
-
-This applies to any MUI component family where a parent passes context to its children: `Accordion`/`AccordionSummary`, `Select`/`MenuItem`, `RadioGroup`/`Radio`, and similar patterns.
-
 ## Anatomy
 
 The Accordion component consists of a root `<div>` that contains the Accordion Summary, Accordion Details, and optional Accordion Actions for action buttons.

--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -132,6 +132,30 @@ The Accordion component then derives the necessary `aria-labelledby` and `id` fr
 </Accordion>
 ```
 
+## Troubleshooting
+
+### Accordion is unresponsive when using esm.sh or importmaps
+
+If you are loading Material UI directly from a CDN using [esm.sh](https://esm.sh/) or native [import maps](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap), avoid using subpath imports for components that communicate with each other through React Context:
+
+```jsx
+// ❌ Breaks — each URL is a separate module bundle with its own copy of AccordionContext
+import Accordion from 'https://esm.sh/@mui/material/Accordion';
+import AccordionSummary from 'https://esm.sh/@mui/material/AccordionSummary';
+import AccordionDetails from 'https://esm.sh/@mui/material/AccordionDetails';
+```
+
+`Accordion` passes state to `AccordionSummary` via React Context. When each component is loaded from a different URL, they each get their own isolated copy of `AccordionContext`. The provider and consumer end up using different context objects, so the state never connects — leaving the Accordion frozen.
+
+Instead, import from the root package so all components share the same module instance:
+
+```jsx
+// ✅ Works — one bundle, one shared AccordionContext
+import { Accordion, AccordionSummary, AccordionDetails } from 'https://esm.sh/@mui/material';
+```
+
+This applies to any MUI component family where a parent passes context to its children: `Accordion`/`AccordionSummary`, `Select`/`MenuItem`, `RadioGroup`/`Radio`, and similar patterns.
+
 ## Anatomy
 
 The Accordion component consists of a root `<div>` that contains the Accordion Summary, Accordion Details, and optional Accordion Actions for action buttons.

--- a/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
+++ b/docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md
@@ -191,8 +191,7 @@ To align with React 19's removal of UMD builds, Material UI has also removed it
 This results in a reduction of the `@mui/material` package size by 2.5MB, or 25% of the total package size.
 See [Package Phobia](https://packagephobia.com/result?p=@mui/material) for more details.
 
-Instead, we recommend using ESM-based CDNs such as [esm.sh](https://esm.sh/).
-For alternative installation methods, refer to the [CDN documentation](/material-ui/getting-started/installation/#cdn).
+For alternative installation methods, refer to the [installation documentation](/material-ui/getting-started/installation/).
 
 ### Accordion
 


### PR DESCRIPTION
Fixes #44649

## Context

Based on @Janpot's feedback — esm.sh cannot correctly deduplicate across `@mui/*` packages, so we shouldn't endorse it in our docs.

## Changes

**`docs/data/material/components/accordion/accordion.md`**
- Removed the Troubleshooting section that guided esm.sh usage (was added in the first commit of this PR)

**`docs/data/material/migration/upgrade-to-v6/upgrade-to-v6.md`**
- Removed the explicit esm.sh recommendation from the "UMD bundle removed" section:
  - Before: `"Instead, we recommend using ESM-based CDNs such as esm.sh."`
  - After: `"For alternative installation methods, refer to the installation documentation."`