### PR TITLE
[docs] Remove generated CSS utility component doc

### DIFF
--- a/docs/data/system/components/box/BoxSystemProps.js
+++ b/docs/data/system/components/box/BoxSystemProps.js
@@ -14,7 +14,7 @@ export default function BoxSystemProps() {
         border: '2px solid grey',
       }}
     >
-      This Box uses MUI System props for quick customization.
+      This Box uses MUI System properties through the sx prop.
     </Box>
   );
 }

--- a/docs/data/system/components/box/BoxSystemProps.tsx
+++ b/docs/data/system/components/box/BoxSystemProps.tsx
@@ -14,7 +14,7 @@ export default function BoxSystemProps() {
         border: '2px solid grey',
       }}
     >
-      This Box uses MUI System props for quick customization.
+      This Box uses MUI System properties through the sx prop.
     </Box>
   );
 }

--- a/docs/data/system/components/box/BoxSystemProps.tsx.preview
+++ b/docs/data/system/components/box/BoxSystemProps.tsx.preview
@@ -1,2 +1,2 @@
 
-  This Box uses MUI System props for quick customization.
+  This Box uses MUI System properties through the sx prop.

--- a/docs/data/system/components/box/box.md
+++ b/docs/data/system/components/box/box.md
@@ -36,10 +36,9 @@ The demo below replaces the `<div>` with a `<section>` element:
 
 ## Customization
 
-### With MUI System props
+### With MUI System properties
 
-As a CSS utility component, the Box supports all [MUI System properties](/system/properties/).
-You can use them as props directly on the component.
+Use the [`sx` prop](/system/getting-started/the-sx-prop/) to apply [MUI System properties](/system/properties/) and theme-aware CSS utilities to any Box instance.
 
 {{"demo": "BoxSystemProps.js", "defaultCodeOpen": true }}
 

--- a/docs/data/system/getting-started/usage/usage.md
+++ b/docs/data/system/getting-started/usage/usage.md
@@ -169,8 +169,8 @@ MUI System's unifying `sx` prop helps to maintain the separation of concerns be
 
 For instance, a `color` prop on a button impacts multiple states (hover, focus, etc.), and is distinct from the CSS `color` property.
 
-Only the `Box`, `Stack`, `Typography`, and `Grid` components accept MUI System properties as props for this reason.
-These components are designed to solve CSS problems—they are CSS component utilities.
+MUI components apply System properties through the `sx` prop.
+Component props stay focused on documented component behavior, which helps avoid conflicts with native and custom component props.
 
 ## Where to use MUI System
 

