### PR TITLE
[autocomplete] Fix `renderInput` not passing `slotProps`

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -2595,6 +2595,26 @@ describe('<Autocomplete />', () => {
   });
 
   describe('click input', () => {
+    it('should preserve Autocomplete input props when TextField htmlInput slot props are provided', () => {
+      expect(() => {
+        render(
+          <Autocomplete
+            options={['one', 'two']}
+            renderInput={(params) => (
+              <TextField {...params} slotProps={{ htmlInput: { maxLength: 4 } }} />
+            )}
+          />,
+        );
+      }).not.toErrorDev();
+
+      const textbox = screen.getByRole('combobox');
+      expect(textbox).to.have.property('maxLength', 4);
+
+      fireEvent.mouseDown(textbox);
+      expect(textbox).to.have.attribute('aria-expanded', 'true');
+      expect(screen.getAllByRole('option')).to.have.length(2);
+    });
+
     it('when `openOnFocus` toggles if empty', () => {
       render(
         <Autocomplete

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -2595,24 +2595,18 @@ describe('<Autocomplete />', () => {
   });
 
   describe('click input', () => {
-    it('should preserve Autocomplete input props when TextField htmlInput slot props are provided', () => {
-      expect(() => {
-        render(
-          <Autocomplete
-            options={['one', 'two']}
-            renderInput={(params) => (
-              <TextField {...params} slotProps={{ htmlInput: { maxLength: 4 } }} />
-            )}
-          />,
-        );
-      }).not.toErrorDev();
+    it('should apply TextField htmlInput slot props when Autocomplete renderInput params are spread', () => {
+      render(
+        <Autocomplete
+          options={['one', 'two']}
+          renderInput={(params) => (
+            <TextField {...params} slotProps={{ htmlInput: { maxLength: 4 } }} />
+          )}
+        />,
+      );
 
       const textbox = screen.getByRole('combobox');
       expect(textbox).to.have.property('maxLength', 4);
-
-      fireEvent.mouseDown(textbox);
-      expect(textbox).to.have.attribute('aria-expanded', 'true');
-      expect(screen.getAllByRole('option')).to.have.length(2);
     });
 
     it('when `openOnFocus` toggles if empty', () => {

--- a/packages/mui-material/src/TextField/TextField.js
+++ b/packages/mui-material/src/TextField/TextField.js
@@ -14,6 +14,7 @@ import InputLabel from '../InputLabel';
 import FormControl from '../FormControl';
 import FormHelperText from '../FormHelperText';
 import Select from '../Select';
+import { mergeSlotProps } from '../utils';
 import { getTextFieldUtilityClass } from './textFieldClasses';
 import useSlot from '../utils/useSlot';
 
@@ -37,6 +38,14 @@ const TextFieldRoot = styled(FormControl, {
   name: 'MuiTextField',
   slot: 'Root',
 })({});
+
+const mergeDeprecatedSlotProps = (slotProps, deprecatedSlotProps) => {
+  if (deprecatedSlotProps == null) {
+    return slotProps;
+  }
+
+  return mergeSlotProps(slotProps, deprecatedSlotProps);
+};
 
 /**
  * The `TextField` is a convenience wrapper for the most common cases (80%).
@@ -141,12 +150,12 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
   const externalForwardedProps = {
     slots,
     slotProps: {
-      input: InputPropsProp,
-      inputLabel: InputLabelPropsProp,
-      htmlInput: inputPropsProp,
-      formHelperText: FormHelperTextPropsProp,
-      select: SelectPropsProp,
       ...slotProps,
+      input: mergeDeprecatedSlotProps(slotProps.input, InputPropsProp),
+      inputLabel: mergeDeprecatedSlotProps(slotProps.inputLabel, InputLabelPropsProp),
+      htmlInput: mergeDeprecatedSlotProps(slotProps.htmlInput, inputPropsProp),
+      formHelperText: mergeDeprecatedSlotProps(slotProps.formHelperText, FormHelperTextPropsProp),
+      select: mergeDeprecatedSlotProps(slotProps.select, SelectPropsProp),
     },
   };
 

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -321,7 +321,7 @@ describe('<TextField />', () => {
     it('should merge deprecated props with their matching slot props', () => {
       const handleInputMouseDown = spy();
       const handleSlotInputMouseDown = spy();
-      const { container, unmount } = render(
+      const { container } = render(
         <TextField
           label="Name"
           helperText="Helper"
@@ -403,9 +403,9 @@ describe('<TextField />', () => {
       expect(helperTextElement).to.have.class('slot-helper-text');
       expect(helperTextElement).to.have.attribute('data-deprecated-helper-text', 'true');
       expect(helperTextElement).to.have.attribute('data-slot-helper-text', 'true');
+    });
 
-      unmount();
-
+    it('should merge deprecated SelectProps with slotProps.select', () => {
       const { container: selectContainer } = render(
         <TextField
           select

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -317,6 +317,123 @@ describe('<TextField />', () => {
     });
   });
 
+  describe('prop: slotProps', () => {
+    it('should merge deprecated props with their matching slot props', () => {
+      const handleInputMouseDown = spy();
+      const handleSlotInputMouseDown = spy();
+      const { container, unmount } = render(
+        <TextField
+          label="Name"
+          helperText="Helper"
+          InputProps={{
+            className: 'deprecated-input',
+            'data-deprecated-input': 'true',
+            'data-precedence': 'deprecated',
+            onMouseDown: handleInputMouseDown,
+            style: { color: 'red', backgroundColor: 'blue' },
+          }}
+          InputLabelProps={{
+            className: 'deprecated-input-label',
+            'data-deprecated-input-label': 'true',
+          }}
+          inputProps={{
+            className: 'deprecated-html-input',
+            'data-deprecated-html-input': 'true',
+            maxLength: 2,
+          }}
+          FormHelperTextProps={{
+            className: 'deprecated-helper-text',
+            'data-deprecated-helper-text': 'true',
+          }}
+          slotProps={{
+            input: {
+              className: 'slot-input',
+              'data-slot-input': 'true',
+              'data-precedence': 'slot',
+              onMouseDown: handleSlotInputMouseDown,
+              style: { backgroundColor: 'green' },
+            },
+            inputLabel: {
+              className: 'slot-input-label',
+              'data-slot-input-label': 'true',
+            },
+            htmlInput: {
+              className: 'slot-html-input',
+              'data-slot-html-input': 'true',
+              maxLength: 4,
+            },
+            formHelperText: {
+              className: 'slot-helper-text',
+              'data-slot-helper-text': 'true',
+            },
+          }}
+        />,
+      );
+
+      const textbox = screen.getByRole('textbox');
+      const inputRoot = textbox.closest(`.${inputBaseClasses.root}`);
+      const inputLabel = container.querySelector('label');
+      const helperTextElement = screen.getByText('Helper');
+
+      expect(inputRoot).not.to.equal(null);
+      expect(inputRoot).to.have.class('deprecated-input');
+      expect(inputRoot).to.have.class('slot-input');
+      expect(inputRoot).to.have.attribute('data-deprecated-input', 'true');
+      expect(inputRoot).to.have.attribute('data-slot-input', 'true');
+      expect(inputRoot).to.have.attribute('data-precedence', 'slot');
+      expect(inputRoot.style.color).to.equal('red');
+      expect(inputRoot.style.backgroundColor).to.equal('green');
+
+      fireEvent.mouseDown(inputRoot);
+      expect(handleInputMouseDown.callCount).to.equal(1);
+      expect(handleSlotInputMouseDown.callCount).to.equal(1);
+
+      expect(inputLabel).to.have.class('deprecated-input-label');
+      expect(inputLabel).to.have.class('slot-input-label');
+      expect(inputLabel).to.have.attribute('data-deprecated-input-label', 'true');
+      expect(inputLabel).to.have.attribute('data-slot-input-label', 'true');
+
+      expect(textbox).to.have.class('deprecated-html-input');
+      expect(textbox).to.have.class('slot-html-input');
+      expect(textbox).to.have.attribute('data-deprecated-html-input', 'true');
+      expect(textbox).to.have.attribute('data-slot-html-input', 'true');
+      expect(textbox).to.have.property('maxLength', 4);
+
+      expect(helperTextElement).to.have.class('deprecated-helper-text');
+      expect(helperTextElement).to.have.class('slot-helper-text');
+      expect(helperTextElement).to.have.attribute('data-deprecated-helper-text', 'true');
+      expect(helperTextElement).to.have.attribute('data-slot-helper-text', 'true');
+
+      unmount();
+
+      const { container: selectContainer } = render(
+        <TextField
+          select
+          value="one"
+          SelectProps={{
+            native: true,
+            className: 'deprecated-select',
+            'data-deprecated-select': 'true',
+          }}
+          slotProps={{
+            select: {
+              className: 'slot-select',
+              'data-slot-select': 'true',
+            },
+          }}
+        >
+          <option value="one">One</option>
+        </TextField>,
+      );
+
+      const selectRoot = selectContainer.querySelector('.deprecated-select.slot-select');
+      expect(selectRoot).not.to.equal(null);
+      expect(selectRoot).to.have.attribute('data-deprecated-select', 'true');
+      expect(selectRoot).to.have.attribute('data-slot-select', 'true');
+      expect(screen.getByRole('combobox')).to.have.property('nodeName', 'SELECT');
+    });
+  });
+
   describe('autofill', () => {
     it('should be filled after auto fill event', () => {
       function AutoFillComponentTest() {


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/43869

This doesn't work in v7 because `params` doesn't contain `slotProps`:
```jsx
renderInput={(params) => (
  <TextField
    {...params}
    slotProps={{
      ...params.slotProps,
      htmlInput: {
        ...params.slotProps.htmlInput,
        maxLength: 4,
      },
    }}
  />
)}
```
Worth fixing because `slotProps` individually work with Autocomplete and TextField, but doesn't work for the most common combination of the two

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
