### PR TITLE
[utils] Remove unnecessary `excludeKeys` from `extractEventHandlers`

### DIFF
--- a/packages/mui-material/src/utils/mergeSlotProps.ts
+++ b/packages/mui-material/src/utils/mergeSlotProps.ts
@@ -1,5 +1,5 @@
 import { SlotComponentProps } from '@mui/utils/types';
-import { isEventHandler } from '@mui/utils';
+import isEventHandler from '@mui/utils/isEventHandler';
 import clsx from 'clsx';
 
 export default function mergeSlotProps<

--- a/packages/mui-material/src/utils/mergeSlotProps.ts
+++ b/packages/mui-material/src/utils/mergeSlotProps.ts
@@ -1,19 +1,6 @@
 import { SlotComponentProps } from '@mui/utils/types';
+import { isEventHandler } from '@mui/utils';
 import clsx from 'clsx';
-
-// Brought from [Base UI](https://github.com/mui/base-ui/blob/master/packages/react/src/merge-props/mergeProps.ts#L119)
-// Use it directly from Base UI once it's a package dependency.
-function isEventHandler(key: string, value: unknown) {
-  // This approach is more efficient than using a regex.
-  const thirdCharCode = key.charCodeAt(2);
-  return (
-    key[0] === 'o' &&
-    key[1] === 'n' &&
-    thirdCharCode >= 65 /* A */ &&
-    thirdCharCode <= 90 /* Z */ &&
-    typeof value === 'function'
-  );
-}
 
 export default function mergeSlotProps<
   T extends SlotComponentProps<React.ElementType, {}, {}>,

--- a/packages/mui-utils/src/extractEventHandlers/extractEventHandlers.test.ts
+++ b/packages/mui-utils/src/extractEventHandlers/extractEventHandlers.test.ts
@@ -29,15 +29,4 @@ describe('extractEventHandlers', () => {
     const result = extractEventHandlers(undefined);
     expect(result).to.deep.equal({});
   });
-
-  it('excludes the provided handlers from the result', () => {
-    const input = {
-      onClick: () => {},
-      onChange: () => {},
-      onFocus: () => {},
-    };
-
-    const result = extractEventHandlers(input, ['onClick', 'onFocus']);
-    expect(result).to.deep.equal({ onChange: input.onChange });
-  });
 });

--- a/packages/mui-utils/src/extractEventHandlers/extractEventHandlers.ts
+++ b/packages/mui-utils/src/extractEventHandlers/extractEventHandlers.ts
@@ -1,4 +1,4 @@
-import { isEventHandler } from '@mui/utils';
+import isEventHandler from '@mui/utils/isEventHandler';
 import { EventHandlers } from '../types';
 
 /**

--- a/packages/mui-utils/src/extractEventHandlers/extractEventHandlers.ts
+++ b/packages/mui-utils/src/extractEventHandlers/extractEventHandlers.ts
@@ -13,11 +13,11 @@ function extractEventHandlers(object: Record<string, any> | undefined): EventHan
 
   const result: EventHandlers = {};
 
-  Object.keys(object)
-    .filter((prop) => prop.match(/^on[A-Z]/) && typeof object[prop] === 'function')
-    .forEach((prop) => {
+  for (const prop of Object.keys(object)) {
+    if (prop.match(/^on[A-Z]/) && typeof object[prop] === 'function') {
       result[prop] = object[prop];
-    });
+    }
+  }
 
   return result;
 }

--- a/packages/mui-utils/src/extractEventHandlers/extractEventHandlers.ts
+++ b/packages/mui-utils/src/extractEventHandlers/extractEventHandlers.ts
@@ -5,12 +5,8 @@ import { EventHandlers } from '../types';
  * A prop is considered an event handler if it is a function and its name starts with `on`.
  *
  * @param object An object to extract event handlers from.
- * @param excludeKeys An array of keys to exclude from the returned object.
  */
-function extractEventHandlers(
-  object: Record<string, any> | undefined,
-  excludeKeys: string[] = [],
-): EventHandlers {
+function extractEventHandlers(object: Record<string, any> | undefined): EventHandlers {
   if (object === undefined) {
     return {};
   }
@@ -18,10 +14,7 @@ function extractEventHandlers(
   const result: EventHandlers = {};
 
   Object.keys(object)
-    .filter(
-      (prop) =>
-        prop.match(/^on[A-Z]/) && typeof object[prop] === 'function' && !excludeKeys.includes(prop),
-    )
+    .filter((prop) => prop.match(/^on[A-Z]/) && typeof object[prop] === 'function')
     .forEach((prop) => {
       result[prop] = object[prop];
     });

--- a/packages/mui-utils/src/extractEventHandlers/extractEventHandlers.ts
+++ b/packages/mui-utils/src/extractEventHandlers/extractEventHandlers.ts
@@ -1,3 +1,4 @@
+import { isEventHandler } from '@mui/utils';
 import { EventHandlers } from '../types';
 
 /**
@@ -14,7 +15,7 @@ function extractEventHandlers(object: Record<string, any> | undefined): EventHan
   const result: EventHandlers = {};
 
   for (const prop of Object.keys(object)) {
-    if (prop.match(/^on[A-Z]/) && typeof object[prop] === 'function') {
+    if (isEventHandler(prop, object[prop])) {
       result[prop] = object[prop];
     }
   }

--- a/packages/mui-utils/src/index.ts
+++ b/packages/mui-utils/src/index.ts
@@ -55,4 +55,5 @@ export { default as unstable_resolveComponentProps } from './resolveComponentPro
 export { default as unstable_extractEventHandlers } from './extractEventHandlers';
 export { default as unstable_getReactNodeRef } from './getReactNodeRef';
 export { default as unstable_getReactElementRef } from './getReactElementRef';
+export { default as isEventHandler } from './isEventHandler';
 export * from './types';

--- a/packages/mui-utils/src/isEventHandler/index.ts
+++ b/packages/mui-utils/src/isEventHandler/index.ts
@@ -1,0 +1,1 @@
+export { default } from './isEventHandler';

--- a/packages/mui-utils/src/isEventHandler/isEventHandler.ts
+++ b/packages/mui-utils/src/isEventHandler/isEventHandler.ts
@@ -1,0 +1,13 @@
+// Brought from [Base UI](https://github.com/mui/base-ui/blob/master/packages/react/src/merge-props/mergeProps.ts#L119)
+// Use it directly from Base UI once it's a package dependency.
+export default function isEventHandler(key: string, value: unknown) {
+  // This approach is more efficient than using a regex.
+  const thirdCharCode = key.charCodeAt(2);
+  return (
+    key[0] === 'o' &&
+    key[1] === 'n' &&
+    thirdCharCode >= 65 /* A */ &&
+    thirdCharCode <= 90 /* Z */ &&
+    typeof value === 'function'
+  );
+}


### PR DESCRIPTION
It's not used anywhere as per my search. Not even used in MUI X: https://github.com/search?q=repo%3Amui%2Fmui-x%20extractEventHandlers&type=code.

I noticed this while reviewing a PR. `extractEventHandlers` is also used in `useSlot` method when `getSlotProps` is provided.