### PR TITLE
[stepper] Proper support for vertical alternativeLabel

### DIFF
--- a/docs/data/material/components/steppers/VerticalLinearAlternativeLabelStepper.js
+++ b/docs/data/material/components/steppers/VerticalLinearAlternativeLabelStepper.js
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stepper from '@mui/material/Stepper';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
+import StepContent from '@mui/material/StepContent';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+
+const steps = [
+  {
+    label: 'Select campaign settings',
+    description: `For each ad campaign that you create, you can control how much
+              you're willing to spend on clicks and conversions, which networks
+              and geographical locations you want your ads to show on, and more.`,
+  },
+  {
+    label: 'Create an ad group',
+    description:
+      'An ad group contains one or more ads which target a shared set of keywords.',
+  },
+  {
+    label: 'Create an ad',
+    description: `Try out different ad text to see what brings in the most customers,
+              and learn how to enhance your ads using features like ad extensions.
+              If you run into any problems with your ads, find out how to tell if
+              they're running and how to resolve approval issues.`,
+  },
+];
+
+export default function VerticalLinearAlternativeLabelStepper() {
+  const [activeStep, setActiveStep] = React.useState(0);
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  };
+
+  const handleBack = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep - 1);
+  };
+
+  const handleReset = () => {
+    setActiveStep(0);
+  };
+
+  return (
+    <Box sx={{ maxWidth: 400 }}>
+      <Stepper activeStep={activeStep} orientation="vertical" alternativeLabel>
+        {steps.map((step, index) => (
+          <Step key={step.label}>
+            <StepLabel
+              optional={
+                index === steps.length - 1 ? (
+                  <Typography variant="caption">Last step</Typography>
+                ) : null
+              }
+            >
+              {step.label}
+            </StepLabel>
+            <StepContent>
+              <Typography>{step.description}</Typography>
+              <Box sx={{ mb: 2 }}>
+                <Button
+                  variant="contained"
+                  onClick={handleNext}
+                  sx={{ mt: 1, mr: 1 }}
+                >
+                  {index === steps.length - 1 ? 'Finish' : 'Continue'}
+                </Button>
+                <Button
+                  disabled={index === 0}
+                  onClick={handleBack}
+                  sx={{ mt: 1, mr: 1 }}
+                >
+                  Back
+                </Button>
+              </Box>
+            </StepContent>
+          </Step>
+        ))}
+      </Stepper>
+      {activeStep === steps.length && (
+        <Paper square elevation={0} sx={{ p: 3 }}>
+          <Typography>All steps completed - you&apos;re finished</Typography>
+          <Button onClick={handleReset} sx={{ mt: 1, mr: 1 }}>
+            Reset
+          </Button>
+        </Paper>
+      )}
+    </Box>
+  );
+}

--- a/docs/data/material/components/steppers/VerticalLinearAlternativeLabelStepper.js
+++ b/docs/data/material/components/steppers/VerticalLinearAlternativeLabelStepper.js
@@ -58,7 +58,7 @@ export default function VerticalLinearAlternativeLabelStepper() {
             >
               {step.label}
             </StepLabel>
-            <StepContent>
+            <StepContent sx={{ textAlign: 'right' }}>
               <Typography>{step.description}</Typography>
               <Box sx={{ mb: 2 }}>
                 <Button

--- a/docs/data/material/components/steppers/VerticalLinearAlternativeLabelStepper.tsx
+++ b/docs/data/material/components/steppers/VerticalLinearAlternativeLabelStepper.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stepper from '@mui/material/Stepper';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
+import StepContent from '@mui/material/StepContent';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+
+const steps = [
+  {
+    label: 'Select campaign settings',
+    description: `For each ad campaign that you create, you can control how much
+              you're willing to spend on clicks and conversions, which networks
+              and geographical locations you want your ads to show on, and more.`,
+  },
+  {
+    label: 'Create an ad group',
+    description:
+      'An ad group contains one or more ads which target a shared set of keywords.',
+  },
+  {
+    label: 'Create an ad',
+    description: `Try out different ad text to see what brings in the most customers,
+              and learn how to enhance your ads using features like ad extensions.
+              If you run into any problems with your ads, find out how to tell if
+              they're running and how to resolve approval issues.`,
+  },
+];
+
+export default function VerticalLinearAlternativeLabelStepper() {
+  const [activeStep, setActiveStep] = React.useState(0);
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  };
+
+  const handleBack = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep - 1);
+  };
+
+  const handleReset = () => {
+    setActiveStep(0);
+  };
+
+  return (
+    <Box sx={{ maxWidth: 400 }}>
+      <Stepper activeStep={activeStep} orientation="vertical" alternativeLabel>
+        {steps.map((step, index) => (
+          <Step key={step.label}>
+            <StepLabel
+              optional={
+                index === steps.length - 1 ? (
+                  <Typography variant="caption">Last step</Typography>
+                ) : null
+              }
+            >
+              {step.label}
+            </StepLabel>
+            <StepContent>
+              <Typography>{step.description}</Typography>
+              <Box sx={{ mb: 2 }}>
+                <Button
+                  variant="contained"
+                  onClick={handleNext}
+                  sx={{ mt: 1, mr: 1 }}
+                >
+                  {index === steps.length - 1 ? 'Finish' : 'Continue'}
+                </Button>
+                <Button
+                  disabled={index === 0}
+                  onClick={handleBack}
+                  sx={{ mt: 1, mr: 1 }}
+                >
+                  Back
+                </Button>
+              </Box>
+            </StepContent>
+          </Step>
+        ))}
+      </Stepper>
+      {activeStep === steps.length && (
+        <Paper square elevation={0} sx={{ p: 3 }}>
+          <Typography>All steps completed - you&apos;re finished</Typography>
+          <Button onClick={handleReset} sx={{ mt: 1, mr: 1 }}>
+            Reset
+          </Button>
+        </Paper>
+      )}
+    </Box>
+  );
+}

