### PR TITLE
[Typography] Apply fontFamily to custom typography variants

### DIFF
--- a/packages/mui-material/src/styles/createTypography.js
+++ b/packages/mui-material/src/styles/createTypography.js
@@ -82,6 +82,18 @@ export default function createTypography(palette, typography) {
     },
   };
 
+  // Inject fontFamily and allVariants into any custom typography variant objects in `other`
+  // so they behave consistently with the built-in variants produced by buildVariant.
+  const processedOther = {};
+  Object.keys(other).forEach((key) => {
+    const value = other[key];
+    if (value !== null && typeof value === 'object') {
+      processedOther[key] = { fontFamily, ...allVariants, ...value };
+    } else {
+      processedOther[key] = value;
+    }
+  });
+
   return deepmerge(
     {
       htmlFontSize,
@@ -94,7 +106,7 @@ export default function createTypography(palette, typography) {
       fontWeightBold,
       ...variants,
     },
-    other,
+    processedOther,
     {
       clone: false, // No need to clone deep
     },

--- a/packages/mui-material/src/styles/createTypography.test.js
+++ b/packages/mui-material/src/styles/createTypography.test.js
@@ -84,6 +84,36 @@ describe('createTypography', () => {
     });
   });
 
+  it('should apply fontFamily to custom typography variants', () => {
+    const typography = createTypography(palette, {
+      fontFamily: 'Times New Roman',
+      custom: {
+        color: '#FF0008',
+        textDecoration: 'underline',
+      },
+    });
+    expect(typography.custom.fontFamily).to.equal('Times New Roman');
+  });
+
+  it('should apply allVariants to custom typography variants', () => {
+    const typography = createTypography(palette, {
+      allVariants: { marginBottom: 8 },
+      myVariant: { fontSize: 14 },
+    });
+    expect(typography.myVariant.marginBottom).to.equal(8);
+  });
+
+  it('custom variant explicit fontFamily should override the global fontFamily', () => {
+    const typography = createTypography(palette, {
+      fontFamily: 'Times New Roman',
+      custom: {
+        fontFamily: 'Arial',
+        fontSize: 14,
+      },
+    });
+    expect(typography.custom.fontFamily).to.equal('Arial');
+  });
+
   describe('warnings', () => {
     it('logs an error if `fontSize` is not of type number', () => {
       expect(() => {


### PR DESCRIPTION
﻿## Summary

Fixes #35939.

Custom typography variants added via `createTheme({ typography: { myVariant: { color: 'red' } } })` did not inherit the theme `fontFamily` (or `allVariants` CSS). They ended up with the browser's default font because they were placed in `other` and deep-merged as-is, bypassing the `buildVariant` call that injects `fontFamily` for the 13 built-in variants (`h1`–`overline`, etc.).

**Fix:** In `createTypography`, iterate over `other` and for each object-valued key inject `fontFamily` and `allVariants` before the merge, matching `buildVariant` behavior. Explicit per-variant `fontFamily` inside `other` is still respected because the user's value wins: `{ fontFamily, ...allVariants, ...value }`.

## Test plan

- [ ] New test: "should apply fontFamily to custom typography variants"
- [ ] New test: "should apply allVariants to custom typography variants"
- [ ] New test: "custom variant explicit fontFamily should override the global fontFamily"
- [ ] Existing typography tests pass
