### PR TITLE
[icons] Revert to using wildcard export paths

### DIFF
--- a/packages/mui-icons-material/scripts/merge-package-json.mjs
+++ b/packages/mui-icons-material/scripts/merge-package-json.mjs
@@ -6,25 +6,45 @@ import url from 'url';
 const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
 const packageDir = path.resolve(currentDirectory, '..');
 
+// Wildcard exports keep the published package.json small (~10 lines instead of
+// ~10k explicit subpath entries). The flat list balloons the file enough that
+// the TypeScript language server stalls or crashes when indexing
+// package.json for auto-imports. See https://github.com/mui/material-ui/issues/48364
+// and https://github.com/microsoft/TypeScript/issues/60854.
+const wildcardExports = {
+  './package.json': './package.json',
+  '.': {
+    require: './index.js',
+    import: './index.mjs',
+    default: './index.mjs',
+  },
+  './*': {
+    require: './*.js',
+    import: './*.mjs',
+    default: './*.mjs',
+  },
+};
+
 /**
  * Reads `package.json` and `lib/package.json`, then creates a new package.json
- * where all fields come from the root `package.json` but the `exports` field
- * is copied over from `lib/package.json`.
+ * where all fields come from `lib/package.json` (so build-time fields like
+ * `main` point at `./index.js`), with a few metadata fields pulled from the
+ * root `package.json`. The `exports` field is overridden with a wildcard form.
  */
 async function run() {
   const rootPackageJsonPath = path.resolve(packageDir, 'package.json');
-  const libPackageJsonPath = path.resolve(packageDir, 'lib/package.json');
   const buildPackageJsonPath = path.resolve(packageDir, 'build/package.json');
 
-  const [rootPackageJson, libPackageJson] = await Promise.all([
-    fs.readFile(rootPackageJsonPath, 'utf8').then((content) => JSON.parse(content)),
-    fs.readFile(libPackageJsonPath, 'utf8').then((content) => JSON.parse(content)),
-  ]);
+  const rootPackageJson = await fs
+    .readFile(rootPackageJsonPath, 'utf8')
+    .then((content) => JSON.parse(content));
 
   const mergedPackageJson = {
     ...rootPackageJson,
-    exports: libPackageJson.exports,
+    exports: wildcardExports,
   };
+  mergedPackageJson.main = './index.js';
+  mergedPackageJson.types = './index.d.ts';
   delete mergedPackageJson.publishConfig?.directory;
   // Remove fields that shouldn't be in the published package
   delete mergedPackageJson.devDependencies;


### PR DESCRIPTION
This is to fix the issues with TS/VSCode breaking on trying to index ~11000 subpaths - https://github.com/mui/material-ui/issues/48364

Working demo on -

* CSB - https://codesandbox.io/p/sandbox/mui-icons-pkg-pr-new-demo-forked-pnwzr9?file=%2Fsrc%2FApp.tsx%3A12%2C1
  Note: The ts errors are there but its an issue with their editor as the dev and build works without any issues.
* Stackblitz - https://stackblitz.com/edit/vitejs-vite-ojwbdrrp?file=src%2FApp.tsx

The CSB issue is not with this package but with @mui/material where the context mismatch happens.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
