### PR TITLE
[ButtonBase] Fix text shifting on first hover by pinning font smoothing

### DIFF
--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -57,6 +57,9 @@ export const ButtonBaseRoot = styled('button', {
   textDecoration: 'none',
   // So we take precedent over the style of a native <a /> element.
   color: 'inherit',
+  // Pin font smoothing so background-color changes on hover don't trigger re-evaluation.
+  WebkitFontSmoothing: 'antialiased',
+  MozOsxFontSmoothing: 'grayscale',
   '&::-moz-focus-inner': {
     borderStyle: 'none', // Remove Firefox dotted outline.
   },


### PR DESCRIPTION
## Summary

Closes #40414

On hover, a `MenuItem` (and any `ButtonBase`-derived component) changes its `background-color` from `transparent` to the hover color. This causes WebKit/Blink to re-evaluate `-webkit-font-smoothing`, since the optimal antialiasing mode can depend on the background. The re-evaluation changes glyph metrics by a sub-pixel amount, producing the visible text shift — more noticeable on Windows or lower-DPI screens.

**Fix:** explicitly set `-webkit-font-smoothing: antialiased` and `-moz-osx-font-smoothing: grayscale` on `ButtonBaseRoot`. This pins the values at the element level, matching what `CssBaseline` already sets on `<html>`, so the browser never needs to re-evaluate them on hover.

## Test plan

- [ ] Render a `Menu` with several `MenuItem`s and hover over them — text should not shift
- [ ] Verify on Windows / lower-DPI screen where the bug is most visible
- [ ] Confirm no visual regression on other `ButtonBase`-derived components (Button, IconButton, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)