### PR TITLE
[select] Add Support typeahead when closed

### DIFF
--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -2220,10 +2220,10 @@ describe('<Select />', () => {
       await act(async () => {
         trigger.focus();
       });
-  
+
       expect(trigger).toHaveFocus();
     }
-  
+
     it('selects an option by typing a single character', async () => {
       render(
         <Select defaultValue="" name="test-select">
@@ -2232,16 +2232,16 @@ describe('<Select />', () => {
           <MenuItem value="carrot">Carrot</MenuItem>
         </Select>,
       );
-  
+
       const trigger = screen.getByRole('combobox');
-  
+
       await focusTrigger(trigger);
-  
+
       fireEvent.keyDown(trigger, { key: 'b' });
-  
+
       expect(trigger).to.have.text('Banana');
     });
-  
+
     it('matches using accumulated prefix characters', async () => {
       render(
         <Select defaultValue="">
@@ -2250,17 +2250,17 @@ describe('<Select />', () => {
           <MenuItem value="blueberry">Blueberry</MenuItem>
         </Select>,
       );
-  
+
       const trigger = screen.getByRole('combobox');
-  
+
       await focusTrigger(trigger);
-  
+
       fireEvent.keyDown(trigger, { key: 'b' });
       fireEvent.keyDown(trigger, { key: 'l' });
-  
+
       expect(trigger).to.have.text('Blueberry');
     });
-  
+
     it('cycles through options when the same character is pressed repeatedly', async () => {
       render(
         <Select defaultValue="">
@@ -2269,24 +2269,24 @@ describe('<Select />', () => {
           <MenuItem value="avocado">Avocado</MenuItem>
         </Select>,
       );
-  
+
       const trigger = screen.getByRole('combobox');
-  
+
       await focusTrigger(trigger);
-  
+
       fireEvent.keyDown(trigger, { key: 'a' });
       expect(trigger).to.have.text('Apple');
-  
+
       fireEvent.keyDown(trigger, { key: 'a' });
       expect(trigger).to.have.text('Apricot');
-  
+
       fireEvent.keyDown(trigger, { key: 'a' });
       expect(trigger).to.have.text('Avocado');
-  
+
       fireEvent.keyDown(trigger, { key: 'a' });
       expect(trigger).to.have.text('Apple');
     });
-  
+
     it('resets the typeahead buffer after timeout', async () => {
       render(
         <Select defaultValue="">
@@ -2295,44 +2295,44 @@ describe('<Select />', () => {
           <MenuItem value="blueberry">Blueberry</MenuItem>
         </Select>,
       );
-  
+
       const trigger = screen.getByRole('combobox');
-  
+
       await focusTrigger(trigger);
-  
+
       fireEvent.keyDown(trigger, { key: 'b' });
-  
+
       await act(async () => {
         clock.tick(600);
       });
-  
+
       fireEvent.keyDown(trigger, { key: 'l' });
-  
+
       // should stay on Banana because buffer reset
       expect(trigger).to.have.text('Banana');
     });
-  
+
     it('calls onChange with correct target value during typeahead selection', async () => {
       const onChange = spy();
-  
+
       render(
         <Select defaultValue="" name="food" onChange={onChange}>
           <MenuItem value="apple">Apple</MenuItem>
           <MenuItem value="banana">Banana</MenuItem>
         </Select>,
       );
-  
+
       const trigger = screen.getByRole('combobox');
-  
+
       await focusTrigger(trigger);
-  
+
       fireEvent.keyDown(trigger, { key: 'b' });
-  
+
       expect(onChange.callCount).to.equal(1);
       expect(onChange.firstCall.args[0].target.value).to.equal('banana');
       expect(onChange.firstCall.args[0].target.name).to.equal('food');
     });
-  
+
     it('does not trigger typeahead when select is open', async () => {
       render(
         <Select open value="">
@@ -2340,16 +2340,16 @@ describe('<Select />', () => {
           <MenuItem value="banana">Banana</MenuItem>
         </Select>,
       );
-  
+
       const trigger = screen.getByRole('combobox', { hidden: true });
-  
+
       await focusTrigger(trigger);
-  
+
       fireEvent.keyDown(trigger, { key: 'b' });
-  
+
       expect(trigger).not.to.have.text('Banana');
     });
-  
+
     it('does not trigger typeahead for multiple select', async () => {
       render(
         <Select multiple defaultValue={[]}>
@@ -2357,16 +2357,16 @@ describe('<Select />', () => {
           <MenuItem value="banana">Banana</MenuItem>
         </Select>,
       );
-  
+
       const trigger = screen.getByRole('combobox');
-  
+
       await focusTrigger(trigger);
-  
+
       fireEvent.keyDown(trigger, { key: 'b' });
-  
+
       expect(trigger).not.to.have.text('Banana');
     });
-  
+
     it('does not trigger typeahead when readOnly', async () => {
       render(
         <Select readOnly defaultValue="">
@@ -2374,23 +2374,23 @@ describe('<Select />', () => {
           <MenuItem value="banana">Banana</MenuItem>
         </Select>,
       );
-  
+
       const trigger = screen.getByRole('combobox');
-  
+
       await focusTrigger(trigger);
-  
+
       fireEvent.keyDown(trigger, { key: 'b' });
-  
+
       expect(trigger).not.to.have.text('Banana');
     });
-  
+
     it('supports nested children text in options', async () => {
       render(
         <Select defaultValue="">
           <MenuItem value="apple">
             <span>Apple</span>
           </MenuItem>
-  
+
           <MenuItem value="banana">
             <div>
               <span>Banana</span>
@@ -2398,16 +2398,16 @@ describe('<Select />', () => {
           </MenuItem>
         </Select>,
       );
-  
+
       const trigger = screen.getByRole('combobox');
-  
+
       await focusTrigger(trigger);
-  
+
       fireEvent.keyDown(trigger, { key: 'b' });
-  
+
       expect(trigger).to.have.text('Banana');
     });
-  
+
     it('ignores non-character keys for typeahead', async () => {
       render(
         <Select defaultValue="">
@@ -2415,13 +2415,13 @@ describe('<Select />', () => {
           <MenuItem value="banana">Banana</MenuItem>
         </Select>,
       );
-  
+
       const trigger = screen.getByRole('combobox');
-  
+
       await focusTrigger(trigger);
-  
+
       fireEvent.keyDown(trigger, { key: 'Shift' });
-  
+
       expect(trigger).not.to.have.text('Banana');
     });
   });

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -2215,6 +2215,217 @@ describe('<Select />', () => {
     });
   });
 
+  describe('typeahead keyboard navigation', () => {
+    async function focusTrigger(trigger) {
+      await act(async () => {
+        trigger.focus();
+      });
+  
+      expect(trigger).toHaveFocus();
+    }
+  
+    it('selects an option by typing a single character', async () => {
+      render(
+        <Select defaultValue="" name="test-select">
+          <MenuItem value="apple">Apple</MenuItem>
+          <MenuItem value="banana">Banana</MenuItem>
+          <MenuItem value="carrot">Carrot</MenuItem>
+        </Select>,
+      );
+  
+      const trigger = screen.getByRole('combobox');
+  
+      await focusTrigger(trigger);
+  
+      fireEvent.keyDown(trigger, { key: 'b' });
+  
+      expect(trigger).to.have.text('Banana');
+    });
+  
+    it('matches using accumulated prefix characters', async () => {
+      render(
+        <Select defaultValue="">
+          <MenuItem value="apple">Apple</MenuItem>
+          <MenuItem value="banana">Banana</MenuItem>
+          <MenuItem value="blueberry">Blueberry</MenuItem>
+        </Select>,
+      );
+  
+      const trigger = screen.getByRole('combobox');
+  
+      await focusTrigger(trigger);
+  
+      fireEvent.keyDown(trigger, { key: 'b' });
+      fireEvent.keyDown(trigger, { key: 'l' });
+  
+      expect(trigger).to.have.text('Blueberry');
+    });
+  
+    it('cycles through options when the same character is pressed repeatedly', async () => {
+      render(
+        <Select defaultValue="">
+          <MenuItem value="apple">Apple</MenuItem>
+          <MenuItem value="apricot">Apricot</MenuItem>
+          <MenuItem value="avocado">Avocado</MenuItem>
+        </Select>,
+      );
+  
+      const trigger = screen.getByRole('combobox');
+  
+      await focusTrigger(trigger);
+  
+      fireEvent.keyDown(trigger, { key: 'a' });
+      expect(trigger).to.have.text('Apple');
+  
+      fireEvent.keyDown(trigger, { key: 'a' });
+      expect(trigger).to.have.text('Apricot');
+  
+      fireEvent.keyDown(trigger, { key: 'a' });
+      expect(trigger).to.have.text('Avocado');
+  
+      fireEvent.keyDown(trigger, { key: 'a' });
+      expect(trigger).to.have.text('Apple');
+    });
+  
+    it('resets the typeahead buffer after timeout', async () => {
+      render(
+        <Select defaultValue="">
+          <MenuItem value="apple">Apple</MenuItem>
+          <MenuItem value="banana">Banana</MenuItem>
+          <MenuItem value="blueberry">Blueberry</MenuItem>
+        </Select>,
+      );
+  
+      const trigger = screen.getByRole('combobox');
+  
+      await focusTrigger(trigger);
+  
+      fireEvent.keyDown(trigger, { key: 'b' });
+  
+      await act(async () => {
+        clock.tick(600);
+      });
+  
+      fireEvent.keyDown(trigger, { key: 'l' });
+  
+      // should stay on Banana because buffer reset
+      expect(trigger).to.have.text('Banana');
+    });
+  
+    it('calls onChange with correct target value during typeahead selection', async () => {
+      const onChange = spy();
+  
+      render(
+        <Select defaultValue="" name="food" onChange={onChange}>
+          <MenuItem value="apple">Apple</MenuItem>
+          <MenuItem value="banana">Banana</MenuItem>
+        </Select>,
+      );
+  
+      const trigger = screen.getByRole('combobox');
+  
+      await focusTrigger(trigger);
+  
+      fireEvent.keyDown(trigger, { key: 'b' });
+  
+      expect(onChange.callCount).to.equal(1);
+      expect(onChange.firstCall.args[0].target.value).to.equal('banana');
+      expect(onChange.firstCall.args[0].target.name).to.equal('food');
+    });
+  
+    it('does not trigger typeahead when select is open', async () => {
+      render(
+        <Select open value="">
+          <MenuItem value="apple">Apple</MenuItem>
+          <MenuItem value="banana">Banana</MenuItem>
+        </Select>,
+      );
+  
+      const trigger = screen.getByRole('combobox', { hidden: true });
+  
+      await focusTrigger(trigger);
+  
+      fireEvent.keyDown(trigger, { key: 'b' });
+  
+      expect(trigger).not.to.have.text('Banana');
+    });
+  
+    it('does not trigger typeahead for multiple select', async () => {
+      render(
+        <Select multiple defaultValue={[]}>
+          <MenuItem value="apple">Apple</MenuItem>
+          <MenuItem value="banana">Banana</MenuItem>
+        </Select>,
+      );
+  
+      const trigger = screen.getByRole('combobox');
+  
+      await focusTrigger(trigger);
+  
+      fireEvent.keyDown(trigger, { key: 'b' });
+  
+      expect(trigger).not.to.have.text('Banana');
+    });
+  
+    it('does not trigger typeahead when readOnly', async () => {
+      render(
+        <Select readOnly defaultValue="">
+          <MenuItem value="apple">Apple</MenuItem>
+          <MenuItem value="banana">Banana</MenuItem>
+        </Select>,
+      );
+  
+      const trigger = screen.getByRole('combobox');
+  
+      await focusTrigger(trigger);
+  
+      fireEvent.keyDown(trigger, { key: 'b' });
+  
+      expect(trigger).not.to.have.text('Banana');
+    });
+  
+    it('supports nested children text in options', async () => {
+      render(
+        <Select defaultValue="">
+          <MenuItem value="apple">
+            <span>Apple</span>
+          </MenuItem>
+  
+          <MenuItem value="banana">
+            <div>
+              <span>Banana</span>
+            </div>
+          </MenuItem>
+        </Select>,
+      );
+  
+      const trigger = screen.getByRole('combobox');
+  
+      await focusTrigger(trigger);
+  
+      fireEvent.keyDown(trigger, { key: 'b' });
+  
+      expect(trigger).to.have.text('Banana');
+    });
+  
+    it('ignores non-character keys for typeahead', async () => {
+      render(
+        <Select defaultValue="">
+          <MenuItem value="apple">Apple</MenuItem>
+          <MenuItem value="banana">Banana</MenuItem>
+        </Select>,
+      );
+  
+      const trigger = screen.getByRole('combobox');
+  
+      await focusTrigger(trigger);
+  
+      fireEvent.keyDown(trigger, { key: 'Shift' });
+  
+      expect(trigger).not.to.have.text('Banana');
+    });
+  });
+
   it.skipIf(isJsdom())('updates menu minWidth when the trigger resizes while open', async () => {
     clock.restore();
 

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -542,15 +542,6 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         React.isValidElement(child) && child.props.value !== undefined && !child.props.disabled,
     );
 
-    console.log(
-      'Selectable candidates:',
-      selectableChildren.map((child) => ({
-        text: getOptionText(child.props.children),
-        value: child.props.value,
-        disabled: child.props.disabled,
-      })),
-    );
-
     const criteria = textCriteriaRef.current;
     const lowerKey = event.key.toLowerCase();
     const currTime = performance.now();
@@ -587,11 +578,6 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         return text.length > 0 && text.startsWith(criteria.keys.join(''));
       });
     }
-
-    console.log('Matched item:', {
-      text: match ? getOptionText(match.props.children) : null,
-      value: match ? match.props.value : null,
-    });
 
     if (criteria.previousKeyMatched && match) {
       event.preventDefault();

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -203,10 +203,12 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   const hasSelectedItemInListRef = React.useRef(false);
   const openingMouseUpListenerCleanupRef = React.useRef(null);
   const didPointerDownOnItemRef = React.useRef(false);
-  const typeaheadBufferRef = React.useRef('');
-  const typeaheadLastCharRef = React.useRef('');
-  const typeaheadCycleIndexRef = React.useRef(0);
-  const typeaheadResetTimerRef = React.useRef(null);
+  const textCriteriaRef = React.useRef({
+    keys: [],
+    repeating: true,
+    previousKeyMatched: true,
+    lastTime: null,
+  });
   const selectionRef = React.useRef({
     allowSelectedMouseUp: false,
     allowUnselectedMouseUp: false,
@@ -320,12 +322,6 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       displayRef.current.focus();
     }
   }, [autoFocus]);
-
-  React.useEffect(() => {
-    return () => {
-      clearTimeout(typeaheadResetTimerRef.current);
-    };
-  }, []);
 
   React.useEffect(() => {
     if (!labelId) {
@@ -535,75 +531,84 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       return;
     }
 
-    const char = event.key;
-    if (char.length !== 1) {
+    if (event.key.length !== 1) {
       return;
     }
 
-    event.preventDefault();
+    // Build selectable option list — skip disabled items and non-interactive
+    // subheaders (items without a value prop), consistent with open-popup behavior.
+    const selectableChildren = React.Children.toArray(children).filter(
+      (child) =>
+        React.isValidElement(child) && child.props.value !== undefined && !child.props.disabled,
+    );
 
-    const lowerChar = char.toLowerCase();
-    clearTimeout(typeaheadResetTimerRef.current);
-
-    // Build option list from children
-    const options = React.Children.toArray(children)
-      .filter(React.isValidElement)
-      .map((child) => ({
-        label: getOptionText(child.props.children).toLowerCase(),
+    console.log(
+      'Selectable candidates:',
+      selectableChildren.map((child) => ({
+        text: getOptionText(child.props.children),
         value: child.props.value,
-        child,
-      }))
-      .filter((option) => option.label.length > 0);
+        disabled: child.props.disabled,
+      })),
+    );
 
-    const isSameChar =
-      lowerChar === typeaheadLastCharRef.current && typeaheadBufferRef.current.length === 1;
+    const criteria = textCriteriaRef.current;
+    const lowerKey = event.key.toLowerCase();
+    const currTime = performance.now();
 
-    if (isSameChar) {
-      // CYCLING MODE: same character pressed again → advance to next match
-      const charMatches = options.filter((option) => option.label.startsWith(lowerChar));
-      if (charMatches.length === 0) {
-        return;
+    if (criteria.keys.length > 0) {
+      // Reset after 500ms of inactivity — mirrors MenuList reset threshold
+      if (currTime - criteria.lastTime > 500) {
+        criteria.keys = [];
+        criteria.repeating = true;
+        criteria.previousKeyMatched = true;
+      } else if (criteria.repeating && lowerKey !== criteria.keys[0]) {
+        criteria.repeating = false;
       }
-      typeaheadCycleIndexRef.current = (typeaheadCycleIndexRef.current + 1) % charMatches.length;
-      const match = charMatches[typeaheadCycleIndexRef.current];
-      if (match && match.value !== value) {
-        setValueState(match.value);
+    }
+
+    criteria.lastTime = currTime;
+    criteria.keys.push(lowerKey);
+
+    let match;
+    if (criteria.repeating) {
+      // Find all matches, then pick the NEXT one after the currently selected value
+      const charMatches = selectableChildren.filter((child) => {
+        const text = getOptionText(child.props.children).trim().toLowerCase();
+        return text.length > 0 && text[0] === criteria.keys[0];
+      });
+      const currentIndex = charMatches.findIndex((child) => child.props.value === value);
+      // If current value not in matches, start from 0, otherwise advance to next
+      const nextIndex = (currentIndex + 1) % charMatches.length;
+      match = charMatches[nextIndex];
+    } else {
+      // different characters typed — find first match
+      match = selectableChildren.find((child) => {
+        const text = getOptionText(child.props.children).trim().toLowerCase();
+        return text.length > 0 && text.startsWith(criteria.keys.join(''));
+      });
+    }
+
+    console.log('Matched item:', {
+      text: match ? getOptionText(match.props.children) : null,
+      value: match ? match.props.value : null,
+    });
+
+    if (criteria.previousKeyMatched && match) {
+      event.preventDefault();
+      if (match.props.value !== value) {
+        setValueState(match.props.value);
         if (onChange) {
           const nativeEvent = new Event('change', { bubbles: true });
           Object.defineProperty(nativeEvent, 'target', {
             writable: true,
-            value: { value: match.value, name },
+            value: { value: match.props.value, name },
           });
-          onChange(nativeEvent, match.child);
+          onChange(nativeEvent, match);
         }
       }
     } else {
-      // PREFIX MATCH MODE: accumulate characters and find first match
-      typeaheadBufferRef.current += lowerChar;
-      typeaheadLastCharRef.current = lowerChar;
-      const match = options.find((option) => option.label.startsWith(typeaheadBufferRef.current));
-      if (match) {
-        const charMatches = options.filter((option) => option.label.startsWith(lowerChar));
-        typeaheadCycleIndexRef.current = charMatches.indexOf(match);
-        if (match.value !== value) {
-          setValueState(match.value);
-          if (onChange) {
-            const nativeEvent = new Event('change', { bubbles: true });
-            Object.defineProperty(nativeEvent, 'target', {
-              writable: true,
-              value: { value: match.value, name },
-            });
-            onChange(nativeEvent, match.child);
-          }
-        }
-      }
+      criteria.previousKeyMatched = false;
     }
-
-    typeaheadResetTimerRef.current = setTimeout(() => {
-      typeaheadBufferRef.current = '';
-      typeaheadLastCharRef.current = '';
-      typeaheadCycleIndexRef.current = 0;
-    }, 500);
   };
 
   const handleKeyDown = (event) => {

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -524,17 +524,17 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     if (open || multiple || readOnly || disabled) {
       return;
     }
-  
+
     const char = event.key;
     if (char.length !== 1) {
       return;
     }
-  
+
     event.preventDefault();
-  
+
     const lowerChar = char.toLowerCase();
     clearTimeout(typeaheadResetTimerRef.current);
-  
+
     // Build option list from children
     const options = React.Children.toArray(children)
       .filter(React.isValidElement)
@@ -544,9 +544,10 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         child,
       }))
       .filter((option) => option.label.length > 0);
-  
-    const isSameChar = lowerChar === typeaheadLastCharRef.current && typeaheadBufferRef.current.length === 1;
-  
+
+    const isSameChar =
+      lowerChar === typeaheadLastCharRef.current && typeaheadBufferRef.current.length === 1;
+
     if (isSameChar) {
       // CYCLING MODE: same character pressed again → advance to next match
       const charMatches = options.filter((option) => option.label.startsWith(lowerChar));
@@ -587,7 +588,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         }
       }
     }
-  
+
     typeaheadResetTimerRef.current = setTimeout(() => {
       typeaheadBufferRef.current = '';
       typeaheadLastCharRef.current = '';

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -63,12 +63,22 @@ function isMouseEventInsideElement(event, element) {
 }
 
 function getOptionText(node) {
-  if (node == null) return '';
-  if (typeof node === 'string' || typeof node === 'number') return String(node);
-  if (Array.isArray(node)) return node.map(getOptionText).join('');
+  if (node == null) {
+    return '';
+  }
+
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(getOptionText).join('');
+  }
+
   if (React.isValidElement(node) && node.props.children) {
     return getOptionText(node.props.children);
   }
+
   return '';
 }
 

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -62,6 +62,16 @@ function isMouseEventInsideElement(event, element) {
   );
 }
 
+function getOptionText(node) {
+  if (node == null) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(getOptionText).join('');
+  if (React.isValidElement(node) && node.props.children) {
+    return getOptionText(node.props.children);
+  }
+  return '';
+}
+
 const SelectSelect = styled(StyledSelectSelect, {
   name: 'MuiSelect',
   slot: 'Select',
@@ -183,6 +193,10 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   const hasSelectedItemInListRef = React.useRef(false);
   const openingMouseUpListenerCleanupRef = React.useRef(null);
   const didPointerDownOnItemRef = React.useRef(false);
+  const typeaheadBufferRef = React.useRef('');
+  const typeaheadLastCharRef = React.useRef('');
+  const typeaheadCycleIndexRef = React.useRef(0);
+  const typeaheadResetTimerRef = React.useRef(null);
   const selectionRef = React.useRef({
     allowSelectedMouseUp: false,
     allowUnselectedMouseUp: false,
@@ -296,6 +310,12 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       displayRef.current.focus();
     }
   }, [autoFocus]);
+
+  React.useEffect(() => {
+    return () => {
+      clearTimeout(typeaheadResetTimerRef.current);
+    };
+  }, []);
 
   React.useEffect(() => {
     if (!labelId) {
@@ -500,6 +520,81 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     event.currentTarget.click();
   };
 
+  const handleTypeaheadKeyDown = (event) => {
+    if (open || multiple || readOnly || disabled) {
+      return;
+    }
+  
+    const char = event.key;
+    if (char.length !== 1) {
+      return;
+    }
+  
+    event.preventDefault();
+  
+    const lowerChar = char.toLowerCase();
+    clearTimeout(typeaheadResetTimerRef.current);
+  
+    // Build option list from children
+    const options = React.Children.toArray(children)
+      .filter(React.isValidElement)
+      .map((child) => ({
+        label: getOptionText(child.props.children).toLowerCase(),
+        value: child.props.value,
+        child,
+      }))
+      .filter((option) => option.label.length > 0);
+  
+    const isSameChar = lowerChar === typeaheadLastCharRef.current && typeaheadBufferRef.current.length === 1;
+  
+    if (isSameChar) {
+      // CYCLING MODE: same character pressed again → advance to next match
+      const charMatches = options.filter((option) => option.label.startsWith(lowerChar));
+      if (charMatches.length === 0) {
+        return;
+      }
+      typeaheadCycleIndexRef.current = (typeaheadCycleIndexRef.current + 1) % charMatches.length;
+      const match = charMatches[typeaheadCycleIndexRef.current];
+      if (match && match.value !== value) {
+        setValueState(match.value);
+        if (onChange) {
+          const nativeEvent = new Event('change', { bubbles: true });
+          Object.defineProperty(nativeEvent, 'target', {
+            writable: true,
+            value: { value: match.value, name },
+          });
+          onChange(nativeEvent, match.child);
+        }
+      }
+    } else {
+      // PREFIX MATCH MODE: accumulate characters and find first match
+      typeaheadBufferRef.current += lowerChar;
+      typeaheadLastCharRef.current = lowerChar;
+      const match = options.find((option) => option.label.startsWith(typeaheadBufferRef.current));
+      if (match) {
+        const charMatches = options.filter((option) => option.label.startsWith(lowerChar));
+        typeaheadCycleIndexRef.current = charMatches.indexOf(match);
+        if (match.value !== value) {
+          setValueState(match.value);
+          if (onChange) {
+            const nativeEvent = new Event('change', { bubbles: true });
+            Object.defineProperty(nativeEvent, 'target', {
+              writable: true,
+              value: { value: match.value, name },
+            });
+            onChange(nativeEvent, match.child);
+          }
+        }
+      }
+    }
+  
+    typeaheadResetTimerRef.current = setTimeout(() => {
+      typeaheadBufferRef.current = '';
+      typeaheadLastCharRef.current = '';
+      typeaheadCycleIndexRef.current = 0;
+    }, 500);
+  };
+
   const handleKeyDown = (event) => {
     if (!readOnly) {
       const validKeys = [
@@ -517,6 +612,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       }
       onKeyDown?.(event);
     }
+    handleTypeaheadKeyDown(event);
   };
 
   const handleBlur = (event) => {

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -527,7 +527,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   };
 
   const handleTypeaheadKeyDown = (event) => {
-    if (open || multiple || readOnly || disabled) {
+    if (openRef.current || multiple || readOnly || disabled) {
       return;
     }
 


### PR DESCRIPTION
fixes #48467 

https://deploy-preview-48504--material-ui.netlify.app/material-ui/react-select/

Added tests to verify that typeahead keyboard navigation does not trigger when the Select is open, multiple, readOnly, or disabled. Also added coverage for matching, cycling, and timeout reset behavior.