--- a/docs/data/material/components/steppers/VerticalLinearAlternativeLabelStepper.tsx
+++ b/docs/data/material/components/steppers/VerticalLinearAlternativeLabelStepper.tsx
@@ -58,7 +58,7 @@ export default function VerticalLinearAlternativeLabelStepper() {
             >
               {step.label}
             </StepLabel>
-            <StepContent>
+            <StepContent sx={{ textAlign: 'right' }}>
               <Typography>{step.description}</Typography>
               <Box sx={{ mb: 2 }}>
                 <Button

--- a/docs/data/material/components/steppers/steppers.md
+++ b/docs/data/material/components/steppers/steppers.md
@@ -99,12 +99,18 @@ Vertical steppers are designed for narrow screen sizes. They are ideal for mobil
 
 {{"demo": "VerticalLinearStepper.js"}}
 
-### Transition
+### Alternative label
+
+Use `alternativeLabel` prop on the vertical `Stepper` component to reverse the placement of the label and content.
+
+{{"demo": "VerticalLinearAlternativeLabelStepper.js"}}
+
+## Transition
 
 `StepContent` uses [Collapse](/material-ui/transitions/#collapse) by default.
 Use `slots.transition` and `slotProps.transition` to replace it with another transition or to pass transition props.
 
-### Performance
+## Performance
 
 The content of a step is unmounted when closed.
 If you need to make the content available to search engines or render expensive component trees inside your modal while optimizing for interaction responsiveness it might be a good idea to keep the step mounted with:

--- a/docs/translations/api-docs/stepper/stepper.json
+++ b/docs/translations/api-docs/stepper/stepper.json
@@ -5,7 +5,7 @@
       "description": "Set the active step (zero based index). Set to -1 to disable all the steps."
     },
     "alternativeLabel": {
-      "description": "If set to &#39;true&#39; and orientation is horizontal, then the step label will be positioned under the icon."
+      "description": "If set to &#39;true&#39; and orientation is horizontal, then the step label will be positioned under the icon. If set to &#39;true&#39; and orientation is vertical, then the step label will be positioned to the right of the icon."
     },
     "children": { "description": "Two or more <code>&lt;Step /&gt;</code> components." },
     "classes": { "description": "Override or extend the styles applied to the component." },

--- a/docs/translations/api-docs/stepper/stepper.json
+++ b/docs/translations/api-docs/stepper/stepper.json
@@ -5,7 +5,7 @@
       "description": "Set the active step (zero based index). Set to -1 to disable all the steps."
     },
     "alternativeLabel": {
-      "description": "If set to &#39;true&#39; and orientation is horizontal, then the step label will be positioned under the icon. If set to &#39;true&#39; and orientation is vertical, then the step label will be positioned to the right of the icon."
+      "description": "If set to &#39;true&#39; and orientation is horizontal, then the step label will be positioned under the icon. If set to &#39;true&#39; and orientation is vertical, it reverses the position of the label and content."
     },
     "children": { "description": "Two or more <code>&lt;Step /&gt;</code> components." },
     "classes": { "description": "Override or extend the styles applied to the component." },

