### PR TITLE
[docs-infra] Remove outdated noSEOadvantage entries

### DIFF
--- a/packages-internal/markdown/parseMarkdown.mjs
+++ b/packages-internal/markdown/parseMarkdown.mjs
@@ -264,20 +264,14 @@ const noSEOadvantage = [
   'https://m2.material.io/',
   'https://m3.material.io/',
   'https://material.io/',
-  'https://getbootstrap.com/',
-  'https://icons.getbootstrap.com/',
+  'https://themes.getbootstrap.com/',
   'https://pictogrammers.com/',
   'https://www.w3.org/',
   'https://tailwindcss.com/',
   'https://heroicons.com/',
   'https://react-icons.github.io/',
   'https://fontawesome.com/',
-  'https://react-spectrum.adobe.com/',
-  'https://headlessui.com/',
-  'https://refine.dev/',
-  'https://scaffoldhub.io/',
   'https://marmelab.com/',
-  'https://framesxdesign.com/',
 ];
 
 /**


### PR DESCRIPTION
A quick clean-up. We don't link those domains from Material UI or MUI X or Toolpad docs anymore.

As for the general principle, I have updated https://github.com/mui/base-ui/issues/1615 (point 8.) to suggest introducing a `noSEOadvantage` back. https://github.com/mui/base-ui/pull/4802 made me think about this.