### PR TITLE
[poc][autocomplete] Improve speed of opening the menu

### DIFF
--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -1308,6 +1308,8 @@ function useAutocomplete(props) {
       // Only handle event when the main button is pressed (left click).
       event.button === 0
     ) {
+      // Batch focused set with open and pristine state updates.
+      setFocused(true);
       handlePopupIndicator(event);
     }
   };

--- a/test/e2e/autocomplete-open-perf.test.ts
+++ b/test/e2e/autocomplete-open-perf.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Automated perf test: measures time from mousedown on the Autocomplete input
+ * to the popup being committed to the DOM (via the performance.measure entry
+ * written by the useLayoutEffect in useAutocomplete).
+ *
+ * Run with:
+ *   pnpm test:e2e
+ *
+ * For a production build baseline first run:
+ *   pnpm docs:build && pnpm docs:start
+ * and point BASE_URL to the prod server.
+ */
+import { Browser, Page, chromium } from '@playwright/test';
+import { beforeAll, afterAll, describe, it } from 'vitest';
+
+const BASE_URL = 'http://localhost:5001';
+const RUNS = 300;
+const WARMUP = 10;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function attemptGoto(page: Page, url: string) {
+  for (let i = 0; i < 10; i += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await page.goto(url);
+      return;
+    } catch {
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(250);
+    }
+  }
+}
+
+describe('Autocomplete open perf', () => {
+  let browser: Browser;
+  let page: Page;
+
+  beforeAll(async () => {
+    browser = await chromium.launch();
+    page = await browser.newPage();
+    await attemptGoto(page, `${BASE_URL}/e2e/Autocomplete/OpenPerfAutocomplete#no-dev`);
+    await page.waitForSelector('[data-testid="testcase"]:not([aria-busy="true"])');
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it(`measures popup open time over ${RUNS} clicks`, { timeout: 60_000 }, async () => {
+    const input = page.getByTestId('input');
+    const durations: number[] = [];
+
+    // Warm-up runs — discarded to let the JIT settle before measuring
+    for (let i = 0; i < WARMUP; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await page.mouse.click(0, 0);
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(50);
+      // eslint-disable-next-line no-await-in-loop
+      await input.click();
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(50);
+    }
+    await page.mouse.click(0, 0);
+    await sleep(50);
+
+    for (let i = 0; i < RUNS; i += 1) {
+      // Close the popup by clicking outside (triggers blur)
+      // eslint-disable-next-line no-await-in-loop
+      await page.mouse.click(0, 0);
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(50);
+
+      // Click the input and measure wall time until the listbox appears in the DOM
+      const start = performance.now();
+      // eslint-disable-next-line no-await-in-loop
+      await input.click();
+      // eslint-disable-next-line no-await-in-loop
+      await page.waitForSelector('[role="listbox"]', { state: 'visible' });
+      durations.push(performance.now() - start);
+    }
+
+    const avg = durations.reduce((a, b) => a + b, 0) / durations.length;
+    const min = Math.min(...durations);
+    const max = Math.max(...durations);
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `\nAutocomplete open perf (${RUNS} runs):\n` +
+        `  avg: ${avg.toFixed(2)}ms\n` +
+        `  min: ${min.toFixed(2)}ms\n` +
+        `  max: ${max.toFixed(2)}ms\n` +
+        `  all: ${durations.map((d) => d.toFixed(2)).join(', ')}ms`,
+    );
+  });
+});

--- a/test/e2e/fixtures/Autocomplete/OpenPerfAutocomplete.tsx
+++ b/test/e2e/fixtures/Autocomplete/OpenPerfAutocomplete.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+
+const options = Array.from({ length: 100 }, (_, i) => `Option ${i + 1}`);
+
+function OpenPerfAutocomplete() {
+  return (
+    <Autocomplete
+      options={options}
+      sx={{ width: 300 }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label="Open perf"
+          slotProps={{
+            ...params.slotProps,
+            htmlInput: {
+              ...params.slotProps.htmlInput,
+              autoComplete: 'new-password', // disable autocomplete and autofill
+              'data-testid': 'input',
+            },
+          }}
+        />
+      )}
+    />
+  );
+}
+
+export default OpenPerfAutocomplete;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Some perf measurements and fix proposal, on Autocomplete open action.

To repro, click Autocomplete, then click outside (blur). The issue seems to be the double render, which increases the time the dropdown takes to open. Batching the state updates for open + pristine with focused avoids the double render. This issue is reported in Chrome, as a task that took too long. This is a non-production screenshot, production takes less.

<img width="495" height="70" alt="Screenshot 2026-05-13 at 10 02 30" src="https://github.com/user-attachments/assets/8e967481-1db4-461c-9ee8-d07ce395144e" />

The production version is more likely the one below. However, this is on a Macbook Pro, other devices might not be this fast.

|Before|After|
|--|--|
|<img width="398" height="510" alt="Screenshot 2026-05-13 at 10 09 17" src="https://github.com/user-attachments/assets/da38bc4f-2334-4923-a01f-d2d62d55515c" />|<img width="465" height="508" alt="Screenshot 2026-05-13 at 10 08 39" src="https://github.com/user-attachments/assets/ecac72cf-c216-4fdb-8d06-01171b2f43ed" />|


The PR contains a test that calculates averages of the open action, and a tears down by clicking outside to close the menu. Running the test with and without the fix:

```
  // avg: 18.54ms
  // min: 10.31ms
  // max: 28.77ms

  // avg: 22.26ms
  // min: 16.90ms
  // max: 51.48ms
```