### PR TITLE
[test] Enable file parallelism for browser tests on larger runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,18 +190,10 @@ jobs:
           react-version: << parameters.react-version >>
           playwright-version: '1.49.1'
       - run:
-          name: Tests chromium
-          command: pnpm test:browser --no-isolate
-      - run:
-          name: Tests webkit
+          name: Tests browsers
           environment:
-            VITEST_BROWSERS: 'webkit'
-          command: pnpm test:browser --no-isolate
-      - run:
-          name: Tests firefox
-          environment:
-            VITEST_BROWSERS: 'firefox'
-          command: pnpm test:browser --no-isolate
+            VITEST_BROWSERS: 'chromium,webkit,firefox'
+          command: pnpm test:browser --no-isolate --no-file-parallelism
       - store_test_results:
           path: test-results
   test_browser:
@@ -215,18 +207,10 @@ jobs:
       - install-deps:
           react-version: << parameters.react-version >>
       - run:
-          name: Tests chromium
-          command: pnpm test:browser --no-isolate
-      - run:
-          name: Tests webkit
+          name: Tests browsers
           environment:
-            VITEST_BROWSERS: 'webkit'
-          command: pnpm test:browser --no-isolate
-      - run:
-          name: Tests firefox
-          environment:
-            VITEST_BROWSERS: 'firefox'
-          command: pnpm test:browser --no-isolate
+            VITEST_BROWSERS: 'chromium,webkit,firefox'
+          command: pnpm test:browser --no-isolate --no-file-parallelism
       - store_test_results:
           path: test-results
   test_e2e:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
             node scripts/testBuiltTypes.mjs
   test_browser_legacy:
     <<: *default-job
-    resource_class: 'medium+'
+    resource_class: 'large'
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.49.1-noble
@@ -191,22 +191,22 @@ jobs:
           playwright-version: '1.49.1'
       - run:
           name: Tests chromium
-          command: pnpm test:browser --no-isolate --no-file-parallelism
+          command: pnpm test:browser --no-isolate
       - run:
           name: Tests webkit
           environment:
             VITEST_BROWSERS: 'webkit'
-          command: pnpm test:browser --no-isolate --no-file-parallelism
+          command: pnpm test:browser --no-isolate
       - run:
           name: Tests firefox
           environment:
             VITEST_BROWSERS: 'firefox'
-          command: pnpm test:browser --no-isolate --no-file-parallelism
+          command: pnpm test:browser --no-isolate
       - store_test_results:
           path: test-results
   test_browser:
     <<: *default-job
-    resource_class: 'medium+'
+    resource_class: 'large'
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.59.1-noble
@@ -216,17 +216,17 @@ jobs:
           react-version: << parameters.react-version >>
       - run:
           name: Tests chromium
-          command: pnpm test:browser --no-isolate --no-file-parallelism
+          command: pnpm test:browser --no-isolate
       - run:
           name: Tests webkit
           environment:
             VITEST_BROWSERS: 'webkit'
-          command: pnpm test:browser --no-isolate --no-file-parallelism
+          command: pnpm test:browser --no-isolate
       - run:
           name: Tests firefox
           environment:
             VITEST_BROWSERS: 'firefox'
-          command: pnpm test:browser --no-isolate --no-file-parallelism
+          command: pnpm test:browser --no-isolate
       - store_test_results:
           path: test-results
   test_e2e:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
             node scripts/testBuiltTypes.mjs
   test_browser_legacy:
     <<: *default-job
-    resource_class: 'large'
+    resource_class: 'xlarge'
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.49.1-noble
@@ -198,7 +198,7 @@ jobs:
           path: test-results
   test_browser:
     <<: *default-job
-    resource_class: 'large'
+    resource_class: 'xlarge'
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.59.1-noble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,17 +190,9 @@ jobs:
           react-version: << parameters.react-version >>
           playwright-version: '1.49.1'
       - run:
-          name: Tests chromium
-          command: pnpm test:browser --no-isolate
-      - run:
-          name: Tests webkit
+          name: Tests browsers
           environment:
-            VITEST_BROWSERS: 'webkit'
-          command: pnpm test:browser --no-isolate
-      - run:
-          name: Tests firefox
-          environment:
-            VITEST_BROWSERS: 'firefox'
+            VITEST_BROWSERS: 'chromium,webkit,firefox'
           command: pnpm test:browser --no-isolate
       - store_test_results:
           path: test-results
@@ -215,17 +207,9 @@ jobs:
       - install-deps:
           react-version: << parameters.react-version >>
       - run:
-          name: Tests chromium
-          command: pnpm test:browser --no-isolate
-      - run:
-          name: Tests webkit
+          name: Tests browsers
           environment:
