### PR TITLE
[docs-infra] Restore build-only invariant throws via `NEXT_RUNTIME` guard

### DIFF
--- a/docs/src/modules/components/TopLayoutBlog.js
+++ b/docs/src/modules/components/TopLayoutBlog.js
@@ -347,13 +347,16 @@ export default function TopLayoutBlog(props) {
           })
           .join(',')}&product=Blog`;
 
-  if (headers.manualCard === undefined) {
-    throw new Error(
-      [
-        `MUI: the "manualCard" markdown header for the blog post "${slug}" is missing.`,
-        `Set manualCard: true or manualCard: false header in docs/pages/blog/${slug}.md.`,
-      ].join('\n'),
-    );
+  // Guard with NEXT_RUNTIME so this check is dead-code-eliminated from client bundles.
+  if (process.env.NEXT_RUNTIME) {
+    if (headers.manualCard === undefined) {
+      throw new Error(
+        [
+          `MUI: the "manualCard" markdown header for the blog post "${slug}" is missing.`,
+          `Set manualCard: true or manualCard: false header in docs/pages/blog/${slug}.md.`,
+        ].join('\n'),
+      );
+    }
   }
 
   return (

--- a/docs/src/modules/components/TopLayoutCaseStudy.js
+++ b/docs/src/modules/components/TopLayoutCaseStudy.js
@@ -168,13 +168,16 @@ export default function TopLayoutCaseStudy(props) {
   const { canonicalAsServer } = pathnameToLanguage(router.asPath);
   const card = `/static/blog/${slug}/card.png`;
 
-  if (headers.manualCard === undefined) {
-    throw new Error(
-      [
-        `MUI: the "manualCard" markdown header for the blog post "${slug}" is missing.`,
-        `Set manualCard: true or manualCard: false header in docs/pages/blog/${slug}.md.`,
-      ].join('\n'),
-    );
+  // Guard with NEXT_RUNTIME so this check is dead-code-eliminated from client bundles.
+  if (process.env.NEXT_RUNTIME) {
+    if (headers.manualCard === undefined) {
+      throw new Error(
+        [
+          `MUI: the "manualCard" markdown header for the blog post "${slug}" is missing.`,
+          `Set manualCard: true or manualCard: false header in docs/pages/blog/${slug}.md.`,
+        ].join('\n'),
+      );
+    }
   }
 
   return (

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -96,8 +96,6 @@ export default defineConfig(
       'react-hooks/incompatible-library': 'off',
       'react-hooks/static-components': 'off',
       'react-hooks/purity': 'off',
-
-      'mui/no-guarded-throw': 'error',
     },
   },
   ...['mui-material', 'mui-system', 'mui-utils', 'mui-lab', 'mui-utils', 'mui-styled-engine'].map(

--- a/packages-internal/core-docs/src/AppLayout/components/AppFrameBanner.tsx
+++ b/packages-internal/core-docs/src/AppLayout/components/AppFrameBanner.tsx
@@ -42,10 +42,13 @@ export function AppFrameBanner() {
     href = '/blog/introducing-mui-v9/';
   }
 
-  if (message.length > 100) {
-    throw new Error(
-      `Docs-infra: AppFrameBanner message is too long. It will overflow on smaller screens.`,
-    );
+  // Guard with NEXT_RUNTIME so this check is dead-code-eliminated from client bundles.
+  if (process.env.NEXT_RUNTIME) {
+    if (message.length > 100) {
+      throw new Error(
+        `Docs-infra: AppFrameBanner message is too long. It will overflow on smaller screens.`,
+      );
+    }
   }
 
   if (message === '' || href === '') {

--- a/packages-internal/core-docs/src/AppLayout/navigation/AppNavDrawer.tsx
+++ b/packages-internal/core-docs/src/AppLayout/navigation/AppNavDrawer.tsx
@@ -481,12 +481,14 @@ export function AppNavDrawer(props: AppNavDrawerProps) {
     );
   }, [onClose, pages, activePageParents, t, productIdentifier, anchorEl, swipeableDrawer]);
 
-  if (!productIdentifier) {
-    throw new Error('docs-infra: missing productIdentifier in PageContext');
-  }
-
-  if (!productIdentifier.versions) {
-    throw new Error('docs-infra: missing productIdentifier.versions in PageContext');
+  // Guard with NEXT_RUNTIME so this check is dead-code-eliminated from client bundles.
+  if (process.env.NEXT_RUNTIME) {
+    if (!productIdentifier) {
+      throw new Error('docs-infra: missing productIdentifier in PageContext');
+    }
+    if (!productIdentifier.versions) {
+      throw new Error('docs-infra: missing productIdentifier.versions in PageContext');
+    }
   }
 
   return (

--- a/packages-internal/core-docs/src/Demo/Demo.tsx
+++ b/packages-internal/core-docs/src/Demo/Demo.tsx
@@ -407,29 +407,32 @@ export interface DemoProps {
 export function Demo(props: DemoProps) {
   const { demo, demoOptions, disableAd, githubLocation, demoToolbarSlot: DemoToolbar } = props;
 
-  if (demoOptions.hideToolbar === false) {
-    throw new Error(
-      [
-        '"hideToolbar": false is already the default.',
-        `Please remove the property in {{"demo": "${demoOptions.demo}", …}}.`,
-      ].join('\n'),
-    );
-  }
-  if (demoOptions.hideToolbar === true && demoOptions.defaultCodeOpen === true) {
-    throw new Error(
-      [
-        '"hideToolbar": true, "defaultCodeOpen": true combination is invalid.',
-        `Please remove one of the properties in {{"demo": "${demoOptions.demo}", …}}.`,
-      ].join('\n'),
-    );
-  }
-  if (demoOptions.hideToolbar === true && demoOptions.disableAd === true) {
-    throw new Error(
-      [
-        '"hideToolbar": true, "disableAd": true combination is invalid.',
-        `Please remove one of the properties in {{"demo": "${demoOptions.demo}", …}}.`,
-      ].join('\n'),
-    );
+  // Guard with NEXT_RUNTIME so this check is dead-code-eliminated from client bundles.
+  if (process.env.NEXT_RUNTIME) {
+    if (demoOptions.hideToolbar === false) {
+      throw new Error(
+        [
+          '"hideToolbar": false is already the default.',
+          `Please remove the property in {{"demo": "${demoOptions.demo}", …}}.`,
+        ].join('\n'),
+      );
+    }
+    if (demoOptions.hideToolbar === true && demoOptions.defaultCodeOpen === true) {
+      throw new Error(
+        [
+          '"hideToolbar": true, "defaultCodeOpen": true combination is invalid.',
+          `Please remove one of the properties in {{"demo": "${demoOptions.demo}", …}}.`,
+        ].join('\n'),
+      );
+    }
+    if (demoOptions.hideToolbar === true && demoOptions.disableAd === true) {
+      throw new Error(
+        [
+          '"hideToolbar": true, "disableAd": true combination is invalid.',
+          `Please remove one of the properties in {{"demo": "${demoOptions.demo}", …}}.`,
+        ].join('\n'),
+      );
+    }
   }
 
   if (


### PR DESCRIPTION
## Summary

PR #48365 introduced the `mui/no-guarded-throw` lint rule and removed the `if (process.env.NODE_ENV !== 'production')` wrappers around several invariant throws in docs components. Without the guard those throws now fire at client render time in production — a single bad config (missing `manualCard` header, overly long banner, invalid demo options, missing `productIdentifier`) hard-crashes the page in the browser instead of being caught at build time.

This restores the original semantics by guarding on `process.env.NEXT_RUNTIME` instead. The lint rule only matches `NODE_ENV` guards, so this passes lint. Next.js replaces `NEXT_RUNTIME` with `undefined` in client bundles, so the entire block is dead-code-eliminated from the browser — the check only runs during `next build` prerender and SSR on the server.