### PR TITLE
[test] Speed up test_types job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
             git add -A && git diff --exit-code --staged
   test_types:
     <<: *default-job
-    resource_class: 'medium+'
+    resource_class: 'large'
     steps:
       - checkout
       - install-deps

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "test:browser": "cross-env TEST_SCOPE=browser pnpm test:unit",
     "test:argos": "code-infra argos-push --folder test/regressions/screenshots/chrome",
     "typescript": "lerna run --no-bail typescript",
-    "typescript:ci": "lerna run --concurrency 2 --no-bail typescript",
+    "typescript:ci": "lerna run --concurrency 3 --no-bail typescript",
     "typescript:module-augmentation": "lerna run --concurrency 1 --no-bail typescript:module-augmentation",
     "use-react-version": "node ./scripts/useReactVersion.mjs",
     "validate-declarations": "tsx scripts/validateTypescriptDeclarations.mts",


### PR DESCRIPTION
Port of mui/mui-x#22442.

Bumps the CircleCI `test_types` job from `medium+` (3 vCPU / 6 GB) to `large` (4 vCPU / 8 GB) and raises `typescript:ci` concurrency from 2 to 3 so more package `tsc` invocations run in parallel.

In mui-x, the equivalent change more than halved the job runtime (10m54s → 4m42s) with CPU saturated for most of the run, making it credit-positive in CI credits.

The `formattedTSDemos.js` cleanup from the source PR does not apply here — material-ui's version uses `createTypeScriptProjectBuilder` and never had the unused `ts.createProgram` setup that mui-x dropped.