### PR TITLE
Change publish-prepare action to specific commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0 # Fetch full history for proper git operations
       - name: Prepare for publishing
-        uses: mui/mui-public/.github/actions/publish-prepare@master
+        uses: mui/mui-public/.github/actions/publish-prepare@dd7db35e4c70c656b86a98cf9b4819e7a4105f48 # master
       - name: Publish packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Make sure we can publish from this branch with a policy of pinned dependencies