### PR TITLE
[code-infra] Deduplicate vale script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,6 @@ jobs:
         run: |
           VERSION=$(node -p "(require('./package.json').config && require('./package.json').config.valeVersion) || ''")
           echo "vale_version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Cache Vale binary
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: node_modules/.cache/mui-vale
-          key: ${{ runner.os }}-mui-vale-${{ steps.vale-version.outputs.vale_version }}
       - uses: vale-cli/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         continue-on-error: true # GitHub Action flag needed until https://github.com/errata-ai/vale-action/issues/89 is fixed
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint:ci": "eslint . --report-unused-disable-directives --max-warnings 0",
     "stylelint": "stylelint --reportInvalidScopeDisables --reportNeedlessDisables \"docs/**/*.?(c|m)[jt]s?(x)\" \"docs/**/*.css\" --ignore-path .lintignore",
     "markdownlint": "markdownlint-cli2 \"**/*.md\"",
-    "vale:fix": "pnpm code-infra vale sync --vale-version $npm_package_config_valeVersion && git ls-files | grep -E \"\\.(md|mdx)$\" | xargs pnpm code-infra vale --vale-version $npm_package_config_valeVersion --filter='.Level==\"error\"' --auto-fix all",
+    "vale:fix": "pnpm valelint --auto-fix all",
     "valelint": "pnpm code-infra vale sync --vale-version $npm_package_config_valeVersion && git ls-files | grep -E \"\\.(md|mdx)$\" | xargs pnpm code-infra vale --vale-version $npm_package_config_valeVersion --filter='.Level==\"error\"'",
     "prettier": "pretty-quick --ignore-path .lintignore --branch master",
     "prettier:all": "prettier --write . --ignore-path .lintignore",


### PR DESCRIPTION
Mirrors https://github.com/mui/base-ui-mosaic/pull/218.

Also removes the unused Vale cache step: vale-action installs the binary to `/home/runner/vale/`, not `node_modules/.cache/mui-vale`, so the cache step never populated and produced a `Path Validation Error` in the post-step.