### PR TITLE
[docs] Clarify styled-components version compatibility

### DIFF
--- a/docs/data/material/integrations/styled-components/styled-components.md
+++ b/docs/data/material/integrations/styled-components/styled-components.md
@@ -93,7 +93,7 @@ For TypeScript, you must also update the `tsconfig.json` as shown here:
 ```
 
 :::info
-**Versions compatibility**: Use the same major version of `@mui/styled-engine-sc` as your Material UI packages—for example, `@mui/styled-engine-sc@9.x` with `@mui/material@9.x`.
+**Versions compatibility**: Use the same major version of `@mui/styled-engine-sc` as your Material UI packages—for example, `@mui/styled-engine-sc@9.x` with `@mui/material@9.x`.
 
-The installed `styled-components` version only needs to satisfy the peer dependency of `@mui/styled-engine-sc`. For Material UI v7 and v9, this is `styled-components@^6.0.0`.
+The installed `styled-components` version only needs to satisfy the peer dependency of `@mui/styled-engine-sc`. For Material UI v7 and v9, this is `styled-components@^6.0.0`.
 :::

--- a/docs/data/material/integrations/styled-components/styled-components.md
+++ b/docs/data/material/integrations/styled-components/styled-components.md
@@ -93,5 +93,5 @@ For TypeScript, you must also update the `tsconfig.json` as shown here:
 ```
 
 :::info
-**Versions compatibility**: To ensure compatibility, it's essential to align the major version of `@mui/styled-engine-sc` with that of the `styled-components` package you're using. For instance, if you opt for `styled-components` version 5, it's necessary to use `@mui/styled-engine-sc` version 5. Similarly, if your preference is `styled-components` version 6, you'll need to upgrade `@mui/styled-engine-sc` to its version 6, which is currently in an alpha state.
+**Versions compatibility**: To ensure compatibility, align the major version of `@mui/styled-engine-sc` with the other MUI packages you're using. For example, use `@mui/styled-engine-sc@9.x` with `@mui/material@9.x`. The `styled-components` package is versioned separately, so install a version that satisfies the peer dependency declared by your `@mui/styled-engine-sc` release. Current releases require `styled-components@^6.0.0`.
 :::

--- a/docs/data/material/integrations/styled-components/styled-components.md
+++ b/docs/data/material/integrations/styled-components/styled-components.md
@@ -93,5 +93,7 @@ For TypeScript, you must also update the `tsconfig.json` as shown here:
 ```
 
 :::info
-**Versions compatibility**: To ensure compatibility, align the major version of `@mui/styled-engine-sc` with the other MUI packages you're using. For example, use `@mui/styled-engine-sc@9.x` with `@mui/material@9.x`. The `styled-components` package is versioned separately, so install a version that satisfies the peer dependency declared by your `@mui/styled-engine-sc` release. Current releases require `styled-components@^6.0.0`.
+**Versions compatibility**: Use the same major version of `@mui/styled-engine-sc` as your Material UI packages—for example, `@mui/styled-engine-sc@9.x` with `@mui/material@9.x`.
+
+The installed `styled-components` version only needs to satisfy the peer dependency of `@mui/styled-engine-sc`. For Material UI v7 and v9, this is `styled-components@^6.0.0`.
 :::


### PR DESCRIPTION
Closes #48044

## Summary
- Clarify that `@mui/styled-engine-sc` should match the major version of the other MUI packages in the app.
- Explain that `styled-components` is versioned separately and should satisfy the peer dependency declared by `@mui/styled-engine-sc`.

## Impact
This removes stale version guidance from the styled-components integration docs. No runtime code changes.

## Validation
- `git diff --check` -> passed
- `corepack pnpm exec markdownlint-cli2 docs/data/material/integrations/styled-components/styled-components.md` -> 0 errors