### PR TITLE
[docs-infra] Fix import of cjs react-simple-code-editor in esm

### DIFF
--- a/packages-internal/core-docs/package.json
+++ b/packages-internal/core-docs/package.json
@@ -53,11 +53,11 @@
     "next": "15.5.15"
   },
   "peerDependencies": {
+    "@base-ui/react": "^1",
     "@docsearch/react": "catalog:docs",
     "@emotion/cache": "catalog:docs",
     "@emotion/react": "catalog:docs",
     "@emotion/styled": "catalog:docs",
-    "@base-ui/react": "catalog:docs",
     "@mui/icons-material": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^9.0.0 || ^9.0.0-alpha || ^9.0.0-beta",
     "@mui/material": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^9.0.0 || ^9.0.0-alpha || ^9.0.0-beta",
     "@mui/material-nextjs": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^9.0.0 || ^9.0.0-alpha || ^9.0.0-beta",

--- a/packages-internal/core-docs/src/Demo/DemoEditor.tsx
+++ b/packages-internal/core-docs/src/Demo/DemoEditor.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import SimpleCodeEditor from 'react-simple-code-editor';
+import SimpleCodeEditorImport from 'react-simple-code-editor';
+
 import Box from '@mui/material/Box';
 import NoSsr from '@mui/material/NoSsr';
 import { styled, alpha, useTheme } from '@mui/material/styles';
@@ -9,6 +10,13 @@ import { MarkdownElement } from '../MarkdownDocs/MarkdownElement';
 import { CodeCopyButton, useCodeCopy } from '../CodeCopy';
 import { useTranslate } from '../i18n';
 import { blueDark } from '../branding';
+
+// `react-simple-code-editor` is CJS-only. In Node ESM, the default import
+// resolves to the whole `module.exports` object, putting the component on
+// `.default`. Bundlers with synthetic-default give the component directly.
+// Fallback covers both.
+const SimpleCodeEditor = ((SimpleCodeEditorImport as any).default ??
+  SimpleCodeEditorImport) as typeof SimpleCodeEditorImport;
 
 const StyledMarkdownElement = styled(MarkdownElement)(({ theme }) => [
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,7 +712,7 @@ importers:
         specifier: ^7.29.2
         version: 7.29.2
       '@base-ui/react':
-        specifier: catalog:docs
+        specifier: ^1
         version: 1.4.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@2.30.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docsearch/react':
         specifier: catalog:docs


### PR DESCRIPTION
This is needed to make the package work correctly in mui-x.

Also -

- Updated the peer dep version requirement for base-ui to be 1 instead of whatever is used in the workspace