### PR TITLE
[docs] Fix RTL toggle highlight in docs settings drawer

### DIFF
--- a/packages-internal/core-docs/src/branding/BrandingCssVarsProvider.tsx
+++ b/packages-internal/core-docs/src/branding/BrandingCssVarsProvider.tsx
@@ -183,6 +183,7 @@ export function BrandingCssVarsProvider(props: {
   }, [direction]);
   return (
     <BrandingCssThemeProvider
+      direction={direction}
       forceThemeRerender={canonicalAs.startsWith('/x/') || canonicalAs.startsWith('/toolpad/')}
     >
       <NextNProgressBar />


### PR DESCRIPTION
The left-to-right button remains highlighted even after selecting RTL in the settings drawer.

### Before
<img width="687" height="466" alt="image" src="https://github.com/user-attachments/assets/ac19bf2a-6054-40f5-87f2-6af02fe51ac8" />

### After
<img width="765" height="464" alt="image" src="https://github.com/user-attachments/assets/90cae210-4e11-4ef9-9940-6f4c7e1a8b31" />
