### PR TITLE
[stepper] Include StepConnector inside Step element

### DIFF
--- a/packages/mui-material/src/Step/Step.js
+++ b/packages/mui-material/src/Step/Step.js
@@ -36,10 +36,25 @@ const StepRoot = styled('li', {
 })({
   variants: [
     {
-      props: { orientation: 'horizontal' },
+      props: { orientation: 'horizontal', alternativeLabel: false, hasConnector: false },
       style: {
         paddingLeft: 8,
+      },
+    },
+    {
+      props: { orientation: 'horizontal', alternativeLabel: false, last: true },
+      style: {
         paddingRight: 8,
+      },
+    },
+    {
+      props: { orientation: 'horizontal', alternativeLabel: false, hasConnector: true },
+      style: {
+        flex: '1 1 auto',
+        display: 'grid',
+        gridTemplateColumns: '1fr auto',
+        alignItems: 'center',
+        gap: 8,
       },
     },
     {
@@ -89,6 +104,8 @@ const Step = React.forwardRef(function Step(inProps, ref) {
     [index, last, expanded, active, completed, disabled],
   );
 
+  const hasConnector = !!connector && index !== 0;
+
   const ownerState = {
     ...props,
     active,
@@ -98,34 +115,24 @@ const Step = React.forwardRef(function Step(inProps, ref) {
     disabled,
     expanded,
     component,
+    hasConnector,
   };
 
   const classes = useUtilityClasses(ownerState);
 
-  const newChildren = (
-    <StepRoot
-      as={component}
-      className={clsx(classes.root, className)}
-      ref={ref}
-      ownerState={ownerState}
-      role={isTabList ? 'presentation' : undefined}
-      {...other}
-    >
-      {connector && alternativeLabel && index !== 0 ? connector : null}
-      {children}
-    </StepRoot>
-  );
-
   return (
     <StepContext.Provider value={contextValue}>
-      {connector && !alternativeLabel && index !== 0 ? (
-        <React.Fragment>
-          {connector}
-          {newChildren}
-        </React.Fragment>
-      ) : (
-        newChildren
-      )}
+      <StepRoot
+        as={component}
+        className={clsx(classes.root, className)}
+        ref={ref}
+        ownerState={ownerState}
+        role={isTabList ? 'presentation' : undefined}
+        {...other}
+      >
+        {hasConnector ? connector : null}
+        {children}
+      </StepRoot>
     </StepContext.Provider>
   );
 });

--- a/packages/mui-material/src/Step/Step.test.js
+++ b/packages/mui-material/src/Step/Step.test.js
@@ -152,5 +152,47 @@ describe('<Step />', () => {
       const stepLabels = container.querySelectorAll(`.${stepLabelClasses.root}`);
       expect(stepLabels[1]).to.have.class(stepLabelClasses.disabled);
     });
+
+    it('checks that step connector is a child of the step when alternativeLabel is true', () => {
+      const { container } = render(
+        <Stepper activeStep={1} connector={<div data-testid="connector" />} alternativeLabel>
+          <Step>
+            <StepLabel>Step 1</StepLabel>
+          </Step>
+          <Step>
+            <StepLabel>Step 2</StepLabel>
+          </Step>
+          <Step>
+            <StepLabel>Step 3</StepLabel>
+          </Step>
+        </Stepper>,
+      );
+
+      const connectors = container.querySelectorAll('li>[data-testid="connector"]');
+      expect(connectors).to.have.lengthOf(2);
+    });
+
+    it('checks that step connector is a child of the step when alternativeLabel is false', () => {
+      const { container } = render(
+        <Stepper
+          activeStep={1}
+          connector={<div data-testid="connector" />}
+          alternativeLabel={false}
+        >
+          <Step>
+            <StepLabel>Step 1</StepLabel>
+          </Step>
+          <Step>
+            <StepLabel>Step 2</StepLabel>
+          </Step>
+          <Step>
+            <StepLabel>Step 3</StepLabel>
+          </Step>
+        </Stepper>,
+      );
+
+      const connectors = container.querySelectorAll('li>[data-testid="connector"]');
+      expect(connectors).to.have.lengthOf(2);
+    });
   });
 });

--- a/packages/mui-material/src/Stepper/Stepper.js
+++ b/packages/mui-material/src/Stepper/Stepper.js
@@ -48,6 +48,12 @@ const StepperRoot = styled('ol', {
       },
     },
     {
+      props: { orientation: 'horizontal', alternativeLabel: false },
+      style: {
+        gap: 8,
+      },
+    },
+    {
       props: { orientation: 'vertical' },
       style: {
         flexDirection: 'column',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Includes the StepConnector inside the Step element at all times. This is done to ensure we only have `<li>` elements inside the `<ol>` stepper element. The `<div>` elements from the connectors now are part of the `<li>`.

Updated the styles to keep the non-alternativeLabel variant the same visually.

Follow up for https://github.com/mui/material-ui/pull/48397