--- a/packages/mui-material/src/Step/Step.js
+++ b/packages/mui-material/src/Step/Step.js
@@ -65,7 +65,7 @@ const StepRoot = styled('li', {
       },
     },
     {
-      props: { alternativeLabel: true },
+      props: { orientation: 'horizontal', alternativeLabel: true },
       style: {
         flex: 1,
         position: 'relative',

--- a/packages/mui-material/src/Step/Step.js
+++ b/packages/mui-material/src/Step/Step.js
@@ -58,6 +58,13 @@ const StepRoot = styled('li', {
       },
     },
     {
+      props: { orientation: 'vertical', alternativeLabel: true },
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+      },
+    },
+    {
       props: { alternativeLabel: true },
       style: {
         flex: 1,

--- a/packages/mui-material/src/StepConnector/StepConnector.js
+++ b/packages/mui-material/src/StepConnector/StepConnector.js
@@ -51,7 +51,14 @@ const StepConnectorRoot = styled('div', {
       },
     },
     {
-      props: { alternativeLabel: true },
+      props: { orientation: 'vertical', alternativeLabel: true },
+      style: {
+        marginLeft: 'auto',
+        marginRight: 12, // half icon
+      },
+    },
+    {
+      props: { orientation: 'horizontal', alternativeLabel: true },
       style: {
         position: 'absolute',
         top: 8 + 4,

--- a/packages/mui-material/src/StepContent/StepContent.js
+++ b/packages/mui-material/src/StepContent/StepContent.js
@@ -52,7 +52,6 @@ const StepContentRoot = styled('div', {
           marginRight: 12, // half icon
           paddingLeft: 8,
           paddingRight: 8 + 12, // margin + half icon
-          textAlign: 'right',
           borderLeft: 'none',
           borderRight: theme.vars
             ? `1px solid ${theme.vars.palette.StepContent.border}`

--- a/packages/mui-material/src/StepContent/StepContent.js
+++ b/packages/mui-material/src/StepContent/StepContent.js
@@ -45,6 +45,28 @@ const StepContentRoot = styled('div', {
           borderLeft: 'none',
         },
       },
+      {
+        props: { alternativeLabel: true },
+        style: {
+          marginLeft: 0,
+          marginRight: 12, // half icon
+          paddingLeft: 8,
+          paddingRight: 8 + 12, // margin + half icon
+          textAlign: 'right',
+          borderLeft: 'none',
+          borderRight: theme.vars
+            ? `1px solid ${theme.vars.palette.StepContent.border}`
+            : `1px solid ${
+                theme.palette.mode === 'light' ? theme.palette.grey[400] : theme.palette.grey[600]
+              }`,
+        },
+      },
+      {
+        props: { alternativeLabel: true, last: true },
+        style: {
+          borderRight: 'none',
+        },
+      },
     ],
   })),
 );
@@ -65,10 +87,10 @@ const StepContent = React.forwardRef(function StepContent(inProps, ref) {
     ...other
   } = props;
 
-  const { orientation } = useStepperContext();
+  const { orientation, alternativeLabel } = useStepperContext();
   const { active, last, expanded } = React.useContext(StepContext);
 
-  const ownerState = { ...props, last };
+  const ownerState = { ...props, last, alternativeLabel };
   const classes = useUtilityClasses(ownerState);
 
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/mui-material/src/StepLabel/StepLabel.js
+++ b/packages/mui-material/src/StepLabel/StepLabel.js
@@ -70,6 +70,14 @@ const StepLabelRoot = styled('span', {
         padding: '8px 0',
       },
     },
+    {
+      props: { orientation: 'vertical', alternativeLabel: true },
+      style: {
+        [`&.${stepLabelClasses.alternativeLabel}`]: {
+          flexDirection: 'row-reverse',
+        },
+      },
+    },
   ],
 });
 
@@ -93,6 +101,16 @@ const StepLabelLabel = styled('span', {
     [`&.${stepLabelClasses.error}`]: {
       color: (theme.vars || theme).palette.error.main,
     },
+    variants: [
+      {
+        props: { orientation: 'vertical', alternativeLabel: true },
+        style: {
+          [`&.${stepLabelClasses.alternativeLabel}`]: {
+            marginTop: 0,
+          },
+        },
+      },
+    ],
   })),
 );
 
@@ -106,6 +124,15 @@ const StepLabelIconContainer = styled('span', {
   [`&.${stepLabelClasses.alternativeLabel}`]: {
     paddingRight: 0,
   },
+  variants: [
+    {
+      props: { orientation: 'vertical', alternativeLabel: true },
+      style: {
+        paddingRight: 0,
+        paddingLeft: 8,
+      },
+    },
+  ],
 });
 
 const StepLabelLabelContainer = styled('span', {
@@ -118,6 +145,16 @@ const StepLabelLabelContainer = styled('span', {
     [`&.${stepLabelClasses.alternativeLabel}`]: {
       textAlign: 'center',
     },
+    variants: [
+      {
+        props: { orientation: 'vertical', alternativeLabel: true },
+        style: {
+          [`&.${stepLabelClasses.alternativeLabel}`]: {
+            textAlign: 'right',
+          },
+        },
+      },
+    ],
   })),
 );
 

