### PR TITLE
[system] Apply theme variants to all slots by default

### DIFF
--- a/packages/mui-system/src/createStyled/createStyled.js
+++ b/packages/mui-system/src/createStyled/createStyled.js
@@ -151,13 +151,8 @@ export default function createStyled(input = {}) {
         ? 'components'
         : 'custom';
 
-    // if skipVariantsResolver option is defined, take the value, otherwise, true for root and false for other slots.
     const skipVariantsResolver =
-      inputSkipVariantsResolver !== undefined
-        ? inputSkipVariantsResolver
-        : // TODO v6: remove `Root` in the next major release
-          // For more details: https://github.com/mui/material-ui/pull/37908
-          (componentSlot && componentSlot !== 'Root' && componentSlot !== 'root') || false;
+      inputSkipVariantsResolver !== undefined ? inputSkipVariantsResolver : false;
 
     const skipSx = inputSkipSx || false;
 

--- a/packages/mui-system/src/styled/styled.test.js
+++ b/packages/mui-system/src/styled/styled.test.js
@@ -289,11 +289,36 @@ describe('styled', () => {
       });
     });
 
-    it('variants should be skipped for non root slots', () => {
+    it('variants should apply to non-root slots by default', () => {
       const TestSlot = styled('div', {
         shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx',
         name: 'MuiTest',
         slot: 'Slot',
+      })`
+        width: 200px;
+        height: 300px;
+      `;
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <TestSlot variant="rect" size="large">
+            Test
+          </TestSlot>
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).toHaveComputedStyle({
+        width: '400px',
+        height: '400px',
+      });
+    });
+
+    it('variants should be skipped for non-root slots when skipVariantsResolver is true', () => {
+      const TestSlot = styled('div', {
+        shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx',
+        name: 'MuiTest',
+        slot: 'Slot',
+        skipVariantsResolver: true,
       })`
         width: 200px;
         height: 300px;
@@ -337,7 +362,7 @@ describe('styled', () => {
       });
     });
 
-    it('variants should respect skipVariantsResolver if defined', () => {
+    it('variants should apply when skipVariantsResolver is explicitly false', () => {
       const TestSlot = styled('div', {
         shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'size' && prop !== 'sx',
         name: 'MuiTest',


### PR DESCRIPTION
Fixes #44272

## Problem

`theme.components[X].variants` silently had no effect for any slot other than `Root`/`root`. The root cause: `skipVariantsResolver` defaulted to `true` for any non-root slot name (e.g. `icon`, `label`, `track`), which caused the variants resolution block to be skipped entirely.

This was inconsistent with `styleOverrides`, which already applies to every slot.

## Fix

Remove the slot-name condition so `skipVariantsResolver` is `false` for all slots unless explicitly opted out with `skipVariantsResolver: true`.

## Tests

- Updated "variants should be skipped for non root slots" to reflect the new default (variants now apply to non-root slots)
- Added "variants should be skipped for non-root slots when skipVariantsResolver is true" for the explicit opt-out case