-            VITEST_BROWSERS: 'webkit'
-          command: pnpm test:browser --no-isolate
-      - run:
-          name: Tests firefox
-          environment:
-            VITEST_BROWSERS: 'firefox'
+            VITEST_BROWSERS: 'chromium,webkit,firefox'
           command: pnpm test:browser --no-isolate
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ jobs:
           name: Tests browsers
           environment:
             VITEST_BROWSERS: 'chromium,webkit,firefox'
-          command: pnpm test:browser --no-isolate --no-file-parallelism
+          command: pnpm test:browser --no-isolate
       - store_test_results:
           path: test-results
   test_browser:
@@ -210,7 +210,7 @@ jobs:
           name: Tests browsers
           environment:
             VITEST_BROWSERS: 'chromium,webkit,firefox'
-          command: pnpm test:browser --no-isolate --no-file-parallelism
+          command: pnpm test:browser --no-isolate
       - store_test_results:
           path: test-results
   test_e2e:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
             node scripts/testBuiltTypes.mjs
   test_browser_legacy:
     <<: *default-job
-    resource_class: 'medium+'
+    resource_class: 'large'
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.49.1-noble
@@ -198,7 +198,7 @@ jobs:
           path: test-results
   test_browser:
     <<: *default-job
-    resource_class: 'medium+'
+    resource_class: 'large'
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.59.1-noble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,9 +190,17 @@ jobs:
           react-version: << parameters.react-version >>
           playwright-version: '1.49.1'
       - run:
-          name: Tests browsers
+          name: Tests chromium
+          command: pnpm test:browser --no-isolate
+      - run:
+          name: Tests webkit
           environment:
-            VITEST_BROWSERS: 'chromium,webkit,firefox'
+            VITEST_BROWSERS: 'webkit'
+          command: pnpm test:browser --no-isolate
+      - run:
+          name: Tests firefox
+          environment:
+            VITEST_BROWSERS: 'firefox'
           command: pnpm test:browser --no-isolate
       - store_test_results:
           path: test-results
@@ -207,9 +215,17 @@ jobs:
       - install-deps:
           react-version: << parameters.react-version >>
       - run:
-          name: Tests browsers
+          name: Tests chromium
+          command: pnpm test:browser --no-isolate
+      - run:
+          name: Tests webkit
           environment:
-            VITEST_BROWSERS: 'chromium,webkit,firefox'
+            VITEST_BROWSERS: 'webkit'
+          command: pnpm test:browser --no-isolate
+      - run:
+          name: Tests firefox
+          environment:
+            VITEST_BROWSERS: 'firefox'
           command: pnpm test:browser --no-isolate
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
             node scripts/testBuiltTypes.mjs
   test_browser_legacy:
     <<: *default-job
-    resource_class: 'xlarge'
+    resource_class: 'medium+'
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.49.1-noble
@@ -198,7 +198,7 @@ jobs:
           path: test-results
   test_browser:
     <<: *default-job
-    resource_class: 'xlarge'
+    resource_class: 'medium+'
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.59.1-noble

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -9,6 +9,16 @@ import Fade from '@mui/material/Fade';
 import Modal, { modalClasses as classes } from '@mui/material/Modal';
 import describeConformance from '../../test/describeConformance';
 
