### PR TITLE
[tooltip] Fix controlled open race condition

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -14,6 +14,7 @@ import { useDefaultProps } from '../DefaultPropsProvider';
 import capitalize from '../utils/capitalize';
 import Grow from '../Grow';
 import Popper from '../Popper';
+import useEnhancedEffect from '../utils/useEnhancedEffect';
 import useEventCallback from '../utils/useEventCallback';
 import useForkRef from '../utils/useForkRef';
 import useId from '../utils/useId';
@@ -352,6 +353,8 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   const enterTimer = useTimeout();
   const leaveTimer = useTimeout();
   const touchTimer = useTimeout();
+  // Tracks an open request until the next committed render so a rapid close event can cancel it.
+  const openRequestRef = React.useRef(false);
 
   const [openState, setOpenState] = useControlled({
     controlled: openProp,
@@ -361,6 +364,12 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   });
 
   let open = openState;
+
+  // Intentionally no dependency array. The flag should be cleared after every commit;
+  // it only needs to stay true between `onOpen` and the next rendered `open` prop.
+  useEnhancedEffect(() => {
+    openRequestRef.current = false;
+  });
 
   if (process.env.NODE_ENV !== 'production') {
     // TODO: uncomment once we enable eslint-plugin-react-compiler // eslint-disable-next-line react-compiler/react-compiler
@@ -412,7 +421,8 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     // We are using the mouseover event instead of the mouseenter event to fix a hide/show issue.
     setOpenState(true);
 
-    if (onOpen && !open) {
+    if (onOpen && !open && !openRequestRef.current) {
+      openRequestRef.current = true;
       onOpen(event);
     }
   };
@@ -425,9 +435,12 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
       hystersisTimer.start(800 + leaveDelay, () => {
         hystersisOpen = false;
       });
+      // A close request should cancel a pending open request before it renders.
+      const wasOpen = open || openRequestRef.current;
+      openRequestRef.current = false;
       setOpenState(false);
 
-      if (onClose && open) {
+      if (onClose && wasOpen) {
         onClose(event);
       }
 

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -13,6 +13,7 @@ import {
 } from '@mui/internal-test-utils';
 import { camelCase } from 'es-toolkit/string';
 import Tooltip, { tooltipClasses as classes } from '@mui/material/Tooltip';
+import IconButton from '@mui/material/IconButton';
 import { testReset } from './Tooltip';
 import describeConformance from '../../test/describeConformance';
 
@@ -373,6 +374,109 @@ describe('<Tooltip />', () => {
     clock.tick(0);
 
     expect(eventLog).to.deep.equal(['mouseover', 'open', 'mouseleave', 'close']);
+  });
+
+  it('should close a controlled tooltip if the trigger is left before the open prop is rendered', async () => {
+    const eventLog = [];
+
+    function Test() {
+      const [open, setOpen] = React.useState(false);
+      const openTimerRef = React.useRef();
+
+      React.useEffect(() => {
+        return () => {
+          clearTimeout(openTimerRef.current);
+        };
+      }, []);
+
+      return (
+        <Tooltip
+          enterDelay={0}
+          open={open}
+          onClose={() => {
+            eventLog.push('close');
+            clearTimeout(openTimerRef.current);
+            setOpen(false);
+          }}
+          onOpen={() => {
+            eventLog.push('open');
+            openTimerRef.current = setTimeout(() => {
+              setOpen(true);
+            }, 20);
+          }}
+          slotProps={{
+            transition: { timeout: 0 },
+          }}
+          title="Hello World"
+        >
+          <IconButton>
+            <svg data-testid="icon" viewBox="0 0 24 24">
+              <path d="M0 0h24v24H0z" />
+            </svg>
+          </IconButton>
+        </Tooltip>
+      );
+    }
+
+    clock.restore();
+    const { user } = render(<Test />);
+    const trigger = screen.getByRole('button');
+
+    await user.hover(trigger);
+    await user.unhover(trigger);
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 30);
+      });
+    });
+
+    expect(eventLog).to.deep.equal(['open', 'close']);
+    expect(screen.queryByRole('tooltip')).to.equal(null);
+  });
+
+  it('should not call onOpen again while a controlled open request is pending', async () => {
+    const eventLog = [];
+
+    function Test() {
+      const [open, setOpen] = React.useState(false);
+      const openTimerRef = React.useRef();
+
+      React.useEffect(() => {
+        return () => {
+          clearTimeout(openTimerRef.current);
+        };
+      }, []);
+
+      return (
+        <Tooltip
+          enterDelay={0}
+          open={open}
+          onOpen={() => {
+            eventLog.push('open');
+            openTimerRef.current = setTimeout(() => {
+              setOpen(true);
+            }, 20);
+          }}
+          title="Hello World"
+        >
+          <IconButton>
+            <svg data-testid="icon" viewBox="0 0 24 24">
+              <path d="M0 0h24v24H0z" />
+            </svg>
+          </IconButton>
+        </Tooltip>
+      );
+    }
+
+    clock.restore();
+    const { user } = render(<Test />);
+    const trigger = screen.getByRole('button');
+    const icon = screen.getByTestId('icon');
+
+    await user.hover(trigger);
+    await user.hover(icon);
+
+    expect(eventLog).to.deep.equal(['open']);
   });
 
   it('should not call onOpen again if already open', () => {


### PR DESCRIPTION
Best guess fix by Codex for https://github.com/mui/material-ui/issues/47073

Codex explanation:


> This looks like a real controlled `Tooltip` race, not a stale sandbox/conditional-SVG usage issue. In `Tooltip.js`, `handleOpen` calls `onOpen` only when the rendered `open` value is false, later `handleClose` calls `onClose` only when the rendered `open` value is true.
> 
> For a fast enter/leave in controlled mode, `onOpen` can enqueue `setIsOpen(true)`, then the leave can happen before Tooltip has rendered with `open={true}`. `handleClose` then sees stale `open === false`, skips `onClose`, and the queued parent open wins. That leaves the tooltip stuck open.
> 
> This was validated with a scratch test in `.context/tooltip-race.test.js`: current source fails when `mouseOver -> enterDelay tick -> mouseLeave` happen in one act.

Before fix: https://stackblitz.com/edit/axuetr6v?file=src%2FDemo.tsx

After fix: https://stackblitz.com/edit/axuetr6v-rx5dwsmb?file=src%2FDemo.tsx

User's screen recording of the bug:

https://github.com/user-attachments/assets/57b85941-686f-4c15-826c-915eb0346705

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
