### PR TITLE
[Avatar] continue fallback chain when child img fails to load

### DIFF
--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -188,6 +188,12 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
     slotProps,
   };
 
+  const [childImgError, setChildImgError] = React.useState(false);
+
+  React.useEffect(() => {
+    setChildImgError(false);
+  }, [childrenProp]);
+
   const [RootSlot, rootSlotProps] = useSlot('root', {
     ref,
     className: clsx(classes.root, className),
@@ -220,8 +226,20 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
     children = <ImgSlot {...imgSlotProps} />;
     // We only render valid children, non valid children are rendered with a fallback
     // We consider that invalid children are all falsy values, except 0, which is valid.
-  } else if (!!childrenProp || childrenProp === 0) {
-    children = childrenProp;
+  } else if ((!!childrenProp || childrenProp === 0) && !childImgError) {
+    // Intercept img children to continue the fallback chain if they error.
+    children =
+      React.Children.map(childrenProp, (child) => {
+        if (React.isValidElement(child) && child.type === 'img') {
+          return React.cloneElement(child, {
+            onError(event) {
+              child.props.onError?.(event);
+              setChildImgError(true);
+            },
+          });
+        }
+        return child;
+      }) ?? childrenProp;
   } else if (hasImg && alt) {
     children = alt[0];
   } else {

--- a/packages/mui-material/src/Avatar/Avatar.test.js
+++ b/packages/mui-material/src/Avatar/Avatar.test.js
@@ -256,32 +256,29 @@ describe('<Avatar />', () => {
   });
 
   describe('child img fallback', () => {
-    it('should show fallback when child img fails to load', async () => {
+    it('should show fallback when child img fails to load', () => {
       const { container } = render(
         <Avatar>
           <img src="/broken.png" alt="broken" />
         </Avatar>,
       );
       const avatar = container.firstChild;
-      const img = avatar.querySelector('img');
-      fireEvent.error(img);
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      fireEvent.error(avatar.querySelector('img'));
       expect(avatar.firstChild).to.have.attribute('data-testid', 'PersonIcon');
     });
 
-    it('should call the original onError when child img fails', async () => {
+    it('should call the original onError when child img fails', () => {
       const onError = spy();
       const { container } = render(
         <Avatar>
           <img src="/broken.png" onError={onError} alt="broken" />
         </Avatar>,
       );
-      const img = container.querySelector('img');
-      fireEvent.error(img);
+      fireEvent.error(container.querySelector('img'));
       expect(onError.callCount).to.equal(1);
     });
 
-    it('should reset child img error state when children changes', async () => {
+    it('should reset child img error state when children changes', () => {
       const { container, rerender } = render(
         <Avatar>
           <img src="/broken.png" alt="broken" />
@@ -289,7 +286,6 @@ describe('<Avatar />', () => {
       );
       const avatar = container.firstChild;
       fireEvent.error(avatar.querySelector('img'));
-      await new Promise((resolve) => setTimeout(resolve, 0));
 
       rerender(<Avatar>OT</Avatar>);
       expect(avatar.firstChild).to.text('OT');

--- a/packages/mui-material/src/Avatar/Avatar.test.js
+++ b/packages/mui-material/src/Avatar/Avatar.test.js
@@ -255,6 +255,47 @@ describe('<Avatar />', () => {
     });
   });
 
+  describe('child img fallback', () => {
+    it('should show fallback when child img fails to load', async () => {
+      const { container } = render(
+        <Avatar>
+          <img src="/broken.png" alt="broken" />
+        </Avatar>,
+      );
+      const avatar = container.firstChild;
+      const img = avatar.querySelector('img');
+      fireEvent.error(img);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(avatar.firstChild).to.have.attribute('data-testid', 'PersonIcon');
+    });
+
+    it('should call the original onError when child img fails', async () => {
+      const onError = spy();
+      const { container } = render(
+        <Avatar>
+          <img src="/broken.png" onError={onError} alt="broken" />
+        </Avatar>,
+      );
+      const img = container.querySelector('img');
+      fireEvent.error(img);
+      expect(onError.callCount).to.equal(1);
+    });
+
+    it('should reset child img error state when children changes', async () => {
+      const { container, rerender } = render(
+        <Avatar>
+          <img src="/broken.png" alt="broken" />
+        </Avatar>,
+      );
+      const avatar = container.firstChild;
+      fireEvent.error(avatar.querySelector('img'));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      rerender(<Avatar>OT</Avatar>);
+      expect(avatar.firstChild).to.text('OT');
+    });
+  });
+
   it('should not throw error when ownerState is used in styleOverrides', () => {
     const theme = createTheme({
       components: {


### PR DESCRIPTION
## Summary

Fixes #48190 (follow-up from the comment by @Rc85).

When `<Avatar>` has no `src`/`srcSet` prop but receives a child `<img>` element whose `src` is broken, the component previously rendered the broken img with no fallback. The fallback chain only kicked in for the Avatar's own `src`/`srcSet` (tracked by the `useLoaded` hook), not for arbitrary `<img>` children passed via `children`.

### Changes

- Added `childImgError` state inside `Avatar`
- Added `useEffect` to reset `childImgError` when `children` changes (e.g., parent re-renders with a new child)
- In the `children` fallback block, use `React.Children.map` + `React.cloneElement` to inject an `onError` handler on any direct `<img>` children. When the injected handler fires, it calls the original `onError` (if any) and sets `childImgError(true)`, which causes the component to re-render and continue down the chain:
  1. `src`/`srcSet` → img (tracked by `useLoaded`)
  2. valid `children` → rendered as-is (child `<img>` errors now intercepted)
  3. `alt[0]` → first character of alt text
  4. `<FallbackSlot />` → Person icon

### Before

```jsx
<Avatar>
  <img src="/broken.png" />
</Avatar>
// Renders: broken <img> with no fallback
```

### After

```jsx
<Avatar>
  <img src="/broken.png" />
</Avatar>
// Renders: Person icon fallback once the img errors
```

## Test plan

- [ ] New tests in `Avatar.test.js` cover: child img error shows Person fallback, original `onError` is still called, `childImgError` resets when `children` changes
- [ ] Existing Avatar tests all pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)