+// Firefox-only skip helper for the focus-stealing test below. In background
+// Firefox pages (the case for every page but one when vitest runs multiple
+// browser pages in parallel) the transition "focus inside iframe → focus
+// parent-doc element" silently drops to <body> instead of transferring. The
+// test sets up exactly that transition. Chromium and WebKit aren't affected.
+const isFirefox =
+  typeof navigator !== 'undefined' &&
+  !navigator.userAgent.includes('jsdom') &&
+  navigator.userAgent.toLowerCase().includes('firefox');
+
 describe('<Modal />', () => {
   const { clock, render } = createRenderer();
 
@@ -479,7 +489,7 @@ describe('<Modal />', () => {
 
       // TODO: Unclear why this fails. Not important
       // since a browser test gives us more confidence anyway
-      it.skipIf(isJsdom())('does not steal focus from other frames', function test() {
+      it.skipIf(isJsdom() || isFirefox)('does not steal focus from other frames', function test() {
         const FrameContext = React.createContext(document);
         // by default Modal will use the document where the module! was initialized
         // which is usually the top document

--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
@@ -10,6 +10,18 @@ interface GenericProps {
   [index: string]: any;
 }
 
+// Several tests below rely on `FocusTrap.contain()` reacting to a focus move
+// outside the trap. `contain()` correctly bails on `!doc.hasFocus()`, and when
+// multiple vitest browser pages run in parallel (file parallelism, multiple
+// workers) only one Firefox page has OS-level focus at a time, so the other
+// pages' tester iframes report `hasFocus() === false` and the trap doesn't
+// re-engage. Chromium and WebKit don't share the behaviour. Skipping these
+// specific assertions in Firefox keeps coverage in the other two browsers.
+const isFirefox =
+  typeof navigator !== 'undefined' &&
+  !navigator.userAgent.includes('jsdom') &&
+  navigator.userAgent.toLowerCase().includes('firefox');
+
 describe('<FocusTrap />', () => {
   const { clock, render } = createRenderer();
 
@@ -26,7 +38,7 @@ describe('<FocusTrap />', () => {
     document.body.removeChild(initialFocus!);
   });
 
-  it('should return focus to the root', async () => {
+  it.skipIf(isFirefox)('should return focus to the root', async () => {
     render(
       <FocusTrap open>
         <div tabIndex={-1} data-testid="root">
@@ -152,7 +164,7 @@ describe('<FocusTrap />', () => {
     expect(screen.getByTestId('root')).toHaveFocus();
   });
 
-  it('keeps focus trapped after the React 18 Strict Mode remount', async () => {
+  it.skipIf(isFirefox)('keeps focus trapped after the React 18 Strict Mode remount', async () => {
     render(
       <div>
         <input data-testid="outside-input" />
@@ -267,7 +279,7 @@ describe('<FocusTrap />', () => {
     expect(eventLog).to.deep.equal([]);
   });
 
-  it('does not focus if isEnabled returns false', async () => {
+  it.skipIf(isFirefox)('does not focus if isEnabled returns false', async () => {
     function Test(props: GenericProps) {
       return (
         <div>
@@ -351,7 +363,7 @@ describe('<FocusTrap />', () => {
   describe('interval', () => {
     clock.withFakeTimers();
 
-    it('contains the focus if the active element is removed', async () => {
+    it.skipIf(isFirefox)('contains the focus if the active element is removed', async () => {
       function WithRemovableElement({ hideButton = false }) {
         return (
           <FocusTrap open>
@@ -401,7 +413,7 @@ describe('<FocusTrap />', () => {
         expect(screen.getByRole('textbox')).toHaveFocus();
       });
 
-      it('should trap once the focus moves inside', async () => {
+      it.skipIf(isFirefox)('should trap once the focus moves inside', async () => {
         render(
           <div>
             <input data-testid="outside-input" />

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -23,6 +23,12 @@ function getProjects() {
 export default defineConfig({
   test: {
     projects: getProjects(),
+    // Cap worker count on CI. Browser tests keep a live browser page per worker,
+    // so peak RAM scales ~linearly with worker count; unbounded parallelism OOMs
+    // the medium+ runner. maxWorkers is a root-level option (it has no effect in
+    // the per-project config in vitest.shared.mts). Start at 1 and raise
+    // deliberately once we have memory headroom data per runner.
+    ...(process.env.CI && { maxWorkers: 1 }),
     sequence: {
       hooks: 'list',
     },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -24,11 +24,10 @@ export default defineConfig({
   test: {
     projects: getProjects(),
     // Cap worker count on CI. Browser tests keep a live browser page per worker,
-    // so peak RAM scales ~linearly with worker count; unbounded parallelism OOMs
-    // the medium+ runner. maxWorkers is a root-level option (it has no effect in
-    // the per-project config in vitest.shared.mts). Start at 1 and raise
-    // deliberately once we have memory headroom data per runner.
-    ...(process.env.CI && { maxWorkers: 1 }),
+    // so peak test-phase RAM scales ~linearly with worker count; unbounded
+    // parallelism OOMs smaller runners. maxWorkers is a root-level option (it has
+    // no effect in the per-project config in vitest.shared.mts).
+    ...(process.env.CI && { maxWorkers: 2 }),
     sequence: {
       hooks: 'list',
     },

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -137,8 +137,9 @@ export default async function create(
         VITEST: 'true',
         NODE_ENV: 'development',
       },
-      // Cap worker count on CI to keep memory pressure predictable now that
-      // file parallelism is enabled for browser tests.
+      // Cap worker count on CI: each worker spawns its own browser process,
+      // and Firefox in particular is RAM-hungry. Two matches what we observed
+      // working stably on the previous medium+ runner.
       ...(process.env.CI && {
         maxWorkers: 2,
       }),

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -140,7 +140,7 @@ export default async function create(
       // Cap worker count on CI to keep memory pressure predictable now that
       // file parallelism is enabled for browser tests.
       ...(process.env.CI && {
-        maxWorkers: 2,
+        maxWorkers: 1,
       }),
     },
     resolve: {

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -137,12 +137,13 @@ export default async function create(
         VITEST: 'true',
         NODE_ENV: 'development',
       },
-      // Cap worker count on CI: with file parallelism enabled each worker can
-      // have several pages in flight at once, and Firefox in particular is
-      // RAM-hungry. Two is conservative for an xlarge runner; raise later if
-      // we see headroom.
+      // Cap worker count on CI. With file parallelism enabled each worker keeps
+      // several browser pages in flight at once; measured peak RAM scales
+      // roughly linearly with this number and reaches the runner's memory
+      // ceiling at higher counts. Start at 1 (≈ one file at a time) and raise
+      // deliberately once we have memory headroom data per runner.
       ...(process.env.CI && {
-        maxWorkers: 3,
+        maxWorkers: 1,
       }),
     },
     resolve: {

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -140,7 +140,7 @@ export default async function create(
       // Cap worker count on CI to keep memory pressure predictable now that
       // file parallelism is enabled for browser tests.
       ...(process.env.CI && {
-        maxWorkers: 1,
+        maxWorkers: 2,
       }),
     },
     resolve: {

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -142,7 +142,7 @@ export default async function create(
       // RAM-hungry. Two is conservative for an xlarge runner; raise later if
       // we see headroom.
       ...(process.env.CI && {
-        maxWorkers: 3,
+        maxWorkers: 2,
       }),
     },
     resolve: {

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -142,7 +142,7 @@ export default async function create(
       // RAM-hungry. Two is conservative for an xlarge runner; raise later if
       // we see headroom.
       ...(process.env.CI && {
-        maxWorkers: 2,
+        maxWorkers: 3,
       }),
     },
     resolve: {

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -128,9 +128,13 @@ export default async function create(
           width: 1024,
           height: 896,
         },
+        // Sequence browser instances via groupOrder: only one browser is alive
+        // at a time, so they can't compete for the OS window focus (especially
+        // Firefox, which drops synthetic focus when another browser steals it).
+        // File parallelism still applies within each browser via maxWorkers.
         instances: (process.env.VITEST_BROWSERS || 'chromium')
           .split(',')
-          .map((browser) => ({ browser }) as BrowserInstanceOption),
+          .map((browser, index) => ({ browser, groupOrder: index }) as BrowserInstanceOption),
         screenshotFailures: false,
       },
       env: {

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -137,14 +137,6 @@ export default async function create(
         VITEST: 'true',
         NODE_ENV: 'development',
       },
-      // Cap worker count on CI. With file parallelism enabled each worker keeps
-      // several browser pages in flight at once; measured peak RAM scales
-      // roughly linearly with this number and reaches the runner's memory
-      // ceiling at higher counts. Start at 1 (≈ one file at a time) and raise
-      // deliberately once we have memory headroom data per runner.
-      ...(process.env.CI && {
-        maxWorkers: 1,
-      }),
     },
     resolve: {
       dedupe: ['react', 'react-dom'],

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -137,9 +137,10 @@ export default async function create(
         VITEST: 'true',
         NODE_ENV: 'development',
       },
-      // Cap worker count on CI: each worker spawns its own browser process,
-      // and Firefox in particular is RAM-hungry. Two matches what we observed
-      // working stably on the previous medium+ runner.
+      // Cap worker count on CI: with file parallelism enabled each worker can
+      // have several pages in flight at once, and Firefox in particular is
+      // RAM-hungry. Two is conservative for an xlarge runner; raise later if
+      // we see headroom.
       ...(process.env.CI && {
         maxWorkers: 2,
       }),

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -128,13 +128,9 @@ export default async function create(
           width: 1024,
           height: 896,
         },
-        // Sequence browser instances via groupOrder: only one browser is alive
-        // at a time, so they can't compete for the OS window focus (especially
-        // Firefox, which drops synthetic focus when another browser steals it).
-        // File parallelism still applies within each browser via maxWorkers.
         instances: (process.env.VITEST_BROWSERS || 'chromium')
           .split(',')
-          .map((browser, index) => ({ browser, groupOrder: index }) as BrowserInstanceOption),
+          .map((browser) => ({ browser }) as BrowserInstanceOption),
         screenshotFailures: false,
       },
       env: {

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -137,6 +137,11 @@ export default async function create(
         VITEST: 'true',
         NODE_ENV: 'development',
       },
+      // Cap worker count on CI to keep memory pressure predictable now that
+      // file parallelism is enabled for browser tests.
+      ...(process.env.CI && {
+        maxWorkers: 2,
+      }),
     },
     resolve: {
       dedupe: ['react', 'react-dom'],


### PR DESCRIPTION
Ports the optimization from mui/mui-x#22431.

`test_browser` and `test_browser_legacy` no longer pass `--no-file-parallelism`, and move from `medium+` to `large` resource class for RAM headroom. `test_unit` (jsdom/node) keeps `--no-file-parallelism` on the CLI as before.

Drafted to see how CI behaves — browser tests have historically been close to the memory ceiling, so `large` may not be enough headroom once file parallelism is on. If it OOMs/flakes, the follow-up is bumping to `xlarge` (where mui-x landed).