### PR TITLE
[docs-infra] Fix tab index on base ui tab

### DIFF
--- a/packages-internal/core-docs/src/Demo/Demo.tsx
+++ b/packages-internal/core-docs/src/Demo/Demo.tsx
@@ -685,7 +685,7 @@ export function Demo(props: DemoProps) {
               {/* A limitation from https://github.com/nihgwu/react-runner,
                 we can't inject the `window` of the iframe so we need a disableLiveEdit option. */}
               {tabs.map((tab, index) => (
-                <Tabs.Panel value={index} key={index}>
+                <Tabs.Panel value={index} key={index} tabIndex={-1}>
                   {demoOptions.disableLiveEdit || index > 0 ? (
                     <DemoCodeViewer
                       key={index}

--- a/packages-internal/core-docs/src/Demo/Demo.tsx
+++ b/packages-internal/core-docs/src/Demo/Demo.tsx
@@ -596,6 +596,7 @@ export function Demo(props: DemoProps) {
       console.error('Code content not copied', error);
     }
   };
+  const willRenderTabList = demoData.relativeModules && openDemoSource && !editorCode.isPreview;
 
   return (
     <Root>
@@ -667,7 +668,7 @@ export function Demo(props: DemoProps) {
             )}
           </DemoToolbarRoot>
           <Tabs.Root value={activeTab} onValueChange={handleTabChange}>
-            {demoData.relativeModules && openDemoSource && !editorCode.isPreview ? (
+            {willRenderTabList ? (
               <CodeTabList ownerState={ownerState}>
                 {tabs.map((tab, index) => (
                   <CodeTab
@@ -685,7 +686,12 @@ export function Demo(props: DemoProps) {
               {/* A limitation from https://github.com/nihgwu/react-runner,
                 we can't inject the `window` of the iframe so we need a disableLiveEdit option. */}
               {tabs.map((tab, index) => (
-                <Tabs.Panel value={index} key={index} tabIndex={-1}>
+                <Tabs.Panel
+                  role={willRenderTabList ? 'tabpanel' : undefined}
+                  value={index}
+                  key={index}
+                  tabIndex={-1}
+                >
                   {demoOptions.disableLiveEdit || index > 0 ? (
                     <DemoCodeViewer
                       key={index}

--- a/packages-internal/core-docs/src/Demo/DemoEditor.tsx
+++ b/packages-internal/core-docs/src/Demo/DemoEditor.tsx
@@ -119,7 +119,7 @@ export function DemoEditor(props: DemoEditorProps) {
       {...other}
     >
       <div className="MuiCode-root" {...handlers}>
-        <div className="scrollContainer">
+        <div className="scrollContainer" tabIndex={-1}>
           <NoSsr>
             <CodeCopyButton {...copyButtonProps} code={value} />
           </NoSsr>

--- a/packages-internal/core-docs/src/HighlightedCodeWithTabs/HighlightedCodeWithTabs.tsx
+++ b/packages-internal/core-docs/src/HighlightedCodeWithTabs/HighlightedCodeWithTabs.tsx
@@ -330,7 +330,7 @@ export function HighlightedCodeWithTabs(
         ))}
       </CodeTabList>
       {tabs.map(({ tab, language, code }) => (
-        <CodeTabPanel ownerState={ownerState} key={tab} value={tab}>
+        <CodeTabPanel ownerState={ownerState} key={tab} value={tab} tabIndex={-1}>
           <HighlightedCode
             language={language || 'bash'}
             code={typeof code === 'function' ? code(tab) : code}


### PR DESCRIPTION
In the current docs, there's already an inner element for code that has its own tab index.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
