### PR TITLE
[TabScrollButton] Fix StartScrollButtonIcon/EndScrollButtonIcon swap in RTL

### DIFF
--- a/packages/mui-material/src/TabScrollButton/TabScrollButton.js
+++ b/packages/mui-material/src/TabScrollButton/TabScrollButton.js
@@ -110,7 +110,7 @@ const TabScrollButton = React.forwardRef(function TabScrollButton(inProps, ref) 
         }),
       }}
     >
-      {direction === 'left' ? (
+      {(direction === 'left') !== isRtl ? (
         <StartButtonIcon {...startButtonIconProps} />
       ) : (
         <EndButtonIcon {...endButtonIconProps} />

--- a/packages/mui-material/src/TabScrollButton/TabScrollButton.test.js
+++ b/packages/mui-material/src/TabScrollButton/TabScrollButton.test.js
@@ -1,7 +1,9 @@
+import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import TabScrollButton, { tabScrollButtonClasses as classes } from '@mui/material/TabScrollButton';
 import { createSvgIcon } from '@mui/material/utils';
+import RtlProvider from '@mui/system/RtlProvider';
 import describeConformance from '../../test/describeConformance';
 
 const ArrowBackIcon = createSvgIcon(<path d="M3 3h18v18H3z" />, 'ArrowBack');
@@ -80,5 +82,35 @@ describe('<TabScrollButton />', () => {
     );
 
     expect(screen.getAllByTestId('ArrowForwardIcon')).to.have.lengthOf(1);
+  });
+
+  describe('RTL', () => {
+    it('should render StartScrollButtonIcon for direction="right" in RTL', () => {
+      render(
+        <RtlProvider>
+          <TabScrollButton
+            {...defaultProps}
+            direction="right"
+            disabled
+            slots={{ StartScrollButtonIcon: ArrowBackIcon }}
+          />
+        </RtlProvider>,
+      );
+      expect(screen.getAllByTestId('ArrowBackIcon')).to.have.lengthOf(1);
+    });
+
+    it('should render EndScrollButtonIcon for direction="left" in RTL', () => {
+      render(
+        <RtlProvider>
+          <TabScrollButton
+            {...defaultProps}
+            direction="left"
+            disabled
+            slots={{ EndScrollButtonIcon: ArrowForwardIcon }}
+          />
+        </RtlProvider>,
+      );
+      expect(screen.getAllByTestId('ArrowForwardIcon')).to.have.lengthOf(1);
+    });
   });
 });


### PR DESCRIPTION
﻿## Summary

Fixes #39296.

In RTL layout, `Tabs.js` passes `direction="right"` to the **start** scroll button and `direction="left"` to the **end** scroll button (the directions are flipped so the arrows point the right way visually). However, `TabScrollButton` selected which slot icon to render based solely on `direction === 'left'` with no awareness of RTL. This caused custom `StartScrollButtonIcon` and `EndScrollButtonIcon` slot overrides to appear on the **wrong** sides in RTL mode.

**Fix:** Change the icon selection to `(direction === 'left') !== isRtl`. This XOR keeps LTR behavior identical and inverts the slot mapping in RTL so `StartScrollButtonIcon` always renders in the start scroll button and `EndScrollButtonIcon` always renders in the end scroll button, regardless of direction.

## Test plan

- [ ] New RTL tests: `StartScrollButtonIcon` renders for `direction="right"` in RTL
- [ ] New RTL tests: `EndScrollButtonIcon` renders for `direction="left"` in RTL
- [ ] Existing direction LTR tests still pass
