### PR TITLE
[code-infra] Fix type shadowing

### DIFF
--- a/packages/mui-material/src/styles/useThemeProps.d.ts
+++ b/packages/mui-material/src/styles/useThemeProps.d.ts
@@ -5,7 +5,7 @@ export interface ThemeWithProps {
   components?: Components<Omit<Theme, 'components'>> | undefined;
 }
 
-export type ThemedProps<Theme, Name extends keyof any> = Theme extends {
+export type ThemedProps<ThemeInput, Name extends keyof any> = ThemeInput extends {
   components: Record<Name, { defaultProps: infer Props }>;
 }
   ? Props
@@ -39,7 +39,7 @@ export type ThemedProps<Theme, Name extends keyof any> = Theme extends {
  * @param params.name The name of the component as defined in the theme
  */
 export default function useThemeProps<
-  Theme extends ThemeWithProps,
+  ThemeInput extends ThemeWithProps,
   Props,
   Name extends keyof any,
->(params: { props: Props; name: Name }): Props & ThemedProps<Theme, Name>;
+>(params: { props: Props; name: Name }): Props & ThemedProps<ThemeInput, Name>;

--- a/packages/mui-system/src/breakpoints/breakpoints.d.ts
+++ b/packages/mui-system/src/breakpoints/breakpoints.d.ts
@@ -37,6 +37,6 @@ type DefaultBreakPoints = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 /**
  * @returns An enhanced stylefunction that considers breakpoints
  */
-export default function breakpoints<Props, Breakpoints extends string = DefaultBreakPoints>(
+export default function breakpoints<Props, BreakpointsInput extends string = DefaultBreakPoints>(
   styleFunction: StyleFunction<Props>,
-): StyleFunction<Partial<Record<Breakpoints, Props>> & Props>;
+): StyleFunction<Partial<Record<BreakpointsInput, Props>> & Props>;

--- a/packages/mui-utils/src/visuallyHidden/visuallyHidden.ts
+++ b/packages/mui-utils/src/visuallyHidden/visuallyHidden.ts
@@ -1,4 +1,6 @@
-const visuallyHidden: import('react').CSSProperties = {
+import type * as React from 'react';
+
+const visuallyHidden: React.CSSProperties = {
   border: 0,
   clip: 'rect(0 0 0 0)',
   height: '1px',


### PR DESCRIPTION
Prepare for applying `consistentTypeImports`, these will yield additional eslint errors under that flag.

- [`@mui/utils` diff](https://code-infra-dashboard.onrender.com/diff-package?package1=https://pkg.pr.new/mui/material-ui/@mui/utils@fa0bad1&package2=https://pkg.pr.new/mui/material-ui/@mui/utils@afac163): `import()` will be forbidden for types
- [`@mui/material` diff](https://code-infra-dashboard.onrender.com/diff-package?package1=https://pkg.pr.new/mui/material-ui/@mui/material@fa0bad1&package2=https://pkg.pr.new/mui/material-ui/@mui/material@afac163): name clash
- [`@mui/system` diff](https://code-infra-dashboard.onrender.com/diff-package?package1=https://pkg.pr.new/mui/material-ui/@mui/system@fa0bad1&package2=https://pkg.pr.new/mui/material-ui/@mui/system@afac163): name clash
