### PR TITLE
[docs] Remove outdated references of .ttf and .woff

### DIFF
--- a/docs/data/material/customization/typography/typography.md
+++ b/docs/data/material/customization/typography/typography.md
@@ -29,11 +29,10 @@ const theme = createTheme({
 
 ### Self-hosted fonts
 
-To self-host fonts, download the font files in `ttf`, `woff`, and/or `woff2` formats and import them into your code.
+To self-host fonts, download the font files in the `woff2` format and import it into your code.
 
 :::warning
-This requires that you have a plugin or loader in your build process that can handle loading `ttf`, `woff`, and
-`woff2` files. Fonts will _not_ be embedded within your bundle. They will be loaded from your webserver instead of a CDN.
+This requires that you have a plugin or loader in your build process that can handle loading `woff2` files. Fonts will _not_ be embedded within your bundle. They will be loaded from your webserver instead of a CDN.
 :::
 
 ```js

--- a/docs/data/material/customization/typography/typography.md
+++ b/docs/data/material/customization/typography/typography.md
@@ -29,7 +29,7 @@ const theme = createTheme({
 
 ### Self-hosted fonts
 
-To self-host fonts, download the font files in the `woff2` format and import it into your code.
+To self-host fonts, download the font files in the `woff2` format and import them into your code.
 
 :::warning
 This requires that you have a plugin or loader in your build process that can handle loading `woff2` files. Fonts will _not_ be embedded within your bundle. They will be loaded from your webserver instead of a CDN.


### PR DESCRIPTION
Seeing .ttf and .woff still mentioned in the docs feels very clearly: "this is a 2019 project stuck in the past". Aren't those web font formats now very outdated? https://web.dev/articles/font-best-practices#use_woff2 

We need to be coherent with https://mui.com/material-ui/getting-started/supported-platforms/#browser. So, hence the fix (faster to make a PR than to create an issue 😁).

Preview: https://deploy-preview-48399--material-ui.netlify.app/material-ui/customization/typography/#self-hosted-fonts

A continuation of #48398