--- a/packages/mui-material/src/StepLabel/StepLabel.js
+++ b/packages/mui-material/src/StepLabel/StepLabel.js
@@ -56,9 +56,6 @@ const StepLabelRoot = styled('span', {
 })({
   display: 'flex',
   alignItems: 'center',
-  [`&.${stepLabelClasses.alternativeLabel}`]: {
-    flexDirection: 'column',
-  },
   [`&.${stepLabelClasses.disabled}`]: {
     cursor: 'default',
   },
@@ -71,11 +68,15 @@ const StepLabelRoot = styled('span', {
       },
     },
     {
+      props: { alternativeLabel: true },
+      style: {
+        flexDirection: 'column',
+      },
+    },
+    {
       props: { orientation: 'vertical', alternativeLabel: true },
       style: {
-        [`&.${stepLabelClasses.alternativeLabel}`]: {
-          flexDirection: 'row-reverse',
-        },
+        flexDirection: 'row-reverse',
       },
     },
   ],

--- a/packages/mui-material/src/Stepper/Stepper.d.ts
+++ b/packages/mui-material/src/Stepper/Stepper.d.ts
@@ -18,7 +18,7 @@ export interface StepperOwnProps extends Pick<PaperProps, 'elevation' | 'square'
    * If set to 'true' and orientation is horizontal,
    * then the step label will be positioned under the icon.
    * If set to 'true' and orientation is vertical,
-   * then the step label will be positioned to the right of the icon.
+   * it reverses the position of the label and content.
    * @default false
    */
   alternativeLabel?: boolean | undefined;

--- a/packages/mui-material/src/Stepper/Stepper.d.ts
+++ b/packages/mui-material/src/Stepper/Stepper.d.ts
@@ -17,6 +17,8 @@ export interface StepperOwnProps extends Pick<PaperProps, 'elevation' | 'square'
   /**
    * If set to 'true' and orientation is horizontal,
    * then the step label will be positioned under the icon.
+   * If set to 'true' and orientation is vertical,
+   * then the step label will be positioned to the right of the icon.
    * @default false
    */
   alternativeLabel?: boolean | undefined;

--- a/packages/mui-material/src/Stepper/Stepper.js
+++ b/packages/mui-material/src/Stepper/Stepper.js
@@ -65,6 +65,12 @@ const StepperRoot = styled('ol', {
         alignItems: 'flex-start',
       },
     },
+    {
+      props: { orientation: 'vertical', alternativeLabel: true },
+      style: {
+        alignItems: 'flex-end',
+      },
+    },
   ],
 });
 
@@ -212,6 +218,8 @@ Stepper.propTypes /* remove-proptypes */ = {
   /**
    * If set to 'true' and orientation is horizontal,
    * then the step label will be positioned under the icon.
+   * If set to 'true' and orientation is vertical,
+   * then the step label will be positioned to the right of the icon.
    * @default false
    */
   alternativeLabel: PropTypes.bool,

--- a/packages/mui-material/src/Stepper/Stepper.js
+++ b/packages/mui-material/src/Stepper/Stepper.js
@@ -219,7 +219,7 @@ Stepper.propTypes /* remove-proptypes */ = {
    * If set to 'true' and orientation is horizontal,
    * then the step label will be positioned under the icon.
    * If set to 'true' and orientation is vertical,
-   * then the step label will be positioned to the right of the icon.
+   * it reverses the position of the label and content.
    * @default false
    */
   alternativeLabel: PropTypes.bool,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Properly support `vertical` orientation with `alternativeLabel`.

Move the steps and the content to the opposite side using variant overrides. Another option would have been to ignore the alternativeLabel prop when vertical orientation is used, and show a warning. But supporting it visually without showing a broken UI seems to be better.

|Before|After|
|--|--|
|<img width="481" height="437" alt="Screenshot 2026-05-06 at 17 01 31" src="https://github.com/user-attachments/assets/04e5b969-22ac-494f-b6a4-e45374396171" />|<img width="413" height="417" alt="Screenshot 2026-05-06 at 16 57 04" src="https://github.com/user-attachments/assets/ce81d1ac-b848-4c24-8a7c-77b530b75241" />|


