### PR TITLE
[InputLabel] keep required asterisk visible when label text is truncated

### DIFF
--- a/packages/mui-material/src/FormLabel/FormLabel.js
+++ b/packages/mui-material/src/FormLabel/FormLabel.js
@@ -24,6 +24,7 @@ const useUtilityClasses = (ownerState) => {
       required && 'required',
     ],
     asterisk: ['asterisk', error && 'error'],
+    labelText: ['labelText'],
   };
 
   return composeClasses(slots, getFormLabelUtilityClasses, classes);
@@ -84,6 +85,11 @@ const AsteriskComponent = styled('span', {
   })),
 );
 
+const FormLabelText = styled('span', {
+  name: 'MuiFormLabel',
+  slot: 'LabelText',
+})({});
+
 const FormLabel = React.forwardRef(function FormLabel(inProps, ref) {
   const props = useDefaultProps({ props: inProps, name: 'MuiFormLabel' });
   const {
@@ -125,7 +131,9 @@ const FormLabel = React.forwardRef(function FormLabel(inProps, ref) {
       ref={ref}
       {...other}
     >
-      {children}
+      <FormLabelText ownerState={ownerState} className={classes.labelText}>
+        {children}
+      </FormLabelText>
       {fcs.required && (
         <AsteriskComponent ownerState={ownerState} aria-hidden className={classes.asterisk}>
           &thinsp;{'*'}

--- a/packages/mui-material/src/FormLabel/formLabelClasses.ts
+++ b/packages/mui-material/src/FormLabel/formLabelClasses.ts
@@ -18,6 +18,8 @@ export interface FormLabelClasses {
   required: string;
   /** Styles applied to the asterisk element. */
   asterisk: string;
+  /** Styles applied to the label text wrapper element. */
+  labelText: string;
 }
 
 export type FormLabelClassKey = keyof FormLabelClasses;
@@ -35,6 +37,7 @@ const formLabelClasses: FormLabelClasses = generateUtilityClasses('MuiFormLabel'
   'filled',
   'required',
   'asterisk',
+  'labelText',
 ]);
 
 export default formLabelClasses;

--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -53,12 +53,20 @@ const InputLabelRoot = styled(FormLabel, {
   },
 })(
   memoTheme(({ theme }) => ({
-    display: 'block',
+    display: 'flex',
+    alignItems: 'baseline',
     transformOrigin: 'top left',
     whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
     maxWidth: '100%',
+    [`& .${formLabelClasses.labelText}`]: {
+      flex: '1 1 auto',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      minWidth: 0,
+    },
+    [`& .${formLabelClasses.asterisk}`]: {
+      flexShrink: 0,
+    },
     variants: [
       {
         props: ({ ownerState }) => ownerState.formControl,

--- a/packages/mui-material/src/InputLabel/InputLabel.test.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.test.js
@@ -36,6 +36,22 @@ describe('<InputLabel />', () => {
     expect(container.firstChild).not.to.have.class(classes.animated);
   });
 
+  it('should wrap label text in a labelText element', () => {
+    const { container } = render(<InputLabel>Foo</InputLabel>);
+    const label = container.querySelector('label');
+    expect(label.firstChild).to.have.tagName('span');
+    expect(label.firstChild).to.have.text('Foo');
+  });
+
+  it('should keep the asterisk outside the labelText wrapper so it is not clipped by overflow', () => {
+    const { container } = render(<InputLabel required>Foo</InputLabel>);
+    const label = container.querySelector('label');
+    const labelText = label.firstChild;
+    const asterisk = label.lastChild;
+    expect(labelText).to.have.text('Foo');
+    expect(asterisk).to.have.class('MuiFormLabel-asterisk');
+  });
+
   it('should forward the asterisk class to AsteriskComponent when required', () => {
     const { container } = render(
       <InputLabel classes={{ asterisk: 'my-asterisk' }} required>
@@ -137,7 +153,7 @@ describe('<InputLabel />', () => {
           },
         });
 
-        render(
+        const { container } = render(
           <ThemeProvider theme={theme}>
             <FormControl focused>
               <InputLabel>Test Label</InputLabel>
@@ -145,7 +161,7 @@ describe('<InputLabel />', () => {
           </ThemeProvider>,
         );
 
-        const label = screen.getByText('Test Label');
+        const label = container.querySelector('label');
 
         expect(label).to.toHaveComputedStyle({
           mixBlendMode: 'darken',
@@ -158,7 +174,7 @@ describe('<InputLabel />', () => {
     it('classes.root should overwrite built-in styles.', () => {
       const text = 'The label';
 
-      render(
+      const { container } = render(
         <ClassNames>
           {({ css }) => (
             <FormControl>
@@ -168,7 +184,7 @@ describe('<InputLabel />', () => {
         </ClassNames>,
       );
 
-      const label = screen.getByText(text);
+      const label = container.querySelector('label');
 
       expect(getComputedStyle(label).position).to.equal('static');
     });
@@ -176,7 +192,7 @@ describe('<InputLabel />', () => {
     it('className should overwrite classes.root and built-in styles.', () => {
       const text = 'The label';
 
-      render(
+      const { container } = render(
         <ClassNames>
           {({ css }) => (
             <FormControl>
@@ -192,7 +208,7 @@ describe('<InputLabel />', () => {
         </ClassNames>,
       );
 
-      const label = screen.getByText(text);
+      const label = container.querySelector('label');
 
       expect(getComputedStyle(label).position).to.equal('static');
     });


### PR DESCRIPTION
## Summary

Fixes #48388.

When a `TextField` (or `InputLabel`) has a long label, the `overflow: hidden; text-overflow: ellipsis` on the root `<label>` would clip the required asterisk `*` along with the overflowing text, making it invisible.

**Root cause**: both the label text and the asterisk `<span>` were inline siblings inside a single `overflow: hidden` block container. The ellipsis replaced content from the end of the combined inline flow — hiding the asterisk.

**Fix**: switch `InputLabelRoot` from `display: block` to `display: flex; align-items: baseline`, and introduce a `FormLabelText` wrapper span (`MuiFormLabel-labelText`) around the label children in `FormLabel`. The text span gets `flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; min-width: 0` so it truncates independently, while the asterisk span gets `flex-shrink: 0` so it is always fully visible.

### Before

```
Very long label describing the purpo...   ← asterisk hidden
```

### After

```
Very long label describing the purpo... * ← asterisk always visible
```

## Changes

- **`FormLabel.js`**: wrap `{children}` in a new `FormLabelText` styled span (`MuiFormLabel-labelText`); add `labelText` slot to `useUtilityClasses`
- **`formLabelClasses.ts`**: export new `labelText` class key
- **`InputLabel.js`**: change root to `display: flex; align-items: baseline`; move `overflow: hidden; text-overflow: ellipsis` from root to `& .MuiFormLabel-labelText`; add `flex-shrink: 0` to `& .MuiFormLabel-asterisk`
- **`InputLabel.test.js`**: update two tests that used `getByText` to find the root `<label>` (now finds the inner span); add two new tests for the fix

## Test plan

- [ ] New tests: `FormLabelText` wrapper is rendered; asterisk is a sibling of the wrapper (not inside it)
- [ ] Existing tests updated to query `label` element directly
- [ ] Visual: long required TextField label shows ellipsis on the text, asterisk remains visible at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)