### PR TITLE
[icon button] Remove unused color palette mapping in styles

### DIFF
--- a/packages/mui-material/src/IconButton/IconButton.js
+++ b/packages/mui-material/src/IconButton/IconButton.js
@@ -115,13 +115,6 @@ const IconButtonRoot = styled(ButtonBase, {
           props: { color },
           style: {
             color: (theme.vars || theme).palette[color].main,
-          },
-        })),
-      ...Object.entries(theme.palette)
-        .filter(createSimplePaletteValueFilter()) // check all the used fields in the style below
-        .map(([color]) => ({
-          props: { color },
-          style: {
             '--IconButton-hoverBg': theme.alpha(
               (theme.vars || theme).palette[color].main,
               (theme.vars || theme).palette.action.hoverOpacity,


### PR DESCRIPTION
This pr simplifies the styling logic for the `IconButtonRoot` component in `IconButton.js` by removing redundant code related to theme palette processing.
