### PR TITLE
[docs][stepper] Fix focus management in examples

### DIFF
--- a/docs/data/material/components/steppers/DotsMobileStepper.js
+++ b/docs/data/material/components/steppers/DotsMobileStepper.js
@@ -46,6 +46,11 @@ export default function DotsMobileStepper() {
       position="static"
       activeStep={activeStep}
       sx={{ maxWidth: 400, flexGrow: 1 }}
+      slotProps={{
+        progress: {
+          'aria-label': 'stepper dotted progress',
+        },
+      }}
       nextButton={
         <Button
           size="small"

--- a/docs/data/material/components/steppers/DotsMobileStepper.js
+++ b/docs/data/material/components/steppers/DotsMobileStepper.js
@@ -17,6 +17,25 @@ export default function DotsMobileStepper() {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
+  const nextButtonRef = React.useRef(null);
+  const backButtonRef = React.useRef(null);
+  const previousActiveStepRef = React.useRef(activeStep);
+
+  // Manage focus when the active step changes.
+  React.useEffect(() => {
+    const previousActiveStep = previousActiveStepRef.current;
+
+    if (activeStep === 0 && previousActiveStep === 1) {
+      // If the user is going back to the first step, focus the Next button.
+      nextButtonRef.current?.focus();
+    } else if (activeStep === 5 && previousActiveStep === 4) {
+      // If the user is going to the last step, focus the Back button.
+      backButtonRef.current?.focus();
+    }
+
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep]);
+
   return (
     <MobileStepper
       variant="dots"
@@ -25,7 +44,12 @@ export default function DotsMobileStepper() {
       activeStep={activeStep}
       sx={{ maxWidth: 400, flexGrow: 1 }}
       nextButton={
-        <Button size="small" onClick={handleNext} disabled={activeStep === 5}>
+        <Button
+          size="small"
+          onClick={handleNext}
+          disabled={activeStep === 5}
+          ref={nextButtonRef}
+        >
           Next
           {theme.direction === 'rtl' ? (
             <KeyboardArrowLeft />
@@ -35,7 +59,12 @@ export default function DotsMobileStepper() {
         </Button>
       }
       backButton={
-        <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+        <Button
+          size="small"
+          onClick={handleBack}
+          disabled={activeStep === 0}
+          ref={backButtonRef}
+        >
           {theme.direction === 'rtl' ? (
             <KeyboardArrowRight />
           ) : (

--- a/docs/data/material/components/steppers/DotsMobileStepper.js
+++ b/docs/data/material/components/steppers/DotsMobileStepper.js
@@ -5,6 +5,8 @@ import Button from '@mui/material/Button';
 import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
 import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
 
+const steps = 6;
+
 export default function DotsMobileStepper() {
   const theme = useTheme();
   const [activeStep, setActiveStep] = React.useState(0);
@@ -27,12 +29,12 @@ export default function DotsMobileStepper() {
     previousActiveStepRef.current = activeStep;
 
     if (activeStep === 0 && previousActiveStep === 1) {
-      // If the user is going back to the first step, focus the Next button.
+      // If the user is going back to the first step, focus the "Next" button.
       nextButtonRef.current?.focus();
       return;
     }
-    if (activeStep === 5 && previousActiveStep === 4) {
-      // If the user is going to the last step, focus the Back button.
+    if (activeStep === steps - 1 && previousActiveStep === steps - 2) {
+      // If the user is going to the last step, focus the "Back" button.
       backButtonRef.current?.focus();
     }
   }, [activeStep]);
@@ -40,7 +42,7 @@ export default function DotsMobileStepper() {
   return (
     <MobileStepper
       variant="dots"
-      steps={6}
+      steps={steps}
       position="static"
       activeStep={activeStep}
       sx={{ maxWidth: 400, flexGrow: 1 }}

--- a/docs/data/material/components/steppers/DotsMobileStepper.js
+++ b/docs/data/material/components/steppers/DotsMobileStepper.js
@@ -24,16 +24,17 @@ export default function DotsMobileStepper() {
   // Manage focus when the active step changes.
   React.useEffect(() => {
     const previousActiveStep = previousActiveStepRef.current;
+    previousActiveStepRef.current = activeStep;
 
     if (activeStep === 0 && previousActiveStep === 1) {
       // If the user is going back to the first step, focus the Next button.
       nextButtonRef.current?.focus();
-    } else if (activeStep === 5 && previousActiveStep === 4) {
+      return;
+    }
+    if (activeStep === 5 && previousActiveStep === 4) {
       // If the user is going to the last step, focus the Back button.
       backButtonRef.current?.focus();
     }
-
-    previousActiveStepRef.current = activeStep;
   }, [activeStep]);
 
   return (

--- a/docs/data/material/components/steppers/DotsMobileStepper.js
+++ b/docs/data/material/components/steppers/DotsMobileStepper.js
@@ -30,12 +30,12 @@ export default function DotsMobileStepper() {
 
     if (activeStep === 0 && previousActiveStep === 1) {
       // If the user is going back to the first step, focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current.focus();
       return;
     }
     if (activeStep === steps - 1 && previousActiveStep === steps - 2) {
       // If the user is going to the last step, focus the "Back" button.
-      backButtonRef.current?.focus();
+      backButtonRef.current.focus();
     }
   }, [activeStep]);
 

--- a/docs/data/material/components/steppers/DotsMobileStepper.tsx
+++ b/docs/data/material/components/steppers/DotsMobileStepper.tsx
@@ -30,12 +30,12 @@ export default function DotsMobileStepper() {
 
     if (activeStep === 0 && previousActiveStep === 1) {
       // If the user is going back to the first step, focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current!.focus();
       return;
     }
     if (activeStep === steps - 1 && previousActiveStep === steps - 2) {
       // If the user is going to the last step, focus the "Back" button.
-      backButtonRef.current?.focus();
+      backButtonRef.current!.focus();
     }
   }, [activeStep]);
 

--- a/docs/data/material/components/steppers/DotsMobileStepper.tsx
+++ b/docs/data/material/components/steppers/DotsMobileStepper.tsx
@@ -46,6 +46,11 @@ export default function DotsMobileStepper() {
       position="static"
       activeStep={activeStep}
       sx={{ maxWidth: 400, flexGrow: 1 }}
+      slotProps={{
+        progress: {
+          'aria-label': 'stepper dotted progress',
+        },
+      }}
       nextButton={
         <Button
           size="small"

--- a/docs/data/material/components/steppers/DotsMobileStepper.tsx
+++ b/docs/data/material/components/steppers/DotsMobileStepper.tsx
@@ -17,6 +17,25 @@ export default function DotsMobileStepper() {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
+  const nextButtonRef = React.useRef<HTMLButtonElement>(null);
+  const backButtonRef = React.useRef<HTMLButtonElement>(null);
+  const previousActiveStepRef = React.useRef(activeStep);
+
+  // Manage focus when the active step changes.
+  React.useEffect(() => {
+    const previousActiveStep = previousActiveStepRef.current;
+
+    if (activeStep === 0 && previousActiveStep === 1) {
+      // If the user is going back to the first step, focus the Next button.
+      nextButtonRef.current?.focus();
+    } else if (activeStep === 5 && previousActiveStep === 4) {
+      // If the user is going to the last step, focus the Back button.
+      backButtonRef.current?.focus();
+    }
+
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep]);
+
   return (
     <MobileStepper
       variant="dots"
@@ -25,7 +44,12 @@ export default function DotsMobileStepper() {
       activeStep={activeStep}
       sx={{ maxWidth: 400, flexGrow: 1 }}
       nextButton={
-        <Button size="small" onClick={handleNext} disabled={activeStep === 5}>
+        <Button
+          size="small"
+          onClick={handleNext}
+          disabled={activeStep === 5}
+          ref={nextButtonRef}
+        >
           Next
           {theme.direction === 'rtl' ? (
             <KeyboardArrowLeft />
@@ -35,7 +59,12 @@ export default function DotsMobileStepper() {
         </Button>
       }
       backButton={
-        <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+        <Button
+          size="small"
+          onClick={handleBack}
+          disabled={activeStep === 0}
+          ref={backButtonRef}
+        >
           {theme.direction === 'rtl' ? (
             <KeyboardArrowRight />
           ) : (

--- a/docs/data/material/components/steppers/DotsMobileStepper.tsx
+++ b/docs/data/material/components/steppers/DotsMobileStepper.tsx
@@ -5,6 +5,8 @@ import Button from '@mui/material/Button';
 import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
 import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
 
+const steps = 6;
+
 export default function DotsMobileStepper() {
   const theme = useTheme();
   const [activeStep, setActiveStep] = React.useState(0);
@@ -27,12 +29,12 @@ export default function DotsMobileStepper() {
     previousActiveStepRef.current = activeStep;
 
     if (activeStep === 0 && previousActiveStep === 1) {
-      // If the user is going back to the first step, focus the Next button.
+      // If the user is going back to the first step, focus the "Next" button.
       nextButtonRef.current?.focus();
       return;
     }
-    if (activeStep === 5 && previousActiveStep === 4) {
-      // If the user is going to the last step, focus the Back button.
+    if (activeStep === steps - 1 && previousActiveStep === steps - 2) {
+      // If the user is going to the last step, focus the "Back" button.
       backButtonRef.current?.focus();
     }
   }, [activeStep]);
@@ -40,7 +42,7 @@ export default function DotsMobileStepper() {
   return (
     <MobileStepper
       variant="dots"
-      steps={6}
+      steps={steps}
       position="static"
       activeStep={activeStep}
       sx={{ maxWidth: 400, flexGrow: 1 }}

--- a/docs/data/material/components/steppers/DotsMobileStepper.tsx
+++ b/docs/data/material/components/steppers/DotsMobileStepper.tsx
@@ -24,16 +24,17 @@ export default function DotsMobileStepper() {
   // Manage focus when the active step changes.
   React.useEffect(() => {
     const previousActiveStep = previousActiveStepRef.current;
+    previousActiveStepRef.current = activeStep;
 
     if (activeStep === 0 && previousActiveStep === 1) {
       // If the user is going back to the first step, focus the Next button.
       nextButtonRef.current?.focus();
-    } else if (activeStep === 5 && previousActiveStep === 4) {
+      return;
+    }
+    if (activeStep === 5 && previousActiveStep === 4) {
       // If the user is going to the last step, focus the Back button.
       backButtonRef.current?.focus();
     }
-
-    previousActiveStepRef.current = activeStep;
   }, [activeStep]);
 
   return (

--- a/docs/data/material/components/steppers/HorizontalLinearStepper.js
+++ b/docs/data/material/components/steppers/HorizontalLinearStepper.js
@@ -12,9 +12,9 @@ export default function HorizontalLinearStepper() {
   const [activeStep, setActiveStep] = React.useState(0);
   const [skipped, setSkipped] = React.useState(new Set());
 
-  const isStepOptional = (step) => {
+  const isStepOptional = React.useCallback((step) => {
     return step === 1;
-  };
+  }, []);
 
   const isStepSkipped = (step) => {
     return skipped.has(step);
@@ -64,20 +64,20 @@ export default function HorizontalLinearStepper() {
     previousActiveStepRef.current = activeStep;
 
     if (activeStep === steps.length) {
-      // If the user has completed all steps and hits Finish, focus the Reset button.
+      // If the user has completed all steps and hits "Finish", focus the "Reset" button.
       resetButtonRef.current?.focus();
       return;
     }
     if (activeStep === 0 && previousActiveStep === steps.length) {
-      // If the user has completed all steps and hits Reset, focus the Next button.
+      // If the user has completed all steps and hits "Reset", focus the "Next" button.
       nextButtonRef.current?.focus();
       return;
     }
     if (isStepOptional(previousActiveStep) && !isStepOptional(activeStep)) {
-      // If the user hits Skip and the next step is not optional, focus the Next button.
+      // If the user hits "Skip" and the next step is not optional, focus the "Next" button.
       nextButtonRef.current?.focus();
     }
-  }, [activeStep]);
+  }, [activeStep, isStepOptional]);
 
   return (
     <Box sx={{ width: '100%' }}>

--- a/docs/data/material/components/steppers/HorizontalLinearStepper.js
+++ b/docs/data/material/components/steppers/HorizontalLinearStepper.js
@@ -54,6 +54,28 @@ export default function HorizontalLinearStepper() {
     setActiveStep(0);
   };
 
+  const previousActiveStepRef = React.useRef(activeStep);
+  const resetButtonRef = React.useRef(null);
+  const nextButtonRef = React.useRef(null);
+
+  // Manage focus when the active step changes.
+  React.useEffect(() => {
+    const previousActiveStep = previousActiveStepRef.current;
+
+    if (activeStep === steps.length) {
+      // If the user has completed all steps and hits Finish, focus the Reset button.
+      resetButtonRef.current?.focus();
+    } else if (activeStep === 0 && previousActiveStep === steps.length) {
+      // If the user has completed all steps and hits Reset, focus the Next button.
+      nextButtonRef.current?.focus();
+    } else if (isStepOptional(previousActiveStep) && !isStepOptional(activeStep)) {
+      // If the user hits Skip and the next step is not optional, focus the Next button.
+      nextButtonRef.current?.focus();
+    }
+
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep]);
+
   return (
     <Box sx={{ width: '100%' }}>
       <Stepper activeStep={activeStep}>
@@ -82,7 +104,9 @@ export default function HorizontalLinearStepper() {
           </Typography>
           <Box sx={{ display: 'flex', flexDirection: 'row', pt: 2 }}>
             <Box sx={{ flex: '1 1 auto' }} />
-            <Button onClick={handleReset}>Reset</Button>
+            <Button onClick={handleReset} ref={resetButtonRef}>
+              Reset
+            </Button>
           </Box>
         </React.Fragment>
       ) : (
@@ -103,7 +127,7 @@ export default function HorizontalLinearStepper() {
                 Skip
               </Button>
             )}
-            <Button onClick={handleNext}>
+            <Button onClick={handleNext} ref={nextButtonRef}>
               {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
             </Button>
           </Box>

--- a/docs/data/material/components/steppers/HorizontalLinearStepper.js
+++ b/docs/data/material/components/steppers/HorizontalLinearStepper.js
@@ -61,19 +61,22 @@ export default function HorizontalLinearStepper() {
   // Manage focus when the active step changes.
   React.useEffect(() => {
     const previousActiveStep = previousActiveStepRef.current;
+    previousActiveStepRef.current = activeStep;
 
     if (activeStep === steps.length) {
       // If the user has completed all steps and hits Finish, focus the Reset button.
       resetButtonRef.current?.focus();
-    } else if (activeStep === 0 && previousActiveStep === steps.length) {
+      return;
+    }
+    if (activeStep === 0 && previousActiveStep === steps.length) {
       // If the user has completed all steps and hits Reset, focus the Next button.
       nextButtonRef.current?.focus();
-    } else if (isStepOptional(previousActiveStep) && !isStepOptional(activeStep)) {
+      return;
+    }
+    if (isStepOptional(previousActiveStep) && !isStepOptional(activeStep)) {
       // If the user hits Skip and the next step is not optional, focus the Next button.
       nextButtonRef.current?.focus();
     }
-
-    previousActiveStepRef.current = activeStep;
   }, [activeStep]);
 
   return (

--- a/docs/data/material/components/steppers/HorizontalLinearStepper.js
+++ b/docs/data/material/components/steppers/HorizontalLinearStepper.js
@@ -65,17 +65,17 @@ export default function HorizontalLinearStepper() {
 
     if (activeStep === steps.length) {
       // If the user has completed all steps and hits "Finish", focus the "Reset" button.
-      resetButtonRef.current?.focus();
+      resetButtonRef.current.focus();
       return;
     }
     if (activeStep === 0 && previousActiveStep === steps.length) {
       // If the user has completed all steps and hits "Reset", focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current.focus();
       return;
     }
     if (isStepOptional(previousActiveStep) && !isStepOptional(activeStep)) {
       // If the user hits "Skip" and the next step is not optional, focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current.focus();
     }
   }, [activeStep, isStepOptional]);
 

--- a/docs/data/material/components/steppers/HorizontalLinearStepper.tsx
+++ b/docs/data/material/components/steppers/HorizontalLinearStepper.tsx
@@ -12,9 +12,9 @@ export default function HorizontalLinearStepper() {
   const [activeStep, setActiveStep] = React.useState(0);
   const [skipped, setSkipped] = React.useState(new Set<number>());
 
-  const isStepOptional = (step: number) => {
+  const isStepOptional = React.useCallback((step: number) => {
     return step === 1;
-  };
+  }, []);
 
   const isStepSkipped = (step: number) => {
     return skipped.has(step);
@@ -64,20 +64,20 @@ export default function HorizontalLinearStepper() {
     previousActiveStepRef.current = activeStep;
 
     if (activeStep === steps.length) {
-      // If the user has completed all steps and hits Finish, focus the Reset button.
+      // If the user has completed all steps and hits "Finish", focus the "Reset" button.
       resetButtonRef.current?.focus();
       return;
     }
     if (activeStep === 0 && previousActiveStep === steps.length) {
-      // If the user has completed all steps and hits Reset, focus the Next button.
+      // If the user has completed all steps and hits "Reset", focus the "Next" button.
       nextButtonRef.current?.focus();
       return;
     }
     if (isStepOptional(previousActiveStep) && !isStepOptional(activeStep)) {
-      // If the user hits Skip and the next step is not optional, focus the Next button.
+      // If the user hits "Skip" and the next step is not optional, focus the "Next" button.
       nextButtonRef.current?.focus();
     }
-  }, [activeStep]);
+  }, [activeStep, isStepOptional]);
 
   return (
     <Box sx={{ width: '100%' }}>

--- a/docs/data/material/components/steppers/HorizontalLinearStepper.tsx
+++ b/docs/data/material/components/steppers/HorizontalLinearStepper.tsx
@@ -54,6 +54,28 @@ export default function HorizontalLinearStepper() {
     setActiveStep(0);
   };
 
+  const previousActiveStepRef = React.useRef(activeStep);
+  const resetButtonRef = React.useRef<HTMLButtonElement>(null);
+  const nextButtonRef = React.useRef<HTMLButtonElement>(null);
+
+  // Manage focus when the active step changes.
+  React.useEffect(() => {
+    const previousActiveStep = previousActiveStepRef.current;
+
+    if (activeStep === steps.length) {
+      // If the user has completed all steps and hits Finish, focus the Reset button.
+      resetButtonRef.current?.focus();
+    } else if (activeStep === 0 && previousActiveStep === steps.length) {
+      // If the user has completed all steps and hits Reset, focus the Next button.
+      nextButtonRef.current?.focus();
+    } else if (isStepOptional(previousActiveStep) && !isStepOptional(activeStep)) {
+      // If the user hits Skip and the next step is not optional, focus the Next button.
+      nextButtonRef.current?.focus();
+    }
+
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep]);
+
   return (
     <Box sx={{ width: '100%' }}>
       <Stepper activeStep={activeStep}>
@@ -84,7 +106,9 @@ export default function HorizontalLinearStepper() {
           </Typography>
           <Box sx={{ display: 'flex', flexDirection: 'row', pt: 2 }}>
             <Box sx={{ flex: '1 1 auto' }} />
-            <Button onClick={handleReset}>Reset</Button>
+            <Button onClick={handleReset} ref={resetButtonRef}>
+              Reset
+            </Button>
           </Box>
         </React.Fragment>
       ) : (
@@ -105,7 +129,7 @@ export default function HorizontalLinearStepper() {
                 Skip
               </Button>
             )}
-            <Button onClick={handleNext}>
+            <Button onClick={handleNext} ref={nextButtonRef}>
               {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
             </Button>
           </Box>

--- a/docs/data/material/components/steppers/HorizontalLinearStepper.tsx
+++ b/docs/data/material/components/steppers/HorizontalLinearStepper.tsx
@@ -61,19 +61,22 @@ export default function HorizontalLinearStepper() {
   // Manage focus when the active step changes.
   React.useEffect(() => {
     const previousActiveStep = previousActiveStepRef.current;
+    previousActiveStepRef.current = activeStep;
 
     if (activeStep === steps.length) {
       // If the user has completed all steps and hits Finish, focus the Reset button.
       resetButtonRef.current?.focus();
-    } else if (activeStep === 0 && previousActiveStep === steps.length) {
+      return;
+    }
+    if (activeStep === 0 && previousActiveStep === steps.length) {
       // If the user has completed all steps and hits Reset, focus the Next button.
       nextButtonRef.current?.focus();
-    } else if (isStepOptional(previousActiveStep) && !isStepOptional(activeStep)) {
+      return;
+    }
+    if (isStepOptional(previousActiveStep) && !isStepOptional(activeStep)) {
       // If the user hits Skip and the next step is not optional, focus the Next button.
       nextButtonRef.current?.focus();
     }
-
-    previousActiveStepRef.current = activeStep;
   }, [activeStep]);
 
   return (

--- a/docs/data/material/components/steppers/HorizontalLinearStepper.tsx
+++ b/docs/data/material/components/steppers/HorizontalLinearStepper.tsx
@@ -65,17 +65,17 @@ export default function HorizontalLinearStepper() {
 
     if (activeStep === steps.length) {
       // If the user has completed all steps and hits "Finish", focus the "Reset" button.
-      resetButtonRef.current?.focus();
+      resetButtonRef.current!.focus();
       return;
     }
     if (activeStep === 0 && previousActiveStep === steps.length) {
       // If the user has completed all steps and hits "Reset", focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current!.focus();
       return;
     }
     if (isStepOptional(previousActiveStep) && !isStepOptional(activeStep)) {
       // If the user hits "Skip" and the next step is not optional, focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current!.focus();
     }
   }, [activeStep, isStepOptional]);
 

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
@@ -21,7 +21,7 @@ export default function HorizontalNonLinearStepper() {
     const newActiveStep =
       isLastStep && !allStepsCompleted
         ? // It's the last step, but not all steps have been completed,
-          // find the first step that has been completed
+          // find the first step that has not been completed
           steps.findIndex((_step, i) => !(i in completed))
         : activeStep + 1;
     setActiveStep(newActiveStep);
@@ -59,7 +59,7 @@ export default function HorizontalNonLinearStepper() {
     previousCompletedRef.current = completed;
 
     if (allStepsCompleted) {
-      // If the user has completed all steps and hits Finish, focus the Reset button.
+      // If the user has completed all steps and hits "Finish", focus the "Reset" button.
       resetButtonRef.current?.focus();
       return;
     }
@@ -68,7 +68,7 @@ export default function HorizontalNonLinearStepper() {
       Object.keys(completed).length === 0 &&
       Object.keys(previousCompleted).length !== 0
     ) {
-      // If the user has completed all steps and hits Reset, focus the Next button.
+      // If the user has completed all steps and hits "Reset", focus the "Next" button.
       nextButtonRef.current?.focus();
     }
   }, [completed, allStepsCompleted]);
@@ -76,7 +76,7 @@ export default function HorizontalNonLinearStepper() {
   // Manage focus when the active step changes.
   React.useEffect(() => {
     if (activeStep === 0 && previousActiveStepRef.current === 1) {
-      // If the user navigated to first step via Back button, focus the Next button.
+      // If the user navigated to first step via "Back" button, focus the "Next" button.
       nextButtonRef.current?.focus();
     }
 

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
@@ -59,6 +59,31 @@ export default function HorizontalNonLinearStepper() {
     setCompleted({});
   };
 
+  const resetButtonRef = React.useRef(null);
+  const nextButtonRef = React.useRef(null);
+  const previousActiveStepRef = React.useRef(activeStep);
+
+  // Manage focus when the completed steps change.
+  React.useEffect(() => {
+    if (allStepsCompleted()) {
+      // If the user has completed all steps and hits Finish, focus the Reset button.
+      resetButtonRef.current?.focus();
+    } else if (Object.keys(completed).length === 0) {
+      // If the user has completed all steps and hits Reset, focus the Next button.
+      nextButtonRef.current?.focus();
+    }
+  }, [completed]);
+
+  // Manage focus when the active step changes.
+  React.useEffect(() => {
+    if (activeStep === 0 && previousActiveStepRef.current === 1) {
+      // If the user navigated to first step via Back button, focus the Next button.
+      nextButtonRef.current?.focus();
+    }
+
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep]);
+
   return (
     <Box sx={{ width: '100%' }}>
       <Stepper nonLinear activeStep={activeStep}>
@@ -82,7 +107,9 @@ export default function HorizontalNonLinearStepper() {
             </Typography>
             <Box sx={{ display: 'flex', flexDirection: 'row', pt: 2 }}>
               <Box sx={{ flex: '1 1 auto' }} />
-              <Button onClick={handleReset}>Reset</Button>
+              <Button onClick={handleReset} ref={resetButtonRef}>
+                Reset
+              </Button>
             </Box>
           </React.Fragment>
         ) : (
@@ -100,7 +127,7 @@ export default function HorizontalNonLinearStepper() {
                 Back
               </Button>
               <Box sx={{ flex: '1 1 auto' }} />
-              <Button onClick={handleNext} sx={{ mr: 1 }}>
+              <Button onClick={handleNext} sx={{ mr: 1 }} ref={nextButtonRef}>
                 Next
               </Button>
               {activeStep !== steps.length &&

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
@@ -12,28 +12,17 @@ export default function HorizontalNonLinearStepper() {
   const [activeStep, setActiveStep] = React.useState(0);
   const [completed, setCompleted] = React.useState({});
 
-  const totalSteps = () => {
-    return steps.length;
-  };
-
-  const completedSteps = () => {
-    return Object.keys(completed).length;
-  };
-
-  const isLastStep = () => {
-    return activeStep === totalSteps() - 1;
-  };
-
-  const allStepsCompleted = () => {
-    return completedSteps() === totalSteps();
-  };
+  const totalSteps = steps.length;
+  const completedSteps = Object.keys(completed).length;
+  const isLastStep = activeStep === totalSteps - 1;
+  const allStepsCompleted = completedSteps === totalSteps;
 
   const handleNext = () => {
     const newActiveStep =
-      isLastStep() && !allStepsCompleted()
+      isLastStep && !allStepsCompleted
         ? // It's the last step, but not all steps have been completed,
           // find the first step that has been completed
-          steps.findIndex((step, i) => !(i in completed))
+          steps.findIndex((_step, i) => !(i in completed))
         : activeStep + 1;
     setActiveStep(newActiveStep);
   };
@@ -65,14 +54,14 @@ export default function HorizontalNonLinearStepper() {
 
   // Manage focus when the completed steps change.
   React.useEffect(() => {
-    if (allStepsCompleted()) {
+    if (allStepsCompleted) {
       // If the user has completed all steps and hits Finish, focus the Reset button.
       resetButtonRef.current?.focus();
     } else if (Object.keys(completed).length === 0) {
       // If the user has completed all steps and hits Reset, focus the Next button.
       nextButtonRef.current?.focus();
     }
-  }, [completed]);
+  }, [completed, allStepsCompleted]);
 
   // Manage focus when the active step changes.
   React.useEffect(() => {
@@ -100,7 +89,7 @@ export default function HorizontalNonLinearStepper() {
         ))}
       </Stepper>
       <div id="stepper-content">
-        {allStepsCompleted() ? (
+        {allStepsCompleted ? (
           <React.Fragment>
             <Typography sx={{ mt: 2, mb: 1 }}>
               All steps completed - you&apos;re finished
@@ -137,9 +126,7 @@ export default function HorizontalNonLinearStepper() {
                   </Typography>
                 ) : (
                   <Button onClick={handleComplete}>
-                    {completedSteps() === totalSteps() - 1
-                      ? 'Finish'
-                      : 'Complete Step'}
+                    {completedSteps === totalSteps - 1 ? 'Finish' : 'Complete Step'}
                   </Button>
                 ))}
             </Box>

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
@@ -51,13 +51,23 @@ export default function HorizontalNonLinearStepper() {
   const resetButtonRef = React.useRef(null);
   const nextButtonRef = React.useRef(null);
   const previousActiveStepRef = React.useRef(activeStep);
+  const previousCompletedRef = React.useRef(completed);
 
   // Manage focus when the completed steps change.
   React.useEffect(() => {
+    const previousCompleted = previousCompletedRef.current;
+    previousCompletedRef.current = completed;
+
     if (allStepsCompleted) {
       // If the user has completed all steps and hits Finish, focus the Reset button.
       resetButtonRef.current?.focus();
-    } else if (Object.keys(completed).length === 0) {
+      return;
+    }
+
+    if (
+      Object.keys(completed).length === 0 &&
+      Object.keys(previousCompleted).length !== 0
+    ) {
       // If the user has completed all steps and hits Reset, focus the Next button.
       nextButtonRef.current?.focus();
     }

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.js
@@ -60,7 +60,7 @@ export default function HorizontalNonLinearStepper() {
 
     if (allStepsCompleted) {
       // If the user has completed all steps and hits "Finish", focus the "Reset" button.
-      resetButtonRef.current?.focus();
+      resetButtonRef.current.focus();
       return;
     }
 
@@ -69,7 +69,7 @@ export default function HorizontalNonLinearStepper() {
       Object.keys(previousCompleted).length !== 0
     ) {
       // If the user has completed all steps and hits "Reset", focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current.focus();
     }
   }, [completed, allStepsCompleted]);
 
@@ -77,7 +77,7 @@ export default function HorizontalNonLinearStepper() {
   React.useEffect(() => {
     if (activeStep === 0 && previousActiveStepRef.current === 1) {
       // If the user navigated to first step via "Back" button, focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current.focus();
     }
 
     previousActiveStepRef.current = activeStep;

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
@@ -62,7 +62,7 @@ export default function HorizontalNonLinearStepper() {
 
     if (allStepsCompleted) {
       // If the user has completed all steps and hits "Finish", focus the "Reset" button.
-      resetButtonRef.current?.focus();
+      resetButtonRef.current!.focus();
       return;
     }
 
@@ -71,7 +71,7 @@ export default function HorizontalNonLinearStepper() {
       Object.keys(previousCompleted).length !== 0
     ) {
       // If the user has completed all steps and hits "Reset", focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current!.focus();
     }
   }, [completed, allStepsCompleted]);
 
@@ -79,7 +79,7 @@ export default function HorizontalNonLinearStepper() {
   React.useEffect(() => {
     if (activeStep === 0 && previousActiveStepRef.current === 1) {
       // If the user navigated to first step via "Back" button, focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current!.focus();
     }
 
     previousActiveStepRef.current = activeStep;

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
@@ -23,7 +23,7 @@ export default function HorizontalNonLinearStepper() {
     const newActiveStep =
       isLastStep && !allStepsCompleted
         ? // It's the last step, but not all steps have been completed,
-          // find the first step that has been completed
+          // find the first step that has not been completed
           steps.findIndex((_step, i) => !(i in completed))
         : activeStep + 1;
     setActiveStep(newActiveStep);
@@ -61,7 +61,7 @@ export default function HorizontalNonLinearStepper() {
     previousCompletedRef.current = completed;
 
     if (allStepsCompleted) {
-      // If the user has completed all steps and hits Finish, focus the Reset button.
+      // If the user has completed all steps and hits "Finish", focus the "Reset" button.
       resetButtonRef.current?.focus();
       return;
     }
@@ -70,7 +70,7 @@ export default function HorizontalNonLinearStepper() {
       Object.keys(completed).length === 0 &&
       Object.keys(previousCompleted).length !== 0
     ) {
-      // If the user has completed all steps and hits Reset, focus the Next button.
+      // If the user has completed all steps and hits "Reset", focus the "Next" button.
       nextButtonRef.current?.focus();
     }
   }, [completed, allStepsCompleted]);
@@ -78,7 +78,7 @@ export default function HorizontalNonLinearStepper() {
   // Manage focus when the active step changes.
   React.useEffect(() => {
     if (activeStep === 0 && previousActiveStepRef.current === 1) {
-      // If the user navigated to first step via Back button, focus the Next button.
+      // If the user navigated to first step via "Back" button, focus the "Next" button.
       nextButtonRef.current?.focus();
     }
 

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
@@ -14,28 +14,17 @@ export default function HorizontalNonLinearStepper() {
     [k: number]: boolean;
   }>({});
 
-  const totalSteps = () => {
-    return steps.length;
-  };
-
-  const completedSteps = () => {
-    return Object.keys(completed).length;
-  };
-
-  const isLastStep = () => {
-    return activeStep === totalSteps() - 1;
-  };
-
-  const allStepsCompleted = () => {
-    return completedSteps() === totalSteps();
-  };
+  const totalSteps = steps.length;
+  const completedSteps = Object.keys(completed).length;
+  const isLastStep = activeStep === totalSteps - 1;
+  const allStepsCompleted = completedSteps === totalSteps;
 
   const handleNext = () => {
     const newActiveStep =
-      isLastStep() && !allStepsCompleted()
+      isLastStep && !allStepsCompleted
         ? // It's the last step, but not all steps have been completed,
           // find the first step that has been completed
-          steps.findIndex((step, i) => !(i in completed))
+          steps.findIndex((_step, i) => !(i in completed))
         : activeStep + 1;
     setActiveStep(newActiveStep);
   };
@@ -67,14 +56,14 @@ export default function HorizontalNonLinearStepper() {
 
   // Manage focus when the completed steps change.
   React.useEffect(() => {
-    if (allStepsCompleted()) {
+    if (allStepsCompleted) {
       // If the user has completed all steps and hits Finish, focus the Reset button.
       resetButtonRef.current?.focus();
     } else if (Object.keys(completed).length === 0) {
       // If the user has completed all steps and hits Reset, focus the Next button.
       nextButtonRef.current?.focus();
     }
-  }, [completed]);
+  }, [completed, allStepsCompleted]);
 
   // Manage focus when the active step changes.
   React.useEffect(() => {
@@ -102,7 +91,7 @@ export default function HorizontalNonLinearStepper() {
         ))}
       </Stepper>
       <div id="stepper-content">
-        {allStepsCompleted() ? (
+        {allStepsCompleted ? (
           <React.Fragment>
             <Typography sx={{ mt: 2, mb: 1 }}>
               All steps completed - you&apos;re finished
@@ -139,9 +128,7 @@ export default function HorizontalNonLinearStepper() {
                   </Typography>
                 ) : (
                   <Button onClick={handleComplete}>
-                    {completedSteps() === totalSteps() - 1
-                      ? 'Finish'
-                      : 'Complete Step'}
+                    {completedSteps === totalSteps - 1 ? 'Finish' : 'Complete Step'}
                   </Button>
                 ))}
             </Box>

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
@@ -53,13 +53,23 @@ export default function HorizontalNonLinearStepper() {
   const resetButtonRef = React.useRef<HTMLButtonElement>(null);
   const nextButtonRef = React.useRef<HTMLButtonElement>(null);
   const previousActiveStepRef = React.useRef(activeStep);
+  const previousCompletedRef = React.useRef(completed);
 
   // Manage focus when the completed steps change.
   React.useEffect(() => {
+    const previousCompleted = previousCompletedRef.current;
+    previousCompletedRef.current = completed;
+
     if (allStepsCompleted) {
       // If the user has completed all steps and hits Finish, focus the Reset button.
       resetButtonRef.current?.focus();
-    } else if (Object.keys(completed).length === 0) {
+      return;
+    }
+
+    if (
+      Object.keys(completed).length === 0 &&
+      Object.keys(previousCompleted).length !== 0
+    ) {
       // If the user has completed all steps and hits Reset, focus the Next button.
       nextButtonRef.current?.focus();
     }

--- a/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/data/material/components/steppers/HorizontalNonLinearStepper.tsx
@@ -61,6 +61,31 @@ export default function HorizontalNonLinearStepper() {
     setCompleted({});
   };
 
+  const resetButtonRef = React.useRef<HTMLButtonElement>(null);
+  const nextButtonRef = React.useRef<HTMLButtonElement>(null);
+  const previousActiveStepRef = React.useRef(activeStep);
+
+  // Manage focus when the completed steps change.
+  React.useEffect(() => {
+    if (allStepsCompleted()) {
+      // If the user has completed all steps and hits Finish, focus the Reset button.
+      resetButtonRef.current?.focus();
+    } else if (Object.keys(completed).length === 0) {
+      // If the user has completed all steps and hits Reset, focus the Next button.
+      nextButtonRef.current?.focus();
+    }
+  }, [completed]);
+
+  // Manage focus when the active step changes.
+  React.useEffect(() => {
+    if (activeStep === 0 && previousActiveStepRef.current === 1) {
+      // If the user navigated to first step via Back button, focus the Next button.
+      nextButtonRef.current?.focus();
+    }
+
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep]);
+
   return (
     <Box sx={{ width: '100%' }}>
       <Stepper nonLinear activeStep={activeStep}>
@@ -84,7 +109,9 @@ export default function HorizontalNonLinearStepper() {
             </Typography>
             <Box sx={{ display: 'flex', flexDirection: 'row', pt: 2 }}>
               <Box sx={{ flex: '1 1 auto' }} />
-              <Button onClick={handleReset}>Reset</Button>
+              <Button onClick={handleReset} ref={resetButtonRef}>
+                Reset
+              </Button>
             </Box>
           </React.Fragment>
         ) : (
@@ -102,7 +129,7 @@ export default function HorizontalNonLinearStepper() {
                 Back
               </Button>
               <Box sx={{ flex: '1 1 auto' }} />
-              <Button onClick={handleNext} sx={{ mr: 1 }}>
+              <Button onClick={handleNext} sx={{ mr: 1 }} ref={nextButtonRef}>
                 Next
               </Button>
               {activeStep !== steps.length &&

--- a/docs/data/material/components/steppers/ProgressMobileStepper.js
+++ b/docs/data/material/components/steppers/ProgressMobileStepper.js
@@ -43,6 +43,11 @@ export default function ProgressMobileStepper() {
       position="static"
       activeStep={activeStep}
       sx={{ maxWidth: 400, flexGrow: 1 }}
+      slotProps={{
+        progress: {
+          'aria-label': 'stepper linear progress',
+        },
+      }}
       nextButton={
         <Button
           size="small"

--- a/docs/data/material/components/steppers/ProgressMobileStepper.js
+++ b/docs/data/material/components/steppers/ProgressMobileStepper.js
@@ -17,6 +17,25 @@ export default function ProgressMobileStepper() {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
+  const nextButtonRef = React.useRef(null);
+  const backButtonRef = React.useRef(null);
+  const previousActiveStepRef = React.useRef(activeStep);
+
+  // Manage focus when the active step changes.
+  React.useEffect(() => {
+    const previousActiveStep = previousActiveStepRef.current;
+
+    if (activeStep === 0 && previousActiveStep === 1) {
+      // If the user is going back to the first step, focus the Next button.
+      nextButtonRef.current?.focus();
+    } else if (activeStep === 5 && previousActiveStep === 4) {
+      // If the user is going to the last step, focus the Back button.
+      backButtonRef.current?.focus();
+    }
+
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep]);
+
   return (
     <MobileStepper
       variant="progress"
@@ -25,7 +44,12 @@ export default function ProgressMobileStepper() {
       activeStep={activeStep}
       sx={{ maxWidth: 400, flexGrow: 1 }}
       nextButton={
-        <Button size="small" onClick={handleNext} disabled={activeStep === 5}>
+        <Button
+          size="small"
+          onClick={handleNext}
+          disabled={activeStep === 5}
+          ref={nextButtonRef}
+        >
           Next
           {theme.direction === 'rtl' ? (
             <KeyboardArrowLeft />
@@ -35,7 +59,12 @@ export default function ProgressMobileStepper() {
         </Button>
       }
       backButton={
-        <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+        <Button
+          size="small"
+          onClick={handleBack}
+          disabled={activeStep === 0}
+          ref={backButtonRef}
+        >
           {theme.direction === 'rtl' ? (
             <KeyboardArrowRight />
           ) : (

--- a/docs/data/material/components/steppers/ProgressMobileStepper.js
+++ b/docs/data/material/components/steppers/ProgressMobileStepper.js
@@ -26,10 +26,10 @@ export default function ProgressMobileStepper() {
     const previousActiveStep = previousActiveStepRef.current;
 
     if (activeStep === 0 && previousActiveStep === 1) {
-      // If the user is going back to the first step, focus the Next button.
+      // If the user is going back to the first step, focus the "Next" button.
       nextButtonRef.current?.focus();
     } else if (activeStep === 5 && previousActiveStep === 4) {
-      // If the user is going to the last step, focus the Back button.
+      // If the user is going to the last step, focus the "Back" button.
       backButtonRef.current?.focus();
     }
 

--- a/docs/data/material/components/steppers/ProgressMobileStepper.js
+++ b/docs/data/material/components/steppers/ProgressMobileStepper.js
@@ -27,10 +27,10 @@ export default function ProgressMobileStepper() {
 
     if (activeStep === 0 && previousActiveStep === 1) {
       // If the user is going back to the first step, focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current.focus();
     } else if (activeStep === 5 && previousActiveStep === 4) {
       // If the user is going to the last step, focus the "Back" button.
-      backButtonRef.current?.focus();
+      backButtonRef.current.focus();
     }
 
     previousActiveStepRef.current = activeStep;

--- a/docs/data/material/components/steppers/ProgressMobileStepper.tsx
+++ b/docs/data/material/components/steppers/ProgressMobileStepper.tsx
@@ -43,6 +43,11 @@ export default function ProgressMobileStepper() {
       position="static"
       activeStep={activeStep}
       sx={{ maxWidth: 400, flexGrow: 1 }}
+      slotProps={{
+        progress: {
+          'aria-label': 'stepper linear progress',
+        },
+      }}
       nextButton={
         <Button
           size="small"

--- a/docs/data/material/components/steppers/ProgressMobileStepper.tsx
+++ b/docs/data/material/components/steppers/ProgressMobileStepper.tsx
@@ -17,6 +17,25 @@ export default function ProgressMobileStepper() {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
+  const nextButtonRef = React.useRef<HTMLButtonElement>(null);
+  const backButtonRef = React.useRef<HTMLButtonElement>(null);
+  const previousActiveStepRef = React.useRef(activeStep);
+
+  // Manage focus when the active step changes.
+  React.useEffect(() => {
+    const previousActiveStep = previousActiveStepRef.current;
+
+    if (activeStep === 0 && previousActiveStep === 1) {
+      // If the user is going back to the first step, focus the Next button.
+      nextButtonRef.current?.focus();
+    } else if (activeStep === 5 && previousActiveStep === 4) {
+      // If the user is going to the last step, focus the Back button.
+      backButtonRef.current?.focus();
+    }
+
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep]);
+
   return (
     <MobileStepper
       variant="progress"
@@ -25,7 +44,12 @@ export default function ProgressMobileStepper() {
       activeStep={activeStep}
       sx={{ maxWidth: 400, flexGrow: 1 }}
       nextButton={
-        <Button size="small" onClick={handleNext} disabled={activeStep === 5}>
+        <Button
+          size="small"
+          onClick={handleNext}
+          disabled={activeStep === 5}
+          ref={nextButtonRef}
+        >
           Next
           {theme.direction === 'rtl' ? (
             <KeyboardArrowLeft />
@@ -35,7 +59,12 @@ export default function ProgressMobileStepper() {
         </Button>
       }
       backButton={
-        <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+        <Button
+          size="small"
+          onClick={handleBack}
+          disabled={activeStep === 0}
+          ref={backButtonRef}
+        >
           {theme.direction === 'rtl' ? (
             <KeyboardArrowRight />
           ) : (

--- a/docs/data/material/components/steppers/ProgressMobileStepper.tsx
+++ b/docs/data/material/components/steppers/ProgressMobileStepper.tsx
@@ -27,10 +27,10 @@ export default function ProgressMobileStepper() {
 
     if (activeStep === 0 && previousActiveStep === 1) {
       // If the user is going back to the first step, focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current!.focus();
     } else if (activeStep === 5 && previousActiveStep === 4) {
       // If the user is going to the last step, focus the "Back" button.
-      backButtonRef.current?.focus();
+      backButtonRef.current!.focus();
     }
 
     previousActiveStepRef.current = activeStep;

--- a/docs/data/material/components/steppers/ProgressMobileStepper.tsx
+++ b/docs/data/material/components/steppers/ProgressMobileStepper.tsx
@@ -26,10 +26,10 @@ export default function ProgressMobileStepper() {
     const previousActiveStep = previousActiveStepRef.current;
 
     if (activeStep === 0 && previousActiveStep === 1) {
-      // If the user is going back to the first step, focus the Next button.
+      // If the user is going back to the first step, focus the "Next" button.
       nextButtonRef.current?.focus();
     } else if (activeStep === 5 && previousActiveStep === 4) {
-      // If the user is going to the last step, focus the Back button.
+      // If the user is going to the last step, focus the "Back" button.
       backButtonRef.current?.focus();
     }
 

--- a/docs/data/material/components/steppers/TextMobileStepper.js
+++ b/docs/data/material/components/steppers/TextMobileStepper.js
@@ -53,13 +53,13 @@ export default function TextMobileStepper() {
 
     if (activeStep === 0 && previousActiveStep === 1) {
       // If the user is going back to the first step, focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current.focus();
       return;
     }
 
     if (activeStep === maxSteps - 1 && previousActiveStep === maxSteps - 2) {
       // If the user is going to the last step, focus the "Back" button.
-      backButtonRef.current?.focus();
+      backButtonRef.current.focus();
     }
   }, [activeStep, maxSteps]);
 

--- a/docs/data/material/components/steppers/TextMobileStepper.js
+++ b/docs/data/material/components/steppers/TextMobileStepper.js
@@ -42,6 +42,25 @@ export default function TextMobileStepper() {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
+  const nextButtonRef = React.useRef(null);
+  const backButtonRef = React.useRef(null);
+  const previousActiveStepRef = React.useRef(activeStep);
+
+  // Manage focus when the active step changes.
+  React.useEffect(() => {
+    const previousActiveStep = previousActiveStepRef.current;
+
+    if (activeStep === 0 && previousActiveStep === 1) {
+      // If the user is going back to the first step, focus the Next button.
+      nextButtonRef.current?.focus();
+    } else if (activeStep === maxSteps - 1 && previousActiveStep === maxSteps - 2) {
+      // If the user is going to the last step, focus the Back button.
+      backButtonRef.current?.focus();
+    }
+
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep]);
+
   return (
     <Box sx={{ maxWidth: 400, flexGrow: 1 }}>
       <Paper
@@ -70,6 +89,7 @@ export default function TextMobileStepper() {
             size="small"
             onClick={handleNext}
             disabled={activeStep === maxSteps - 1}
+            ref={nextButtonRef}
           >
             Next
             {theme.direction === 'rtl' ? (
@@ -80,7 +100,12 @@ export default function TextMobileStepper() {
           </Button>
         }
         backButton={
-          <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+          <Button
+            size="small"
+            onClick={handleBack}
+            disabled={activeStep === 0}
+            ref={backButtonRef}
+          >
             {theme.direction === 'rtl' ? (
               <KeyboardArrowRight />
             ) : (

--- a/docs/data/material/components/steppers/TextMobileStepper.js
+++ b/docs/data/material/components/steppers/TextMobileStepper.js
@@ -49,17 +49,19 @@ export default function TextMobileStepper() {
   // Manage focus when the active step changes.
   React.useEffect(() => {
     const previousActiveStep = previousActiveStepRef.current;
+    previousActiveStepRef.current = activeStep;
 
     if (activeStep === 0 && previousActiveStep === 1) {
       // If the user is going back to the first step, focus the Next button.
       nextButtonRef.current?.focus();
-    } else if (activeStep === maxSteps - 1 && previousActiveStep === maxSteps - 2) {
+      return;
+    }
+
+    if (activeStep === maxSteps - 1 && previousActiveStep === maxSteps - 2) {
       // If the user is going to the last step, focus the Back button.
       backButtonRef.current?.focus();
     }
-
-    previousActiveStepRef.current = activeStep;
-  }, [activeStep]);
+  }, [activeStep, maxSteps]);
 
   return (
     <Box sx={{ maxWidth: 400, flexGrow: 1 }}>

--- a/docs/data/material/components/steppers/TextMobileStepper.js
+++ b/docs/data/material/components/steppers/TextMobileStepper.js
@@ -52,13 +52,13 @@ export default function TextMobileStepper() {
     previousActiveStepRef.current = activeStep;
 
     if (activeStep === 0 && previousActiveStep === 1) {
-      // If the user is going back to the first step, focus the Next button.
+      // If the user is going back to the first step, focus the "Next" button.
       nextButtonRef.current?.focus();
       return;
     }
 
     if (activeStep === maxSteps - 1 && previousActiveStep === maxSteps - 2) {
-      // If the user is going to the last step, focus the Back button.
+      // If the user is going to the last step, focus the "Back" button.
       backButtonRef.current?.focus();
     }
   }, [activeStep, maxSteps]);

--- a/docs/data/material/components/steppers/TextMobileStepper.tsx
+++ b/docs/data/material/components/steppers/TextMobileStepper.tsx
@@ -53,13 +53,13 @@ export default function TextMobileStepper() {
 
     if (activeStep === 0 && previousActiveStep === 1) {
       // If the user is going back to the first step, focus the "Next" button.
-      nextButtonRef.current?.focus();
+      nextButtonRef.current!.focus();
       return;
     }
 
     if (activeStep === maxSteps - 1 && previousActiveStep === maxSteps - 2) {
       // If the user is going to the last step, focus the "Back" button.
-      backButtonRef.current?.focus();
+      backButtonRef.current!.focus();
     }
   }, [activeStep, maxSteps]);
 

--- a/docs/data/material/components/steppers/TextMobileStepper.tsx
+++ b/docs/data/material/components/steppers/TextMobileStepper.tsx
@@ -49,17 +49,19 @@ export default function TextMobileStepper() {
   // Manage focus when the active step changes.
   React.useEffect(() => {
     const previousActiveStep = previousActiveStepRef.current;
+    previousActiveStepRef.current = activeStep;
 
     if (activeStep === 0 && previousActiveStep === 1) {
       // If the user is going back to the first step, focus the Next button.
       nextButtonRef.current?.focus();
-    } else if (activeStep === maxSteps - 1 && previousActiveStep === maxSteps - 2) {
+      return;
+    }
+
+    if (activeStep === maxSteps - 1 && previousActiveStep === maxSteps - 2) {
       // If the user is going to the last step, focus the Back button.
       backButtonRef.current?.focus();
     }
-
-    previousActiveStepRef.current = activeStep;
-  }, [activeStep]);
+  }, [activeStep, maxSteps]);
 
   return (
     <Box sx={{ maxWidth: 400, flexGrow: 1 }}>

--- a/docs/data/material/components/steppers/TextMobileStepper.tsx
+++ b/docs/data/material/components/steppers/TextMobileStepper.tsx
@@ -52,13 +52,13 @@ export default function TextMobileStepper() {
     previousActiveStepRef.current = activeStep;
 
     if (activeStep === 0 && previousActiveStep === 1) {
-      // If the user is going back to the first step, focus the Next button.
+      // If the user is going back to the first step, focus the "Next" button.
       nextButtonRef.current?.focus();
       return;
     }
 
     if (activeStep === maxSteps - 1 && previousActiveStep === maxSteps - 2) {
-      // If the user is going to the last step, focus the Back button.
+      // If the user is going to the last step, focus the "Back" button.
       backButtonRef.current?.focus();
     }
   }, [activeStep, maxSteps]);

--- a/docs/data/material/components/steppers/TextMobileStepper.tsx
+++ b/docs/data/material/components/steppers/TextMobileStepper.tsx
@@ -42,6 +42,25 @@ export default function TextMobileStepper() {
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
+  const nextButtonRef = React.useRef<HTMLButtonElement>(null);
+  const backButtonRef = React.useRef<HTMLButtonElement>(null);
+  const previousActiveStepRef = React.useRef(activeStep);
+
+  // Manage focus when the active step changes.
+  React.useEffect(() => {
+    const previousActiveStep = previousActiveStepRef.current;
+
+    if (activeStep === 0 && previousActiveStep === 1) {
+      // If the user is going back to the first step, focus the Next button.
+      nextButtonRef.current?.focus();
+    } else if (activeStep === maxSteps - 1 && previousActiveStep === maxSteps - 2) {
+      // If the user is going to the last step, focus the Back button.
+      backButtonRef.current?.focus();
+    }
+
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep]);
+
   return (
     <Box sx={{ maxWidth: 400, flexGrow: 1 }}>
       <Paper
@@ -70,6 +89,7 @@ export default function TextMobileStepper() {
             size="small"
             onClick={handleNext}
             disabled={activeStep === maxSteps - 1}
+            ref={nextButtonRef}
           >
             Next
             {theme.direction === 'rtl' ? (
@@ -80,7 +100,12 @@ export default function TextMobileStepper() {
           </Button>
         }
         backButton={
-          <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+          <Button
+            size="small"
+            onClick={handleBack}
+            disabled={activeStep === 0}
+            ref={backButtonRef}
+          >
             {theme.direction === 'rtl' ? (
               <KeyboardArrowRight />
             ) : (

--- a/docs/data/material/components/steppers/VerticalLinearStepper.js
+++ b/docs/data/material/components/steppers/VerticalLinearStepper.js
@@ -58,10 +58,10 @@ export default function VerticalLinearStepper() {
     if (previousActiveStep < activeStep) {
       if (activeStep === steps.length) {
         // If the user has completed all steps and hits "Finish", focus the "Reset" button.
-        resetButtonRef.current?.focus();
+        resetButtonRef.current.focus();
       } else {
         // Focus the "Continue" button otherwise.
-        continueButtonRef.current?.focus();
+        continueButtonRef.current.focus();
       }
       return;
     }
@@ -69,12 +69,12 @@ export default function VerticalLinearStepper() {
 
     if (activeStep === 0) {
       // If the user hit "Back" on the second step, or hit "Reset", focus the "Continue" button.
-      continueButtonRef.current?.focus();
+      continueButtonRef.current.focus();
       return;
     }
 
     // Focus the "Back" button otherwise.
-    backButtonRef.current?.focus();
+    backButtonRef.current.focus();
   }, [activeStep]);
 
   return (

--- a/docs/data/material/components/steppers/VerticalLinearStepper.js
+++ b/docs/data/material/components/steppers/VerticalLinearStepper.js
@@ -54,6 +54,11 @@ export default function VerticalLinearStepper() {
     const previousActiveStep = previousActiveStepRef.current;
     previousActiveStepRef.current = activeStep;
 
+    // Skip the initial render.
+    if (previousActiveStep === activeStep) {
+      return;
+    }
+
     if (previousActiveStep < activeStep) {
       if (activeStep === steps.length) {
         // If the user has completed all steps and hits Finish, focus the Reset button.
@@ -64,8 +69,8 @@ export default function VerticalLinearStepper() {
       }
       return;
     }
-    if (activeStep === 0) {
-      // If the user has completed all steps and hits Reset, focus the Next button.
+    if (activeStep === 0 && previousActiveStep === steps.length) {
+      // If the user has completed all steps and hits Reset, focus the Continue button.
       continueButtonRef.current?.focus();
     } else {
       // Focus the "Back" button if the user is going backward.
@@ -98,14 +103,15 @@ export default function VerticalLinearStepper() {
                 >
                   {index === steps.length - 1 ? 'Finish' : 'Continue'}
                 </Button>
-                <Button
-                  disabled={index === 0}
-                  onClick={handleBack}
-                  sx={{ mt: 1, mr: 1 }}
-                  ref={backButtonRef}
-                >
-                  Back
-                </Button>
+                {index !== 0 && (
+                  <Button
+                    onClick={handleBack}
+                    sx={{ mt: 1, mr: 1 }}
+                    ref={backButtonRef}
+                  >
+                    Back
+                  </Button>
+                )}
               </Box>
             </StepContent>
           </Step>

--- a/docs/data/material/components/steppers/VerticalLinearStepper.js
+++ b/docs/data/material/components/steppers/VerticalLinearStepper.js
@@ -44,6 +44,36 @@ export default function VerticalLinearStepper() {
     setActiveStep(0);
   };
 
+  const previousActiveStepRef = React.useRef(activeStep);
+  const continueButtonRef = React.useRef(null);
+  const backButtonRef = React.useRef(null);
+  const resetButtonRef = React.useRef(null);
+
+  // Manage focus when the active step changes.
+  React.useEffect(() => {
+    const previousActiveStep = previousActiveStepRef.current;
+
+    if (previousActiveStep < activeStep) {
+      if (activeStep === steps.length) {
+        // If the user has completed all steps and hits Finish, focus the Reset button.
+        resetButtonRef.current?.focus();
+      } else {
+        // Focus the "Continue" button if the user is going forward.
+        continueButtonRef.current?.focus();
+      }
+    } else {
+      if (activeStep === 0) {
+        // If the user has completed all steps and hits Reset, focus the Next button.
+        continueButtonRef.current?.focus();
+      } else {
+        // Focus the "Back" button if the user is going backward.
+        backButtonRef.current?.focus();
+      }
+    }
+
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep]);
+
   return (
     <Box sx={{ maxWidth: 400 }}>
       <Stepper activeStep={activeStep} orientation="vertical">
@@ -65,6 +95,7 @@ export default function VerticalLinearStepper() {
                   variant="contained"
                   onClick={handleNext}
                   sx={{ mt: 1, mr: 1 }}
+                  ref={continueButtonRef}
                 >
                   {index === steps.length - 1 ? 'Finish' : 'Continue'}
                 </Button>
@@ -72,6 +103,7 @@ export default function VerticalLinearStepper() {
                   disabled={index === 0}
                   onClick={handleBack}
                   sx={{ mt: 1, mr: 1 }}
+                  ref={backButtonRef}
                 >
                   Back
                 </Button>
@@ -83,7 +115,7 @@ export default function VerticalLinearStepper() {
       {activeStep === steps.length && (
         <Paper square elevation={0} sx={{ p: 3 }}>
           <Typography>All steps completed - you&apos;re finished</Typography>
-          <Button onClick={handleReset} sx={{ mt: 1, mr: 1 }}>
+          <Button onClick={handleReset} sx={{ mt: 1, mr: 1 }} ref={resetButtonRef}>
             Reset
           </Button>
         </Paper>

--- a/docs/data/material/components/steppers/VerticalLinearStepper.js
+++ b/docs/data/material/components/steppers/VerticalLinearStepper.js
@@ -54,11 +54,6 @@ export default function VerticalLinearStepper() {
     const previousActiveStep = previousActiveStepRef.current;
     previousActiveStepRef.current = activeStep;
 
-    // Skip the initial render.
-    if (previousActiveStep === activeStep) {
-      return;
-    }
-
     if (previousActiveStep < activeStep) {
       if (activeStep === steps.length) {
         // If the user has completed all steps and hits Finish, focus the Reset button.

--- a/docs/data/material/components/steppers/VerticalLinearStepper.js
+++ b/docs/data/material/components/steppers/VerticalLinearStepper.js
@@ -52,6 +52,7 @@ export default function VerticalLinearStepper() {
   // Manage focus when the active step changes.
   React.useEffect(() => {
     const previousActiveStep = previousActiveStepRef.current;
+    previousActiveStepRef.current = activeStep;
 
     if (previousActiveStep < activeStep) {
       if (activeStep === steps.length) {
@@ -61,17 +62,15 @@ export default function VerticalLinearStepper() {
         // Focus the "Continue" button if the user is going forward.
         continueButtonRef.current?.focus();
       }
-    } else {
-      if (activeStep === 0) {
-        // If the user has completed all steps and hits Reset, focus the Next button.
-        continueButtonRef.current?.focus();
-      } else {
-        // Focus the "Back" button if the user is going backward.
-        backButtonRef.current?.focus();
-      }
+      return;
     }
-
-    previousActiveStepRef.current = activeStep;
+    if (activeStep === 0) {
+      // If the user has completed all steps and hits Reset, focus the Next button.
+      continueButtonRef.current?.focus();
+    } else {
+      // Focus the "Back" button if the user is going backward.
+      backButtonRef.current?.focus();
+    }
   }, [activeStep]);
 
   return (

--- a/docs/data/material/components/steppers/VerticalLinearStepper.js
+++ b/docs/data/material/components/steppers/VerticalLinearStepper.js
@@ -54,23 +54,27 @@ export default function VerticalLinearStepper() {
     const previousActiveStep = previousActiveStepRef.current;
     previousActiveStepRef.current = activeStep;
 
+    // If the user is going forward.
     if (previousActiveStep < activeStep) {
       if (activeStep === steps.length) {
-        // If the user has completed all steps and hits Finish, focus the Reset button.
+        // If the user has completed all steps and hits "Finish", focus the "Reset" button.
         resetButtonRef.current?.focus();
       } else {
-        // Focus the "Continue" button if the user is going forward.
+        // Focus the "Continue" button otherwise.
         continueButtonRef.current?.focus();
       }
       return;
     }
-    if (activeStep === 0 && previousActiveStep === steps.length) {
-      // If the user has completed all steps and hits Reset, focus the Continue button.
+    // Otherwise, the user is going back.
+
+    if (activeStep === 0) {
+      // If the user hit "Back" on the second step, or hit "Reset", focus the "Continue" button.
       continueButtonRef.current?.focus();
-    } else {
-      // Focus the "Back" button if the user is going backward.
-      backButtonRef.current?.focus();
+      return;
     }
+
+    // Focus the "Back" button otherwise.
+    backButtonRef.current?.focus();
   }, [activeStep]);
 
   return (

--- a/docs/data/material/components/steppers/VerticalLinearStepper.tsx
+++ b/docs/data/material/components/steppers/VerticalLinearStepper.tsx
@@ -52,6 +52,7 @@ export default function VerticalLinearStepper() {
   // Manage focus when the active step changes.
   React.useEffect(() => {
     const previousActiveStep = previousActiveStepRef.current;
+    previousActiveStepRef.current = activeStep;
 
     if (previousActiveStep < activeStep) {
       if (activeStep === steps.length) {
@@ -61,17 +62,15 @@ export default function VerticalLinearStepper() {
         // Focus the "Continue" button if the user is going forward.
         continueButtonRef.current?.focus();
       }
-    } else {
-      if (activeStep === 0) {
-        // If the user has completed all steps and hits Reset, focus the Next button.
-        continueButtonRef.current?.focus();
-      } else {
-        // Focus the "Back" button if the user is going backward.
-        backButtonRef.current?.focus();
-      }
+      return;
     }
-
-    previousActiveStepRef.current = activeStep;
+    if (activeStep === 0) {
+      // If the user has completed all steps and hits Reset, focus the Next button.
+      continueButtonRef.current?.focus();
+    } else {
+      // Focus the "Back" button if the user is going backward.
+      backButtonRef.current?.focus();
+    }
   }, [activeStep]);
 
   return (
@@ -99,14 +98,15 @@ export default function VerticalLinearStepper() {
                 >
                   {index === steps.length - 1 ? 'Finish' : 'Continue'}
                 </Button>
-                <Button
-                  disabled={index === 0}
-                  onClick={handleBack}
-                  sx={{ mt: 1, mr: 1 }}
-                  ref={backButtonRef}
-                >
-                  Back
-                </Button>
+                {index !== 0 && (
+                  <Button
+                    onClick={handleBack}
+                    sx={{ mt: 1, mr: 1 }}
+                    ref={backButtonRef}
+                  >
+                    Back
+                  </Button>
+                )}
               </Box>
             </StepContent>
           </Step>

--- a/docs/data/material/components/steppers/VerticalLinearStepper.tsx
+++ b/docs/data/material/components/steppers/VerticalLinearStepper.tsx
@@ -44,6 +44,36 @@ export default function VerticalLinearStepper() {
     setActiveStep(0);
   };
 
+  const previousActiveStepRef = React.useRef(activeStep);
+  const continueButtonRef = React.useRef<HTMLButtonElement>(null);
+  const backButtonRef = React.useRef<HTMLButtonElement>(null);
+  const resetButtonRef = React.useRef<HTMLButtonElement>(null);
+
+  // Manage focus when the active step changes.
+  React.useEffect(() => {
+    const previousActiveStep = previousActiveStepRef.current;
+
+    if (previousActiveStep < activeStep) {
+      if (activeStep === steps.length) {
+        // If the user has completed all steps and hits Finish, focus the Reset button.
+        resetButtonRef.current?.focus();
+      } else {
+        // Focus the "Continue" button if the user is going forward.
+        continueButtonRef.current?.focus();
+      }
+    } else {
+      if (activeStep === 0) {
+        // If the user has completed all steps and hits Reset, focus the Next button.
+        continueButtonRef.current?.focus();
+      } else {
+        // Focus the "Back" button if the user is going backward.
+        backButtonRef.current?.focus();
+      }
+    }
+
+    previousActiveStepRef.current = activeStep;
+  }, [activeStep]);
+
   return (
     <Box sx={{ maxWidth: 400 }}>
       <Stepper activeStep={activeStep} orientation="vertical">
@@ -65,6 +95,7 @@ export default function VerticalLinearStepper() {
                   variant="contained"
                   onClick={handleNext}
                   sx={{ mt: 1, mr: 1 }}
+                  ref={continueButtonRef}
                 >
                   {index === steps.length - 1 ? 'Finish' : 'Continue'}
                 </Button>
@@ -72,6 +103,7 @@ export default function VerticalLinearStepper() {
                   disabled={index === 0}
                   onClick={handleBack}
                   sx={{ mt: 1, mr: 1 }}
+                  ref={backButtonRef}
                 >
                   Back
                 </Button>
@@ -83,7 +115,7 @@ export default function VerticalLinearStepper() {
       {activeStep === steps.length && (
         <Paper square elevation={0} sx={{ p: 3 }}>
           <Typography>All steps completed - you&apos;re finished</Typography>
-          <Button onClick={handleReset} sx={{ mt: 1, mr: 1 }}>
+          <Button onClick={handleReset} sx={{ mt: 1, mr: 1 }} ref={resetButtonRef}>
             Reset
           </Button>
         </Paper>

--- a/docs/data/material/components/steppers/VerticalLinearStepper.tsx
+++ b/docs/data/material/components/steppers/VerticalLinearStepper.tsx
@@ -64,8 +64,8 @@ export default function VerticalLinearStepper() {
       }
       return;
     }
-    if (activeStep === 0) {
-      // If the user has completed all steps and hits Reset, focus the Next button.
+    if (activeStep === 0 && previousActiveStep === steps.length) {
+      // If the user has completed all steps and hits Reset, focus the Continue button.
       continueButtonRef.current?.focus();
     } else {
       // Focus the "Back" button if the user is going backward.

--- a/docs/data/material/components/steppers/VerticalLinearStepper.tsx
+++ b/docs/data/material/components/steppers/VerticalLinearStepper.tsx
@@ -54,23 +54,27 @@ export default function VerticalLinearStepper() {
     const previousActiveStep = previousActiveStepRef.current;
     previousActiveStepRef.current = activeStep;
 
+    // If the user is going forward.
     if (previousActiveStep < activeStep) {
       if (activeStep === steps.length) {
-        // If the user has completed all steps and hits Finish, focus the Reset button.
+        // If the user has completed all steps and hits "Finish", focus the "Reset" button.
         resetButtonRef.current?.focus();
       } else {
-        // Focus the "Continue" button if the user is going forward.
+        // Focus the "Continue" button otherwise.
         continueButtonRef.current?.focus();
       }
       return;
     }
-    if (activeStep === 0 && previousActiveStep === steps.length) {
-      // If the user has completed all steps and hits Reset, focus the Continue button.
+    // Otherwise, the user is going back.
+
+    if (activeStep === 0) {
+      // If the user hit "Back" on the second step, or hit "Reset", focus the "Continue" button.
       continueButtonRef.current?.focus();
-    } else {
-      // Focus the "Back" button if the user is going backward.
-      backButtonRef.current?.focus();
+      return;
     }
+
+    // Focus the "Back" button otherwise.
+    backButtonRef.current?.focus();
   }, [activeStep]);
 
   return (

--- a/docs/data/material/components/steppers/VerticalLinearStepper.tsx
+++ b/docs/data/material/components/steppers/VerticalLinearStepper.tsx
@@ -58,10 +58,10 @@ export default function VerticalLinearStepper() {
     if (previousActiveStep < activeStep) {
       if (activeStep === steps.length) {
         // If the user has completed all steps and hits "Finish", focus the "Reset" button.
-        resetButtonRef.current?.focus();
+        resetButtonRef.current!.focus();
       } else {
         // Focus the "Continue" button otherwise.
-        continueButtonRef.current?.focus();
+        continueButtonRef.current!.focus();
       }
       return;
     }
@@ -69,12 +69,12 @@ export default function VerticalLinearStepper() {
 
     if (activeStep === 0) {
       // If the user hit "Back" on the second step, or hit "Reset", focus the "Continue" button.
-      continueButtonRef.current?.focus();
+      continueButtonRef.current!.focus();
       return;
     }
 
     // Focus the "Back" button otherwise.
-    backButtonRef.current?.focus();
+    backButtonRef.current!.focus();
   }, [activeStep]);
 
   return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR addresses focus loss that occurs in interactive Stepper demos when the focused button is removed or disabled after a step transition.

Cases fixed per demo:

- HorizontalLinearStepper — focuses Reset when Finish is clicked (completing all steps); focuses Next when Reset is clicked (returning to step 1); focuses Next when Skip is used and the next step is not optional
- HorizontalNonLinearStepper — refactored helper functions (totalSteps, completedSteps, isLastStep, allStepsCompleted) from functions to derived variables; focuses Reset when all steps are completed; focuses Next when Reset is clicked; focuses Next when navigating back to the first step via Back
- VerticalLinearStepper— focuses Continue when going forward; focuses Reset when Finish is clicked; focuses Continue when Reset is clicked (returning to step 1) or when reaching the first step via Back button; focuses Back when going backward; also removes the Back button from the DOM on the first step instead of just disabling it, so the ref always points to a mounted button
- DotsMobileStepper / ProgressMobileStepper / TextMobileStepper — focuses Next when going back to the first step (Back becomes disabled); focuses Back when reaching the last step (Next becomes disabled)

Also adds aria-labels to the two examples showing a progress indicator:
- ProgressMobileStepper
- DotsMobileStepper
