### PR TITLE
[autocomplete] Fix `renderValue` component not opening popup

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
@@ -76,6 +76,7 @@ export type AutocompleteRenderValueGetItemProps<Multiple extends boolean | undef
         disabled: boolean;
         'data-item-index': number;
         tabIndex: -1;
+        onClick: (event: any) => void;
         onDelete: (event: any) => void;
       };
 

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -4537,6 +4537,66 @@ describe('<Autocomplete />', () => {
       expect(textbox).toHaveComputedStyle({ opacity: '1' });
     });
 
+    it('should open the popup when clicking the rendered value', async () => {
+      const { user } = render(
+        <Autocomplete
+          defaultValue="one"
+          options={['one', 'two']}
+          renderInput={(params) => <TextField {...params} />}
+          renderValue={(value, getItemProps) => <Chip label={value} {...getItemProps()} />}
+        />,
+      );
+
+      expect(screen.queryByRole('listbox')).to.equal(null);
+
+      await user.click(screen.getByRole('button', { name: 'one' }));
+
+      expect(screen.getByRole('listbox')).not.to.equal(null);
+    });
+
+    it('should not open the popup when deleting the rendered value', async () => {
+      const { user } = render(
+        <Autocomplete
+          defaultValue="one"
+          options={['one', 'two']}
+          renderInput={(params) => <TextField {...params} />}
+          renderValue={(value, getItemProps) => (
+            <Chip
+              label={value}
+              deleteIcon={<span aria-label="Remove one">x</span>}
+              {...getItemProps()}
+            />
+          )}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /one/ })).not.to.equal(null);
+
+      await user.click(screen.getByLabelText('Remove one'));
+
+      expect(screen.queryByRole('button', { name: /one/ })).to.equal(null);
+      expect(screen.queryByRole('listbox')).to.equal(null);
+    });
+
+    it('should not open the popup when clicking a disabled rendered value', async () => {
+      const { user } = render(
+        <Autocomplete
+          defaultValue="one"
+          disabled
+          options={['one', 'two']}
+          renderInput={(params) => <TextField {...params} />}
+          renderValue={(value, getItemProps) => {
+            const { onDelete, ...itemProps } = getItemProps();
+            return <span {...itemProps}>{value}</span>;
+          }}
+        />,
+      );
+
+      await user.click(screen.getByText('one'));
+
+      expect(screen.queryByRole('listbox')).to.equal(null);
+    });
+
     it('should allow zero number (0) as a value to render', () => {
       const view = render(
         <Autocomplete

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.d.ts
@@ -362,6 +362,7 @@ export type AutocompleteGetItemProps<Multiple extends boolean | undefined> = Mul
   : (args?: { index?: number | undefined }) => {
       'data-item-index': number;
       tabIndex: -1;
+      onClick: (event: any) => void;
       onDelete: (event: any) => void;
     };
 

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -1255,6 +1255,12 @@ function useAutocomplete(props) {
     });
   };
 
+  const handleSingleItemClick = (event) => {
+    if (!disabledProp) {
+      handleOpen(event);
+    }
+  };
+
   const handlePopupIndicator = (event) => {
     if (open) {
       handleClose(event, 'toggleInput');
@@ -1399,6 +1405,7 @@ function useAutocomplete(props) {
       ...(multiple && { key: index }),
       'data-item-index': index,
       tabIndex: -1,
+      ...(!multiple && renderValue && { onClick: handleSingleItemClick }),
       ...(!readOnly && { onDelete: multiple ? handleItemDelete(index) : handleSingleItemDelete }),
     }),
     getPopupIndicatorProps: () => ({


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/48361

Before: https://stackblitz.com/edit/xjdmgpiv?file=src%2FDemo.tsx

After: https://stackblitz.com/edit/xjdmgpiv-zfjjv9zs?file=package.json

Clicking the value should open the popup

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