--- a/docs/pages/material-ui/api/accordion-actions.json
+++ b/docs/pages/material-ui/api/accordion-actions.json
@@ -36,6 +36,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/AccordionActions/AccordionActions.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-accordion/\">Accordion</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-accordion/\">Accordion</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/accordion-details.json
+++ b/docs/pages/material-ui/api/accordion-details.json
@@ -29,6 +29,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/AccordionDetails/AccordionDetails.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-accordion/\">Accordion</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-accordion/\">Accordion</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/accordion-summary.json
+++ b/docs/pages/material-ui/api/accordion-summary.json
@@ -83,6 +83,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/AccordionSummary/AccordionSummary.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-accordion/\">Accordion</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-accordion/\">Accordion</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/accordion.json
+++ b/docs/pages/material-ui/api/accordion.json
@@ -98,6 +98,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Accordion/Accordion.js",
   "inheritance": { "component": "Paper", "pathname": "/material-ui/api/paper/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-accordion/\">Accordion</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-accordion/\">Accordion</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/alert-title.json
+++ b/docs/pages/material-ui/api/alert-title.json
@@ -29,6 +29,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/AlertTitle/AlertTitle.js",
   "inheritance": { "component": "Typography", "pathname": "/material-ui/api/typography/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-alert/\">Alert</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-alert/\">Alert</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/alert.json
+++ b/docs/pages/material-ui/api/alert.json
@@ -151,6 +151,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Alert/Alert.js",
   "inheritance": { "component": "Paper", "pathname": "/material-ui/api/paper/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-alert/\">Alert</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-alert/\">Alert</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/app-bar.json
+++ b/docs/pages/material-ui/api/app-bar.json
@@ -130,6 +130,5 @@
   "forwardsRefTo": "HTMLElement",
   "filename": "/packages/mui-material/src/AppBar/AppBar.js",
   "inheritance": { "component": "Paper", "pathname": "/material-ui/api/paper/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-app-bar/\">App Bar</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-app-bar/\">App Bar</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/autocomplete.json
+++ b/docs/pages/material-ui/api/autocomplete.json
@@ -350,6 +350,5 @@
   "muiName": "MuiAutocomplete",
   "filename": "/packages/mui-material/src/Autocomplete/Autocomplete.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-autocomplete/\">Autocomplete</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-autocomplete/\">Autocomplete</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/avatar-group.json
+++ b/docs/pages/material-ui/api/avatar-group.json
@@ -69,6 +69,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/AvatarGroup/AvatarGroup.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-avatar/\">Avatar</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-avatar/\">Avatar</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/avatar.json
+++ b/docs/pages/material-ui/api/avatar.json
@@ -93,6 +93,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Avatar/Avatar.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-avatar/\">Avatar</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-avatar/\">Avatar</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/backdrop.json
+++ b/docs/pages/material-ui/api/backdrop.json
@@ -66,6 +66,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Backdrop/Backdrop.js",
   "inheritance": { "component": "Fade", "pathname": "/material-ui/api/fade/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-backdrop/\">Backdrop</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-backdrop/\">Backdrop</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/badge.json
+++ b/docs/pages/material-ui/api/badge.json
@@ -213,6 +213,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/Badge/Badge.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-avatar/\">Avatar</a></li>\n<li><a href=\"/material-ui/react-badge/\">Badge</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-avatar/\">Avatar</a></li>\n<li><a href=\"/material-ui/react-badge/\">Badge</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/bottom-navigation-action.json
+++ b/docs/pages/material-ui/api/bottom-navigation-action.json
@@ -64,6 +64,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-bottom-navigation/\">Bottom Navigation</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-bottom-navigation/\">Bottom Navigation</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/bottom-navigation.json
+++ b/docs/pages/material-ui/api/bottom-navigation.json
@@ -39,6 +39,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/BottomNavigation/BottomNavigation.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-bottom-navigation/\">Bottom Navigation</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-bottom-navigation/\">Bottom Navigation</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/box.json
+++ b/docs/pages/material-ui/api/box.json
@@ -25,6 +25,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Box/Box.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-box/\">Box</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li></ul>",
-  "cssComponent": true
+  "demos": "<ul><li><a href=\"/material-ui/react-box/\">Box</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/breadcrumbs.json
+++ b/docs/pages/material-ui/api/breadcrumbs.json
@@ -67,6 +67,5 @@
   "forwardsRefTo": "HTMLElement",
   "filename": "/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js",
   "inheritance": { "component": "Typography", "pathname": "/material-ui/api/typography/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-breadcrumbs/\">Breadcrumbs</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-breadcrumbs/\">Breadcrumbs</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/button-base.json
+++ b/docs/pages/material-ui/api/button-base.json
@@ -60,6 +60,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/ButtonBase/ButtonBase.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-button/\">Button</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-button/\">Button</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/button-group.json
+++ b/docs/pages/material-ui/api/button-group.json
@@ -144,6 +144,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/ButtonGroup/ButtonGroup.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-button-group/\">Button Group</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-button-group/\">Button Group</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/button.json
+++ b/docs/pages/material-ui/api/button.json
@@ -233,6 +233,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/Button/Button.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-button-group/\">Button Group</a></li>\n<li><a href=\"/material-ui/react-button/\">Button</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li>\n<li><a href=\"/material-ui/react-number-field/\">Number Field</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-button-group/\">Button Group</a></li>\n<li><a href=\"/material-ui/react-button/\">Button</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li>\n<li><a href=\"/material-ui/react-number-field/\">Number Field</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/card-action-area.json
+++ b/docs/pages/material-ui/api/card-action-area.json
@@ -57,6 +57,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/CardActionArea/CardActionArea.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/card-actions.json
+++ b/docs/pages/material-ui/api/card-actions.json
@@ -36,6 +36,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/CardActions/CardActions.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/card-content.json
+++ b/docs/pages/material-ui/api/card-content.json
@@ -30,6 +30,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/CardContent/CardContent.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/card-header.json
+++ b/docs/pages/material-ui/api/card-header.json
@@ -79,6 +79,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/CardHeader/CardHeader.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/card-media.json
+++ b/docs/pages/material-ui/api/card-media.json
@@ -44,6 +44,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/CardMedia/CardMedia.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/card.json
+++ b/docs/pages/material-ui/api/card.json
@@ -27,6 +27,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Card/Card.js",
   "inheritance": { "component": "Paper", "pathname": "/material-ui/api/paper/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/checkbox.json
+++ b/docs/pages/material-ui/api/checkbox.json
@@ -121,6 +121,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/Checkbox/Checkbox.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-checkbox/\">Checkbox</a></li>\n<li><a href=\"/material-ui/react-transfer-list/\">Transfer List</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-checkbox/\">Checkbox</a></li>\n<li><a href=\"/material-ui/react-transfer-list/\">Transfer List</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/chip.json
+++ b/docs/pages/material-ui/api/chip.json
@@ -184,6 +184,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Chip/Chip.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-chip/\">Chip</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-chip/\">Chip</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/circular-progress.json
+++ b/docs/pages/material-ui/api/circular-progress.json
@@ -97,6 +97,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/CircularProgress/CircularProgress.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-progress/\">Progress</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-progress/\">Progress</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/click-away-listener.json
+++ b/docs/pages/material-ui/api/click-away-listener.json
@@ -29,6 +29,5 @@
   "muiName": "MuiClickAwayListener",
   "filename": "/packages/mui-material/src/ClickAwayListener/ClickAwayListener.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-click-away-listener/\">Click-Away Listener</a></li>\n<li><a href=\"/material-ui/react-menu/\">Menu</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-click-away-listener/\">Click-Away Listener</a></li>\n<li><a href=\"/material-ui/react-menu/\">Menu</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/collapse.json
+++ b/docs/pages/material-ui/api/collapse.json
@@ -102,6 +102,5 @@
     "component": "Transition",
     "pathname": "https://reactcommunity.org/react-transition-group/transition/#Transition-props"
   },
-  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li>\n<li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/transitions/\">Transitions</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li>\n<li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/transitions/\">Transitions</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/container.json
+++ b/docs/pages/material-ui/api/container.json
@@ -80,6 +80,5 @@
   "forwardsRefTo": "HTMLElement",
   "filename": "/packages/mui-material/src/Container/Container.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-container/\">Container</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-container/\">Container</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/css-baseline.json
+++ b/docs/pages/material-ui/api/css-baseline.json
@@ -14,6 +14,5 @@
   "muiName": "MuiCssBaseline",
   "filename": "/packages/mui-material/src/CssBaseline/CssBaseline.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-css-baseline/\">CSS Baseline</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-css-baseline/\">CSS Baseline</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/dialog-actions.json
+++ b/docs/pages/material-ui/api/dialog-actions.json
@@ -36,6 +36,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/DialogActions/DialogActions.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-dialog/\">Dialog</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-dialog/\">Dialog</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/dialog-content-text.json
+++ b/docs/pages/material-ui/api/dialog-content-text.json
@@ -29,6 +29,5 @@
   "forwardsRefTo": "HTMLParagraphElement",
   "filename": "/packages/mui-material/src/DialogContentText/DialogContentText.js",
   "inheritance": { "component": "Typography", "pathname": "/material-ui/api/typography/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-dialog/\">Dialog</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-dialog/\">Dialog</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/dialog-content.json
+++ b/docs/pages/material-ui/api/dialog-content.json
@@ -36,6 +36,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/DialogContent/DialogContent.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-dialog/\">Dialog</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-dialog/\">Dialog</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/dialog-title.json
+++ b/docs/pages/material-ui/api/dialog-title.json
@@ -29,6 +29,5 @@
   "forwardsRefTo": "HTMLHeadingElement",
   "filename": "/packages/mui-material/src/DialogTitle/DialogTitle.js",
   "inheritance": { "component": "Typography", "pathname": "/material-ui/api/typography/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-dialog/\">Dialog</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-dialog/\">Dialog</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/dialog.json
+++ b/docs/pages/material-ui/api/dialog.json
@@ -168,6 +168,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Dialog/Dialog.js",
   "inheritance": { "component": "Modal", "pathname": "/material-ui/api/modal/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-dialog/\">Dialog</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-dialog/\">Dialog</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/divider.json
+++ b/docs/pages/material-ui/api/divider.json
@@ -116,6 +116,5 @@
   "forwardsRefTo": "HTMLHRElement",
   "filename": "/packages/mui-material/src/Divider/Divider.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-divider/\">Divider</a></li>\n<li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-divider/\">Divider</a></li>\n<li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/drawer.json
+++ b/docs/pages/material-ui/api/drawer.json
@@ -131,6 +131,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Drawer/Drawer.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-drawer/\">Drawer</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-drawer/\">Drawer</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/fab.json
+++ b/docs/pages/material-ui/api/fab.json
@@ -106,6 +106,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/Fab/Fab.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-floating-action-button/\">Floating Action Button</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-floating-action-button/\">Floating Action Button</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/fade.json
+++ b/docs/pages/material-ui/api/fade.json
@@ -30,6 +30,5 @@
     "component": "Transition",
     "pathname": "https://reactcommunity.org/react-transition-group/transition/#Transition-props"
   },
-  "demos": "<ul><li><a href=\"/material-ui/transitions/\">Transitions</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/transitions/\">Transitions</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/filled-input.json
+++ b/docs/pages/material-ui/api/filled-input.json
@@ -140,6 +140,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/FilledInput/FilledInput.js",
   "inheritance": { "component": "InputBase", "pathname": "/material-ui/api/input-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/form-control-label.json
+++ b/docs/pages/material-ui/api/form-control-label.json
@@ -114,6 +114,5 @@
   "forwardsRefTo": "HTMLLabelElement",
   "filename": "/packages/mui-material/src/FormControlLabel/FormControlLabel.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-checkbox/\">Checkbox</a></li>\n<li><a href=\"/material-ui/react-radio-button/\">Radio Group</a></li>\n<li><a href=\"/material-ui/react-switch/\">Switch</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-checkbox/\">Checkbox</a></li>\n<li><a href=\"/material-ui/react-radio-button/\">Radio Group</a></li>\n<li><a href=\"/material-ui/react-switch/\">Switch</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/form-control.json
+++ b/docs/pages/material-ui/api/form-control.json
@@ -82,6 +82,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/FormControl/FormControl.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-checkbox/\">Checkbox</a></li>\n<li><a href=\"/material-ui/react-number-field/\">Number Field</a></li>\n<li><a href=\"/material-ui/react-radio-button/\">Radio Group</a></li>\n<li><a href=\"/material-ui/react-switch/\">Switch</a></li>\n<li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-checkbox/\">Checkbox</a></li>\n<li><a href=\"/material-ui/react-number-field/\">Number Field</a></li>\n<li><a href=\"/material-ui/react-radio-button/\">Radio Group</a></li>\n<li><a href=\"/material-ui/react-switch/\">Switch</a></li>\n<li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/form-group.json
+++ b/docs/pages/material-ui/api/form-group.json
@@ -42,6 +42,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/FormGroup/FormGroup.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-checkbox/\">Checkbox</a></li>\n<li><a href=\"/material-ui/react-switch/\">Switch</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-checkbox/\">Checkbox</a></li>\n<li><a href=\"/material-ui/react-switch/\">Switch</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/form-helper-text.json
+++ b/docs/pages/material-ui/api/form-helper-text.json
@@ -84,6 +84,5 @@
   "forwardsRefTo": "HTMLParagraphElement",
   "filename": "/packages/mui-material/src/FormHelperText/FormHelperText.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-number-field/\">Number Field</a></li>\n<li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-number-field/\">Number Field</a></li>\n<li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/form-label.json
+++ b/docs/pages/material-ui/api/form-label.json
@@ -83,6 +83,5 @@
   "forwardsRefTo": "HTMLLabelElement",
   "filename": "/packages/mui-material/src/FormLabel/FormLabel.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-checkbox/\">Checkbox</a></li>\n<li><a href=\"/material-ui/react-number-field/\">Number Field</a></li>\n<li><a href=\"/material-ui/react-radio-button/\">Radio Group</a></li>\n<li><a href=\"/material-ui/react-switch/\">Switch</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-checkbox/\">Checkbox</a></li>\n<li><a href=\"/material-ui/react-number-field/\">Number Field</a></li>\n<li><a href=\"/material-ui/react-radio-button/\">Radio Group</a></li>\n<li><a href=\"/material-ui/react-switch/\">Switch</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/global-styles.json
+++ b/docs/pages/material-ui/api/global-styles.json
@@ -18,6 +18,5 @@
   "muiName": "MuiGlobalStyles",
   "filename": "/packages/mui-material/src/GlobalStyles/GlobalStyles.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/customization/how-to-customize/\">How to customize</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/customization/how-to-customize/\">How to customize</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/grid.json
+++ b/docs/pages/material-ui/api/grid.json
@@ -77,6 +77,5 @@
   "forwardsRefTo": "HTMLElement",
   "filename": "/packages/mui-material/src/Grid/Grid.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-grid/\">Grid</a></li></ul>",
-  "cssComponent": true
+  "demos": "<ul><li><a href=\"/material-ui/react-grid/\">Grid</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/grow.json
+++ b/docs/pages/material-ui/api/grow.json
@@ -30,6 +30,5 @@
     "component": "Transition",
     "pathname": "https://reactcommunity.org/react-transition-group/transition/#Transition-props"
   },
-  "demos": "<ul><li><a href=\"/material-ui/react-popover/\">Popover</a></li>\n<li><a href=\"/material-ui/transitions/\">Transitions</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-popover/\">Popover</a></li>\n<li><a href=\"/material-ui/transitions/\">Transitions</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/icon-button.json
+++ b/docs/pages/material-ui/api/icon-button.json
@@ -154,6 +154,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/IconButton/IconButton.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-button/\">Button</a></li>\n<li><a href=\"/material-ui/react-number-field/\">Number Field</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-button/\">Button</a></li>\n<li><a href=\"/material-ui/react-number-field/\">Number Field</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/icon.json
+++ b/docs/pages/material-ui/api/icon.json
@@ -90,6 +90,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/Icon/Icon.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/icons/\">Icons</a></li>\n<li><a href=\"/material-ui/material-icons/\">Material Icons</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/icons/\">Icons</a></li>\n<li><a href=\"/material-ui/material-icons/\">Material Icons</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/image-list-item-bar.json
+++ b/docs/pages/material-ui/api/image-list-item-bar.json
@@ -96,6 +96,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/ImageListItemBar/ImageListItemBar.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-image-list/\">Image List</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-image-list/\">Image List</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/image-list-item.json
+++ b/docs/pages/material-ui/api/image-list-item.json
@@ -62,6 +62,5 @@
   "forwardsRefTo": "HTMLLIElement",
   "filename": "/packages/mui-material/src/ImageListItem/ImageListItem.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-image-list/\">Image List</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-image-list/\">Image List</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/image-list.json
+++ b/docs/pages/material-ui/api/image-list.json
@@ -67,6 +67,5 @@
   "forwardsRefTo": "HTMLUListElement",
   "filename": "/packages/mui-material/src/ImageList/ImageList.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-image-list/\">Image List</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-image-list/\">Image List</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/init-color-scheme-script.json
+++ b/docs/pages/material-ui/api/init-color-scheme-script.json
@@ -26,6 +26,5 @@
   "muiName": "MuiInitColorSchemeScript",
   "filename": "/packages/mui-material/src/InitColorSchemeScript/InitColorSchemeScript.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-init-color-scheme-script/\">InitColorSchemeScript</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-init-color-scheme-script/\">InitColorSchemeScript</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/input-adornment.json
+++ b/docs/pages/material-ui/api/input-adornment.json
@@ -90,6 +90,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/InputAdornment/InputAdornment.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/input-base.json
+++ b/docs/pages/material-ui/api/input-base.json
@@ -168,6 +168,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/InputBase/InputBase.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/input-label.json
+++ b/docs/pages/material-ui/api/input-label.json
@@ -127,6 +127,5 @@
   "forwardsRefTo": "HTMLLabelElement",
   "filename": "/packages/mui-material/src/InputLabel/InputLabel.js",
   "inheritance": { "component": "FormLabel", "pathname": "/material-ui/api/form-label/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-number-field/\">Number Field</a></li>\n<li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-number-field/\">Number Field</a></li>\n<li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/input.json
+++ b/docs/pages/material-ui/api/input.json
@@ -136,6 +136,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Input/Input.js",
   "inheritance": { "component": "InputBase", "pathname": "/material-ui/api/input-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/linear-progress.json
+++ b/docs/pages/material-ui/api/linear-progress.json
@@ -106,6 +106,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/LinearProgress/LinearProgress.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-progress/\">Progress</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-progress/\">Progress</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/link.json
+++ b/docs/pages/material-ui/api/link.json
@@ -79,6 +79,5 @@
   "forwardsRefTo": "HTMLAnchorElement",
   "filename": "/packages/mui-material/src/Link/Link.js",
   "inheritance": { "component": "Typography", "pathname": "/material-ui/api/typography/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-breadcrumbs/\">Breadcrumbs</a></li>\n<li><a href=\"/material-ui/react-link/\">Links</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-breadcrumbs/\">Breadcrumbs</a></li>\n<li><a href=\"/material-ui/react-link/\">Links</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/list-item-avatar.json
+++ b/docs/pages/material-ui/api/list-item-avatar.json
@@ -35,6 +35,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/ListItemAvatar/ListItemAvatar.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/list-item-button.json
+++ b/docs/pages/material-ui/api/list-item-button.json
@@ -83,6 +83,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/ListItemButton/ListItemButton.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/list-item-icon.json
+++ b/docs/pages/material-ui/api/list-item-icon.json
@@ -35,6 +35,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/ListItemIcon/ListItemIcon.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/list-item-secondary-action.json
+++ b/docs/pages/material-ui/api/list-item-secondary-action.json
@@ -36,6 +36,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/list-item-text.json
+++ b/docs/pages/material-ui/api/list-item-text.json
@@ -79,6 +79,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/ListItemText/ListItemText.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/list-item.json
+++ b/docs/pages/material-ui/api/list-item.json
@@ -89,6 +89,5 @@
   "forwardsRefTo": "HTMLLIElement",
   "filename": "/packages/mui-material/src/ListItem/ListItem.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-transfer-list/\">Transfer List</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-transfer-list/\">Transfer List</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/list-subheader.json
+++ b/docs/pages/material-ui/api/list-subheader.json
@@ -70,6 +70,5 @@
   "forwardsRefTo": "HTMLLIElement",
   "filename": "/packages/mui-material/src/ListSubheader/ListSubheader.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/list.json
+++ b/docs/pages/material-ui/api/list.json
@@ -48,6 +48,5 @@
   "forwardsRefTo": "HTMLUListElement",
   "filename": "/packages/mui-material/src/List/List.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li>\n<li><a href=\"/material-ui/react-transfer-list/\">Transfer List</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-list/\">Lists</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li>\n<li><a href=\"/material-ui/react-transfer-list/\">Transfer List</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/masonry.json
+++ b/docs/pages/material-ui/api/masonry.json
@@ -45,6 +45,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-lab/src/Masonry/Masonry.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-masonry/\">Masonry</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-masonry/\">Masonry</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/menu-item.json
+++ b/docs/pages/material-ui/api/menu-item.json
@@ -72,6 +72,5 @@
   "forwardsRefTo": "HTMLLIElement",
   "filename": "/packages/mui-material/src/MenuItem/MenuItem.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-menu/\">Menu</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-menu/\">Menu</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/menu-list.json
+++ b/docs/pages/material-ui/api/menu-list.json
@@ -47,6 +47,5 @@
   "forwardsRefTo": "HTMLUListElement",
   "filename": "/packages/mui-material/src/MenuList/MenuList.js",
   "inheritance": { "component": "List", "pathname": "/material-ui/api/list/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-menu/\">Menu</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-menu/\">Menu</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/menu.json
+++ b/docs/pages/material-ui/api/menu.json
@@ -88,6 +88,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Menu/Menu.js",
   "inheritance": { "component": "Popover", "pathname": "/material-ui/api/popover/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-app-bar/\">App Bar</a></li>\n<li><a href=\"/material-ui/react-menu/\">Menu</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-app-bar/\">App Bar</a></li>\n<li><a href=\"/material-ui/react-menu/\">Menu</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/mobile-stepper.json
+++ b/docs/pages/material-ui/api/mobile-stepper.json
@@ -103,6 +103,5 @@
   "muiName": "MuiMobileStepper",
   "filename": "/packages/mui-material/src/MobileStepper/MobileStepper.js",
   "inheritance": { "component": "Paper", "pathname": "/material-ui/api/paper/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/modal.json
+++ b/docs/pages/material-ui/api/modal.json
@@ -70,6 +70,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Modal/Modal.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-modal/\">Modal</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-modal/\">Modal</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/native-select.json
+++ b/docs/pages/material-ui/api/native-select.json
@@ -128,6 +128,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/NativeSelect/NativeSelect.js",
   "inheritance": { "component": "Input", "pathname": "/material-ui/api/input/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-select/\">Select</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-select/\">Select</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/no-ssr.json
+++ b/docs/pages/material-ui/api/no-ssr.json
@@ -12,6 +12,5 @@
   "muiName": "MuiNoSsr",
   "filename": "/packages/mui-material/src/NoSsr/NoSsr.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-no-ssr/\">No SSR</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-no-ssr/\">No SSR</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/outlined-input.json
+++ b/docs/pages/material-ui/api/outlined-input.json
@@ -146,6 +146,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/OutlinedInput/OutlinedInput.js",
   "inheritance": { "component": "InputBase", "pathname": "/material-ui/api/input-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-number-field/\">Number Field</a></li>\n<li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-number-field/\">Number Field</a></li>\n<li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/pagination-item.json
+++ b/docs/pages/material-ui/api/pagination-item.json
@@ -195,6 +195,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/PaginationItem/PaginationItem.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-pagination/\">Pagination</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-pagination/\">Pagination</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/pagination.json
+++ b/docs/pages/material-ui/api/pagination.json
@@ -103,6 +103,5 @@
   "forwardsRefTo": "HTMLElement",
   "filename": "/packages/mui-material/src/Pagination/Pagination.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-pagination/\">Pagination</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-pagination/\">Pagination</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/paper.json
+++ b/docs/pages/material-ui/api/paper.json
@@ -204,6 +204,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Paper/Paper.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li>\n<li><a href=\"/material-ui/react-paper/\">Paper</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-card/\">Card</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li>\n<li><a href=\"/material-ui/react-paper/\">Paper</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/pigment-container.json
+++ b/docs/pages/material-ui/api/pigment-container.json
@@ -27,6 +27,5 @@
   "muiName": "MuiPigmentContainer",
   "filename": "/packages/mui-material/src/PigmentContainer/PigmentContainer.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-container/\">Container</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-container/\">Container</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/pigment-grid.json
+++ b/docs/pages/material-ui/api/pigment-grid.json
@@ -64,6 +64,5 @@
   "muiName": "MuiPigmentGrid",
   "filename": "/packages/mui-material/src/PigmentGrid/PigmentGrid.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-grid/\">Grid</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-grid/\">Grid</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/pigment-stack.json
+++ b/docs/pages/material-ui/api/pigment-stack.json
@@ -33,6 +33,5 @@
   "muiName": "MuiPigmentStack",
   "filename": "/packages/mui-material/src/PigmentStack/PigmentStack.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-stack/\">Stack</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-stack/\">Stack</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/popover.json
+++ b/docs/pages/material-ui/api/popover.json
@@ -102,6 +102,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Popover/Popover.js",
   "inheritance": { "component": "Modal", "pathname": "/material-ui/api/modal/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-menu/\">Menu</a></li>\n<li><a href=\"/material-ui/react-popover/\">Popover</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-menu/\">Menu</a></li>\n<li><a href=\"/material-ui/react-popover/\">Popover</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/popper.json
+++ b/docs/pages/material-ui/api/popper.json
@@ -69,6 +69,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Popper/Popper.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-autocomplete/\">Autocomplete</a></li>\n<li><a href=\"/material-ui/react-menu/\">Menu</a></li>\n<li><a href=\"/material-ui/react-popper/\">Popper</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-autocomplete/\">Autocomplete</a></li>\n<li><a href=\"/material-ui/react-menu/\">Menu</a></li>\n<li><a href=\"/material-ui/react-popper/\">Popper</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/portal.json
+++ b/docs/pages/material-ui/api/portal.json
@@ -15,6 +15,5 @@
   "muiName": "MuiPortal",
   "filename": "/packages/mui-material/src/Portal/Portal.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-portal/\">Portal</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-portal/\">Portal</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/radio-group.json
+++ b/docs/pages/material-ui/api/radio-group.json
@@ -43,6 +43,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/RadioGroup/RadioGroup.js",
   "inheritance": { "component": "FormGroup", "pathname": "/material-ui/api/form-group/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-radio-button/\">Radio Group</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-radio-button/\">Radio Group</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/radio.json
+++ b/docs/pages/material-ui/api/radio.json
@@ -104,6 +104,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/Radio/Radio.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-radio-button/\">Radio Group</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-radio-button/\">Radio Group</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/rating.json
+++ b/docs/pages/material-ui/api/rating.json
@@ -178,6 +178,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/Rating/Rating.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-rating/\">Rating</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-rating/\">Rating</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/scoped-css-baseline.json
+++ b/docs/pages/material-ui/api/scoped-css-baseline.json
@@ -31,6 +31,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-css-baseline/\">CSS Baseline</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-css-baseline/\">CSS Baseline</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/select.json
+++ b/docs/pages/material-ui/api/select.json
@@ -141,6 +141,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Select/Select.js",
   "inheritance": { "component": "OutlinedInput", "pathname": "/material-ui/api/outlined-input/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-select/\">Select</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-select/\">Select</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/skeleton.json
+++ b/docs/pages/material-ui/api/skeleton.json
@@ -100,6 +100,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/Skeleton/Skeleton.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-skeleton/\">Skeleton</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-skeleton/\">Skeleton</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/slide.json
+++ b/docs/pages/material-ui/api/slide.json
@@ -41,6 +41,5 @@
     "component": "Transition",
     "pathname": "https://reactcommunity.org/react-transition-group/transition/#Transition-props"
   },
-  "demos": "<ul><li><a href=\"/material-ui/react-dialog/\">Dialog</a></li>\n<li><a href=\"/material-ui/transitions/\">Transitions</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-dialog/\">Dialog</a></li>\n<li><a href=\"/material-ui/transitions/\">Transitions</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/slider.json
+++ b/docs/pages/material-ui/api/slider.json
@@ -293,6 +293,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/Slider/Slider.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-slider/\">Slider</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-slider/\">Slider</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/snackbar-content.json
+++ b/docs/pages/material-ui/api/snackbar-content.json
@@ -43,6 +43,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/SnackbarContent/SnackbarContent.js",
   "inheritance": { "component": "Paper", "pathname": "/material-ui/api/paper/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-snackbar/\">Snackbar</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-snackbar/\">Snackbar</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/snackbar.json
+++ b/docs/pages/material-ui/api/snackbar.json
@@ -127,6 +127,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Snackbar/Snackbar.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-snackbar/\">Snackbar</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-snackbar/\">Snackbar</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/speed-dial-action.json
+++ b/docs/pages/material-ui/api/speed-dial-action.json
@@ -90,6 +90,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js",
   "inheritance": { "component": "Tooltip", "pathname": "/material-ui/api/tooltip/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-speed-dial/\">Speed Dial</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-speed-dial/\">Speed Dial</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/speed-dial-icon.json
+++ b/docs/pages/material-ui/api/speed-dial-icon.json
@@ -60,6 +60,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-speed-dial/\">Speed Dial</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-speed-dial/\">Speed Dial</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/speed-dial.json
+++ b/docs/pages/material-ui/api/speed-dial.json
@@ -127,6 +127,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/SpeedDial/SpeedDial.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-speed-dial/\">Speed Dial</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-speed-dial/\">Speed Dial</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/stack.json
+++ b/docs/pages/material-ui/api/stack.json
@@ -35,6 +35,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Stack/Stack.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-stack/\">Stack</a></li></ul>",
-  "cssComponent": true
+  "demos": "<ul><li><a href=\"/material-ui/react-stack/\">Stack</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/step-button.json
+++ b/docs/pages/material-ui/api/step-button.json
@@ -49,6 +49,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/StepButton/StepButton.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/step-connector.json
+++ b/docs/pages/material-ui/api/step-connector.json
@@ -70,6 +70,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/StepConnector/StepConnector.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/step-content.json
+++ b/docs/pages/material-ui/api/step-content.json
@@ -58,6 +58,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/StepContent/StepContent.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/step-icon.json
+++ b/docs/pages/material-ui/api/step-icon.json
@@ -56,6 +56,5 @@
   "forwardsRefTo": "SVGSVGElement",
   "filename": "/packages/mui-material/src/StepIcon/StepIcon.js",
   "inheritance": { "component": "SvgIcon", "pathname": "/material-ui/api/svg-icon/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/step-label.json
+++ b/docs/pages/material-ui/api/step-label.json
@@ -113,6 +113,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/StepLabel/StepLabel.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/step.json
+++ b/docs/pages/material-ui/api/step.json
@@ -57,6 +57,5 @@
   "forwardsRefTo": "HTMLLIElement",
   "filename": "/packages/mui-material/src/Step/Step.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/stepper.json
+++ b/docs/pages/material-ui/api/stepper.json
@@ -62,6 +62,5 @@
   "forwardsRefTo": "HTMLOListElement",
   "filename": "/packages/mui-material/src/Stepper/Stepper.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-stepper/\">Stepper</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/svg-icon.json
+++ b/docs/pages/material-ui/api/svg-icon.json
@@ -103,6 +103,5 @@
   "forwardsRefTo": "SVGSVGElement",
   "filename": "/packages/mui-material/src/SvgIcon/SvgIcon.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/icons/\">Icons</a></li>\n<li><a href=\"/material-ui/material-icons/\">Material Icons</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/icons/\">Icons</a></li>\n<li><a href=\"/material-ui/material-icons/\">Material Icons</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/swipeable-drawer.json
+++ b/docs/pages/material-ui/api/swipeable-drawer.json
@@ -122,6 +122,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js",
   "inheritance": { "component": "Drawer", "pathname": "/material-ui/api/drawer/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-drawer/\">Drawer</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-drawer/\">Drawer</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/switch.json
+++ b/docs/pages/material-ui/api/switch.json
@@ -153,6 +153,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/Switch/Switch.js",
   "inheritance": { "component": "IconButton", "pathname": "/material-ui/api/icon-button/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-switch/\">Switch</a></li>\n<li><a href=\"/material-ui/react-transfer-list/\">Transfer List</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-switch/\">Switch</a></li>\n<li><a href=\"/material-ui/react-transfer-list/\">Transfer List</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/tab-context.json
+++ b/docs/pages/material-ui/api/tab-context.json
@@ -17,6 +17,5 @@
   "muiName": "MuiTabContext",
   "filename": "/packages/mui-lab/src/TabContext/TabContext.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-tabs/\">Tabs</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-tabs/\">Tabs</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/tab-list.json
+++ b/docs/pages/material-ui/api/tab-list.json
@@ -82,6 +82,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-lab/src/TabList/TabList.js",
   "inheritance": { "component": "Tabs", "pathname": "/material-ui/api/tabs/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-tabs/\">Tabs</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-tabs/\">Tabs</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/tab-panel.json
+++ b/docs/pages/material-ui/api/tab-panel.json
@@ -37,6 +37,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-lab/src/TabPanel/TabPanel.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-tabs/\">Tabs</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-tabs/\">Tabs</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/tab-scroll-button.json
+++ b/docs/pages/material-ui/api/tab-scroll-button.json
@@ -64,6 +64,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/TabScrollButton/TabScrollButton.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-tabs/\">Tabs</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-tabs/\">Tabs</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/tab.json
+++ b/docs/pages/material-ui/api/tab.json
@@ -94,6 +94,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/Tab/Tab.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-tabs/\">Tabs</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-tabs/\">Tabs</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/table-body.json
+++ b/docs/pages/material-ui/api/table-body.json
@@ -30,6 +30,5 @@
   "forwardsRefTo": "HTMLTableSectionElement",
   "filename": "/packages/mui-material/src/TableBody/TableBody.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/table-cell.json
+++ b/docs/pages/material-ui/api/table-cell.json
@@ -131,6 +131,5 @@
   "forwardsRefTo": "HTMLTableCellElement",
   "filename": "/packages/mui-material/src/TableCell/TableCell.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/table-container.json
+++ b/docs/pages/material-ui/api/table-container.json
@@ -30,6 +30,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/TableContainer/TableContainer.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/table-footer.json
+++ b/docs/pages/material-ui/api/table-footer.json
@@ -30,6 +30,5 @@
   "forwardsRefTo": "HTMLTableSectionElement",
   "filename": "/packages/mui-material/src/TableFooter/TableFooter.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/table-head.json
+++ b/docs/pages/material-ui/api/table-head.json
@@ -30,6 +30,5 @@
   "forwardsRefTo": "HTMLTableSectionElement",
   "filename": "/packages/mui-material/src/TableHead/TableHead.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/table-pagination-actions.json
+++ b/docs/pages/material-ui/api/table-pagination-actions.json
@@ -70,6 +70,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/TablePaginationActions/TablePaginationActions.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-pagination/\">Pagination</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-pagination/\">Pagination</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/table-pagination.json
+++ b/docs/pages/material-ui/api/table-pagination.json
@@ -143,6 +143,5 @@
   "forwardsRefTo": "HTMLTableCellElement",
   "filename": "/packages/mui-material/src/TablePagination/TablePagination.js",
   "inheritance": { "component": "TableCell", "pathname": "/material-ui/api/table-cell/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-pagination/\">Pagination</a></li>\n<li><a href=\"/material-ui/react-table/\">Table</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-pagination/\">Pagination</a></li>\n<li><a href=\"/material-ui/react-table/\">Table</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/table-row.json
+++ b/docs/pages/material-ui/api/table-row.json
@@ -56,6 +56,5 @@
   "forwardsRefTo": "HTMLTableRowElement",
   "filename": "/packages/mui-material/src/TableRow/TableRow.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/table-sort-label.json
+++ b/docs/pages/material-ui/api/table-sort-label.json
@@ -73,6 +73,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/TableSortLabel/TableSortLabel.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/table.json
+++ b/docs/pages/material-ui/api/table.json
@@ -48,6 +48,5 @@
   "forwardsRefTo": "HTMLTableElement",
   "filename": "/packages/mui-material/src/Table/Table.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-table/\">Table</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/tabs.json
+++ b/docs/pages/material-ui/api/tabs.json
@@ -171,6 +171,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Tabs/Tabs.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-tabs/\">Tabs</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-tabs/\">Tabs</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/text-field.json
+++ b/docs/pages/material-ui/api/text-field.json
@@ -124,6 +124,5 @@
   "muiName": "MuiTextField",
   "filename": "/packages/mui-material/src/TextField/TextField.js",
   "inheritance": { "component": "FormControl", "pathname": "/material-ui/api/form-control/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-autocomplete/\">Autocomplete</a></li>\n<li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-autocomplete/\">Autocomplete</a></li>\n<li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/textarea-autosize.json
+++ b/docs/pages/material-ui/api/textarea-autosize.json
@@ -17,6 +17,5 @@
   "muiName": "MuiTextareaAutosize",
   "filename": "/packages/mui-material/src/TextareaAutosize/TextareaAutosize.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-textarea-autosize/\">Textarea Autosize</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-textarea-autosize/\">Textarea Autosize</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/timeline-connector.json
+++ b/docs/pages/material-ui/api/timeline-connector.json
@@ -29,6 +29,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-lab/src/TimelineConnector/TimelineConnector.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/timeline-content.json
+++ b/docs/pages/material-ui/api/timeline-content.json
@@ -53,6 +53,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-lab/src/TimelineContent/TimelineContent.js",
   "inheritance": { "component": "Typography", "pathname": "/material-ui/api/typography/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/timeline-dot.json
+++ b/docs/pages/material-ui/api/timeline-dot.json
@@ -91,6 +91,5 @@
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-lab/src/TimelineDot/TimelineDot.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/timeline-item.json
+++ b/docs/pages/material-ui/api/timeline-item.json
@@ -65,6 +65,5 @@
   "forwardsRefTo": "HTMLLIElement",
   "filename": "/packages/mui-lab/src/TimelineItem/TimelineItem.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/timeline-opposite-content.json
+++ b/docs/pages/material-ui/api/timeline-opposite-content.json
@@ -53,6 +53,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js",
   "inheritance": { "component": "Typography", "pathname": "/material-ui/api/typography/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/timeline-separator.json
+++ b/docs/pages/material-ui/api/timeline-separator.json
@@ -29,6 +29,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/timeline.json
+++ b/docs/pages/material-ui/api/timeline.json
@@ -58,6 +58,5 @@
   "forwardsRefTo": "HTMLUListElement",
   "filename": "/packages/mui-lab/src/Timeline/Timeline.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-timeline/\">Timeline</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/toggle-button-group.json
+++ b/docs/pages/material-ui/api/toggle-button-group.json
@@ -112,6 +112,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-toggle-button/\">Toggle Button</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-toggle-button/\">Toggle Button</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/toggle-button.json
+++ b/docs/pages/material-ui/api/toggle-button.json
@@ -117,6 +117,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/ToggleButton/ToggleButton.js",
   "inheritance": { "component": "ButtonBase", "pathname": "/material-ui/api/button-base/" },
-  "demos": "<ul><li><a href=\"/material-ui/react-toggle-button/\">Toggle Button</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-toggle-button/\">Toggle Button</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/toolbar.json
+++ b/docs/pages/material-ui/api/toolbar.json
@@ -56,6 +56,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Toolbar/Toolbar.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-app-bar/\">App Bar</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-app-bar/\">App Bar</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/tooltip.json
+++ b/docs/pages/material-ui/api/tooltip.json
@@ -151,6 +151,5 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/mui-material/src/Tooltip/Tooltip.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-tooltip/\">Tooltip</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-tooltip/\">Tooltip</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/typography.json
+++ b/docs/pages/material-ui/api/typography.json
@@ -176,6 +176,5 @@
   "forwardsRefTo": "HTMLParagraphElement",
   "filename": "/packages/mui-material/src/Typography/Typography.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-breadcrumbs/\">Breadcrumbs</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li>\n<li><a href=\"/material-ui/react-typography/\">Typography</a></li></ul>",
-  "cssComponent": true
+  "demos": "<ul><li><a href=\"/material-ui/react-breadcrumbs/\">Breadcrumbs</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar</a></li>\n<li><a href=\"/material-ui/react-typography/\">Typography</a></li></ul>"
 }

--- a/docs/pages/material-ui/api/zoom.json
+++ b/docs/pages/material-ui/api/zoom.json
@@ -30,6 +30,5 @@
     "component": "Transition",
     "pathname": "https://reactcommunity.org/react-transition-group/transition/#Transition-props"
   },
-  "demos": "<ul><li><a href=\"/material-ui/transitions/\">Transitions</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/transitions/\">Transitions</a></li></ul>"
 }

--- a/docs/pages/system/api/box.json
+++ b/docs/pages/system/api/box.json
@@ -25,6 +25,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-system/src/Box/Box.js",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-box/\">Box (Material UI)</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar (Material UI)</a></li>\n<li><a href=\"/system/react-box/\">Box (MUI System)</a></li></ul>",
-  "cssComponent": true
+  "demos": "<ul><li><a href=\"/material-ui/react-box/\">Box (Material UI)</a></li>\n<li><a href=\"/material-ui/react-menubar/\">Menubar (Material UI)</a></li>\n<li><a href=\"/system/react-box/\">Box (MUI System)</a></li></ul>"
 }

--- a/docs/pages/system/api/container.json
+++ b/docs/pages/system/api/container.json
@@ -80,6 +80,5 @@
   "forwardsRefTo": "HTMLElement",
   "filename": "/packages/mui-system/src/Container/Container.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-container/\">Container (Material UI)</a></li>\n<li><a href=\"/system/react-container/\">Container (MUI System)</a></li></ul>",
-  "cssComponent": false
+  "demos": "<ul><li><a href=\"/material-ui/react-container/\">Container (Material UI)</a></li>\n<li><a href=\"/system/react-container/\">Container (MUI System)</a></li></ul>"
 }

--- a/docs/pages/system/api/grid.json
+++ b/docs/pages/system/api/grid.json
@@ -107,6 +107,5 @@
   "forwardsRefTo": "HTMLElement",
   "filename": "/packages/mui-system/src/Grid/Grid.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-grid/\">Grid (Material UI)</a></li></ul>",
-  "cssComponent": true
+  "demos": "<ul><li><a href=\"/material-ui/react-grid/\">Grid (Material UI)</a></li></ul>"
 }

--- a/docs/pages/system/api/stack.json
+++ b/docs/pages/system/api/stack.json
@@ -42,6 +42,5 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-system/src/Stack/Stack.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-stack/\">Stack (Material UI)</a></li>\n<li><a href=\"/system/react-stack/\">Stack (MUI System)</a></li></ul>",
-  "cssComponent": true
+  "demos": "<ul><li><a href=\"/material-ui/react-stack/\">Stack (Material UI)</a></li>\n<li><a href=\"/system/react-stack/\">Stack (MUI System)</a></li></ul>"
 }

--- a/packages-internal/api-docs-builder/src/ApiBuilders/ComponentApiBuilder.ts
+++ b/packages-internal/api-docs-builder/src/ApiBuilders/ComponentApiBuilder.ts
@@ -33,8 +33,6 @@ import {
 import { Slot, ComponentInfo, ApiItemDescription } from '../types/utils.types';
 import extractInfoFromEnum from '../utils/extractInfoFromEnum';
 
-const cssComponents = new Set(['Box', 'Grid', 'Typography', 'Stack']);
-
 /**
  * Produces markdown of the description that can be hosted anywhere.
  *
@@ -353,7 +351,6 @@ const generateApiPage = async (
     demos: `<ul>${reactApi.demos
       .map((item) => `<li><a href="${item.demoPathname}">${item.demoPageTitle}</a></li>`)
       .join('\n')}</ul>`,
-    cssComponent: cssComponents.has(reactApi.name),
     deprecated: reactApi.deprecated,
   };
 

--- a/packages-internal/api-docs-builder/src/types/ApiBuilder.types.ts
+++ b/packages-internal/api-docs-builder/src/types/ApiBuilder.types.ts
@@ -126,7 +126,6 @@ export interface ComponentApiContent {
   filename: string;
   inheritance: null | { component: string; pathname: string };
   demos: string;
-  cssComponent: boolean;
   deprecated: true | undefined;
 }
 

--- a/packages-internal/core-docs/src/ApiPage/ApiPage.tsx
+++ b/packages-internal/core-docs/src/ApiPage/ApiPage.tsx
@@ -93,7 +93,6 @@ export function ApiPage(props: ApiPageProps) {
   const userLanguage = useUserLanguage();
 
   const {
-    cssComponent,
     demos,
     deprecated,
     filename,
@@ -261,17 +260,6 @@ export function ApiPage(props: ApiPageProps) {
             defaultLayout={defaultLayout}
             layoutStorageKey={layoutStorageKey.props}
           />
-          {cssComponent && (
-            <React.Fragment>
-              <div
-                dangerouslySetInnerHTML={{
-                  __html: t('api-docs.cssComponent').replace(/{{name}}/, pageContent.name),
-                }}
-              />
-              <br />
-              <br />
-            </React.Fragment>
-          )}
           <div
             className="MuiCallout-root MuiCallout-info"
             dangerouslySetInnerHTML={{ __html: refHint }}

--- a/packages-internal/core-docs/src/ApiPage/ComponentsApiContent.tsx
+++ b/packages-internal/core-docs/src/ApiPage/ComponentsApiContent.tsx
@@ -82,7 +82,6 @@ export function ComponentsApiContent(props: ComponentsApiContentProps) {
   return components.map((key) => {
     const pageContent = pageContents[key];
     const {
-      cssComponent,
       forwardsRefTo,
       inheritance,
       name: componentName,
@@ -154,17 +153,6 @@ export function ComponentsApiContent(props: ComponentsApiContentProps) {
             layoutStorageKey={layoutStorageKey.props}
           />
           <br />
-          {cssComponent && (
-            <React.Fragment>
-              <div
-                dangerouslySetInnerHTML={{
-                  __html: t('api-docs.cssComponent').replace(/{{name}}/, pageContent.name),
-                }}
-              />
-              <br />
-              <br />
-            </React.Fragment>
-          )}
           <div
             className="MuiCallout-root MuiCallout-info"
             dangerouslySetInnerHTML={{ __html: refHint }}

--- a/packages-internal/core-docs/src/translations/translations.json
+++ b/packages-internal/core-docs/src/translations/translations.json
@@ -13,7 +13,6 @@
     "className": "Class name",
     "cssDescription": "The following class names are useful for styling with CSS (the <a href=\"/material-ui/customization/how-to-customize/#state-classes\">state classes</a> are marked). <br /> To learn more, visit the <a href=\"/material-ui/customization/theme-components/\">component customization</a> page.",
     "css": "CSS",
-    "cssComponent": "As a CSS utility, the {{name}} component also supports all <a href=\"/system/properties/\"><code>system</code></a> properties. You can use them as props directly on the component.",
     "default": "Default",
     "defaultComponent": "Default component",
     "defaultValue": "Default value",

--- a/packages-internal/scripts/generate-llms-txt/src/processApi.ts
+++ b/packages-internal/scripts/generate-llms-txt/src/processApi.ts
@@ -51,7 +51,6 @@ interface ApiJson {
   filename?: string;
   inheritance?: ApiInheritance;
   demos?: string;
-  cssComponent?: boolean;
   deprecated?: boolean;
   deprecationInfo?: string;
 }
@@ -321,11 +320,6 @@ export function processApiJson(apiJson: ApiJson | string, options: ProcessApiOpt
   const classesTable = generateClassesTable(api.classes || [], origin);
   if (classesTable) {
     markdown += `${classesTable}\n`;
-  }
-
-  // Add CSS component note
-  if (api.cssComponent) {
-    markdown += `> **Note**: As a CSS utility, the \`${api.name}\` component also supports all system properties. You can use them as props directly on the component.\n\n`;
   }
 
   // Add source code section

--- a/packages-internal/scripts/generate-llms-txt/test/processApi.test.ts
+++ b/packages-internal/scripts/generate-llms-txt/test/processApi.test.ts
@@ -329,21 +329,6 @@ describe('processApi', () => {
       expect(result).to.include('You can use `MuiButton` to change the default props');
     });
 
-    it('should handle CSS component', () => {
-      const apiJson = {
-        name: 'Box',
-        imports: ["import Box from '@mui/material/Box';"],
-        props: {},
-        cssComponent: true,
-      };
-
-      const result = processApiJson(apiJson);
-
-      expect(result).to.include(
-        'As a CSS utility, the `Box` component also supports all system properties',
-      );
-    });
-
     it('should handle source code section', () => {
       const apiJson = {
         name: 'Component',

--- a/skills/material-ui-styling/AGENTS.md
+++ b/skills/material-ui-styling/AGENTS.md
@@ -121,7 +121,7 @@ To reuse `sx` logic inside `styled()`, use theme's `unstable_sx` (see [styled()â
 ## Imports and consistency
 
 - In application code, prefer one-level imports from packages (for example `@mui/material/Button`) to avoid pulling the entire barrel.
-- `Box` / `Stack` / `Typography` / `Grid`: system layout props apply directly on these; other components use `sx` for system shortcuts, not arbitrary CSS prop shortcuts on the component itself.
+- Use `sx` for system layout shortcuts (`p`, `gap`, `mt`, etc.) on MUI components; use component props only for behavior documented by that component.
 
 ---
 


### PR DESCRIPTION
All the direct system props were removed in v9, the `cssComponent` option for the docs generator is obsolete now

Closes https://github.com/mui/material-ui/issues/48382

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
