### PR TITLE
[Typography] Add `applyRobotoLetterSpacing` option to fix letter spacing with CSS variable fontFamily

### DIFF
--- a/docs/data/material/integrations/nextjs/nextjs.md
+++ b/docs/data/material/integrations/nextjs/nextjs.md
@@ -71,6 +71,7 @@ Use the `options` prop to override the default [cache options](https://emotion.s
 
 To integrate [Next.js font optimization](https://nextjs.org/docs/app/getting-started/fonts) with Material UI, create a new file with the `'use client';` directive.
 Then create a theme using `var(--font-roboto)` as a value for the `typography.fontFamily` field.
+Set `applyRobotoLetterSpacing: true` to preserve the pre-tuned Roboto letter spacing, which is skipped by default when `fontFamily` doesn't match the default font stack string.
 
 ```js title="src/theme.ts"
 'use client';
@@ -79,6 +80,7 @@ import { createTheme } from '@mui/material/styles';
 const theme = createTheme({
   typography: {
     fontFamily: 'var(--font-roboto)',
+    applyRobotoLetterSpacing: true,
   },
 });
 
@@ -451,6 +453,7 @@ To integrate [Next.js font optimization](https://nextjs.org/docs/pages/getting-s
 +const theme = createTheme({
 +  typography: {
 +    fontFamily: 'var(--font-roboto)',
++    applyRobotoLetterSpacing: true,
 +  },
 +});
 

--- a/packages/mui-material/src/styles/createTypography.d.ts
+++ b/packages/mui-material/src/styles/createTypography.d.ts
@@ -29,6 +29,12 @@ export interface FontStyle {
 
 export interface FontStyleOptions extends Partial<FontStyle> {
   allVariants?: React.CSSProperties | undefined;
+  /**
+   * Apply the letter spacing values tuned for Roboto even when a custom `fontFamily` is set.
+   * Useful when the font is Roboto but referenced via a CSS variable (e.g. `var(--font-roboto)`).
+   * Defaults to `true` when `fontFamily` matches the default Roboto stack.
+   */
+  applyRobotoLetterSpacing?: boolean;
 }
 
 // TODO: which one should actually be allowed to be subject to module augmentation?

--- a/packages/mui-material/src/styles/createTypography.js
+++ b/packages/mui-material/src/styles/createTypography.js
@@ -27,6 +27,9 @@ export default function createTypography(palette, typography) {
     htmlFontSize = 16,
     // Apply the CSS properties to all the variants.
     allVariants,
+    // The letter spacing was tuned for Roboto. Set to true when using a custom
+    // fontFamily that is still Roboto (e.g. a CSS variable like var(--font-roboto)).
+    applyRobotoLetterSpacing = fontFamily === defaultFontFamily,
     pxToRem: pxToRem2,
     ...other
   } = typeof typography === 'function' ? typography(palette) : typography;
@@ -51,9 +54,7 @@ export default function createTypography(palette, typography) {
     lineHeight,
     // The letter spacing was designed for the Roboto font-family. Using the same letter-spacing
     // across font-families can cause issues with the kerning.
-    ...(fontFamily === defaultFontFamily
-      ? { letterSpacing: `${round(letterSpacing / size)}em` }
-      : {}),
+    ...(applyRobotoLetterSpacing ? { letterSpacing: `${round(letterSpacing / size)}em` } : {}),
     ...casing,
     ...allVariants,
   });


### PR DESCRIPTION
Fixes #47575

## Problem

The [Next.js font optimization guide](https://mui.com/material-ui/integrations/nextjs/#font-optimization) recommends setting `typography.fontFamily: 'var(--font-roboto)'` in the theme. However, `createTypography` applies Roboto-specific letter spacing only when `fontFamily === defaultFontFamily` (strict string equality). A CSS variable reference never matches that string, so the letter spacing is silently dropped — even though the font in use is still Roboto.

This was identified by @Janpot in #47575. A previous PR (#47627) attempted heuristic string detection which was rightly rejected as too fragile.

## Solution

Add an explicit `applyRobotoLetterSpacing` option to `typography` (option 2 from @Janpot's comment). It defaults to `fontFamily === defaultFontFamily`, preserving existing behaviour for all current users. Callers who reference Roboto via a CSS variable can opt in:

```ts
createTheme({
  typography: {
    fontFamily: 'var(--font-roboto)',
    applyRobotoLetterSpacing: true,
  },
})
```

- No heuristics, no string matching
- Fully backwards compatible — existing themes are unaffected
- Explicit, documentable, and easy to understand

## Changes

- `createTypography.js` — extract `applyRobotoLetterSpacing` (default `fontFamily === defaultFontFamily`) and use it in `buildVariant`
- `createTypography.d.ts` — add type with JSDoc
- `nextjs.md` — add `applyRobotoLetterSpacing: true` to both App Router and Pages Router font optimization examples