### PR TITLE
Fix accessibility issue: `StepConnector` is invalid in list

### DIFF
--- a/docs/data/material/components/steppers/ProgressMobileStepper.js
+++ b/docs/data/material/components/steppers/ProgressMobileStepper.js
@@ -24,6 +24,11 @@ export default function ProgressMobileStepper() {
       position="static"
       activeStep={activeStep}
       sx={{ maxWidth: 400, flexGrow: 1 }}
+      slotProps={{
+        progress: {
+          'aria-label': 'Wizard progress',
+        },
+      }}
       nextButton={
         <Button size="small" onClick={handleNext} disabled={activeStep === 5}>
           Next

--- a/docs/data/material/components/steppers/ProgressMobileStepper.tsx
+++ b/docs/data/material/components/steppers/ProgressMobileStepper.tsx
@@ -24,6 +24,11 @@ export default function ProgressMobileStepper() {
       position="static"
       activeStep={activeStep}
       sx={{ maxWidth: 400, flexGrow: 1 }}
+      slotProps={{
+        progress: {
+          'aria-label': 'Wizard progress',
+        },
+      }}
       nextButton={
         <Button size="small" onClick={handleNext} disabled={activeStep === 5}>
           Next

--- a/packages/mui-material/src/StepConnector/StepConnector.js
+++ b/packages/mui-material/src/StepConnector/StepConnector.js
@@ -105,10 +105,10 @@ const StepConnector = React.forwardRef(function StepConnector(inProps, ref) {
 
   return (
     <StepConnectorRoot
-      ariaHidden={true}
       className={clsx(classes.root, className)}
       ref={ref}
       ownerState={ownerState}
+      aria-hidden
       {...other}
     >
       <StepConnectorLine className={classes.line} ownerState={ownerState} />

--- a/packages/mui-material/src/StepConnector/StepConnector.js
+++ b/packages/mui-material/src/StepConnector/StepConnector.js
@@ -105,6 +105,7 @@ const StepConnector = React.forwardRef(function StepConnector(inProps, ref) {
 
   return (
     <StepConnectorRoot
+      ariaHidden={true}
       className={clsx(classes.root, className)}
       ref={ref}
       ownerState={ownerState}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

(This is my first PR here so please bear with me)

## Why?

Originally raised in [this comment](https://github.com/mui/material-ui/pull/47687#issuecomment-4359826044)

The goal here is to fix accessibility errors around `StepConnectors` as a follow-up to https://github.com/mui/material-ui/pull/47687. Namely, `StepConnectors` are `div`s, which are not permitted as children to `ol` elements.

## What?

- Added `aria-hidden` to `StepConnectors`
- Fixed another accessibility issue in Step docs where there was a missing aria-label.

## Testing

I have tested this fix by checking the docs site both before and after the change and finding that the accessibility error is now fixed.

### Before

<img width="614" height="188" alt="image" src="https://github.com/user-attachments/assets/d9863130-da81-4276-b21b-2cac47fa847b" />


### After

<img width="615" height="306" alt="image" src="https://github.com/user-attachments/assets/5cba2586-828f-4781-8701-aaaf3eaf83b3" />


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
