### PR TITLE
[docs-infra] Fix Cookie banner heading

### DIFF
--- a/packages-internal/core-docs/src/DocsApp/AnalyticsProvider.tsx
+++ b/packages-internal/core-docs/src/DocsApp/AnalyticsProvider.tsx
@@ -129,10 +129,11 @@ export function CookieConsentDialog() {
                 <Stack spacing={0.5}>
                   <Typography
                     variant="subtitle2"
+                    component="h2"
                     id="cookie-consent-dialog-title"
                     sx={{ textAlign: { xs: 'center', sm: 'start' } }}
                   >
-                    Cookie Preferences
+                    Cookie preferences
                   </Typography>
                   <Typography
                     id="cookie-consent-dialog-description"


### PR DESCRIPTION
Solve "TODO on MUI" point 3. from https://github.com/mui/mui-public/issues/321, meaning:

<img width="889" height="581" alt="SCR-20260512-cpzz" src="https://github.com/user-attachments/assets/f56ce4aa-45ab-4957-8f29-872a52f03d64" />

There was 0 errors on the page reported by axe, now there is 1, so it's a regression.

---

There are more problems from that GitHub issue, I'm opening this PR to illustrate one of them.