### PR TITLE
[core] Empty default CircleCI context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,7 @@ default-job: &default-job
     node-version: '22.18'
 
 default-context: &default-context
-  context:
-    - org-global
+  context: []
 
 # CircleCI has disabled the cache across forks for security reasons.
 # Following their official statement, it was a quick solution, they


### PR DESCRIPTION
Drop `org-global` from the CircleCI default context anchor so jobs referencing `*default-context` get an empty context list.