### PR TITLE
[code-infra] Collapse canary workflows into nightly and nightly-cron

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -584,10 +584,11 @@ workflows:
   #         react-version: ^17.0.0
   #         name: test_e2e-react@17
 
-  # This workflow can be triggered manually on the PR
-  react-18:
+  # Manually-triggered counterpart of nightly-cron — runs the full canary
+  # suite (react@18, react@next, typescript@next) on the current PR branch.
+  nightly:
     when:
-      equal: [react-18, << pipeline.parameters.workflow >>]
+      equal: [nightly, << pipeline.parameters.workflow >>]
     jobs:
       - test_unit:
           <<: *default-context
@@ -605,12 +606,6 @@ workflows:
           <<: *default-context
           react-version: ^18.0.0
           name: test_e2e-react@18
-
-  # This workflow can be triggered manually on the PR
-  react-next:
-    when:
-      equal: [react-next, << pipeline.parameters.workflow >>]
-    jobs:
       - test_unit:
           <<: *default-context
           react-version: next
@@ -627,17 +622,12 @@ workflows:
           <<: *default-context
           react-version: next
           name: test_e2e-react@next
-
-  typescript-next:
-    when:
-      equal: [typescript-next, << pipeline.parameters.workflow >>]
-    jobs:
       - test_types_next:
           <<: *default-context
           typescript-version: next
 
-  # Combined nightly canary runs. react@18 runs on all listed branches; the
-  # react@next and typescript@next jobs skip v5.x via per-job branch filters.
+  # Scheduled counterpart of `nightly`. react@18 runs on all listed branches;
+  # the react@next and typescript@next jobs skip v5.x via per-job branch filters.
   nightly-cron:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,8 +606,39 @@ workflows:
           react-version: ^18.0.0
           name: test_e2e-react@18
 
-  # This workflow is identical to react-18, but scheduled
-  react-18-cron:
+  # This workflow can be triggered manually on the PR
+  react-next:
+    when:
+      equal: [react-next, << pipeline.parameters.workflow >>]
+    jobs:
+      - test_unit:
+          <<: *default-context
+          react-version: next
+          name: test_unit-react@next
+      - test_browser:
+          <<: *default-context
+          react-version: next
+          name: test_browser-react@next
+      - test_regressions:
+          <<: *default-context
+          react-version: next
+          name: test_regressions-react@next
+      - test_e2e:
+          <<: *default-context
+          react-version: next
+          name: test_e2e-react@next
+
+  typescript-next:
+    when:
+      equal: [typescript-next, << pipeline.parameters.workflow >>]
+    jobs:
+      - test_types_next:
+          <<: *default-context
+          typescript-version: next
+
+  # Combined nightly canary runs. react@18 runs on all listed branches; the
+  # react@next and typescript@next jobs skip v5.x via per-job branch filters.
+  nightly-cron:
     triggers:
       - schedule:
           cron: '0 0 * * *'
@@ -635,76 +666,37 @@ workflows:
           <<: *default-context
           react-version: ^18.0.0
           name: test_e2e-react@18
-
-  # This workflow can be triggered manually on the PR
-  react-next:
-    when:
-      equal: [react-next, << pipeline.parameters.workflow >>]
-    jobs:
       - test_unit:
           <<: *default-context
           react-version: next
           name: test_unit-react@next
+          filters:
+            branches:
+              ignore: v5.x
       - test_browser:
           <<: *default-context
           react-version: next
           name: test_browser-react@next
+          filters:
+            branches:
+              ignore: v5.x
       - test_regressions:
           <<: *default-context
           react-version: next
           name: test_regressions-react@next
+          filters:
+            branches:
+              ignore: v5.x
       - test_e2e:
           <<: *default-context
           react-version: next
           name: test_e2e-react@next
-  # This workflow is identical to react-next, but scheduled
-  react-next-cron:
-    triggers:
-      - schedule:
-          cron: '0 0 * * *'
           filters:
             branches:
-              only:
-                # #target-branch-reference
-                - master
-                - v6.x
-    jobs:
-      - test_unit:
-          <<: *default-context
-          react-version: next
-          name: test_unit-react@next
-      - test_browser:
-          <<: *default-context
-          react-version: next
-          name: test_browser-react@next
-      - test_regressions:
-          <<: *default-context
-          react-version: next
-          name: test_regressions-react@next
-      - test_e2e:
-          <<: *default-context
-          react-version: next
-          name: test_e2e-react@next
-
-  typescript-next:
-    when:
-      equal: [typescript-next, << pipeline.parameters.workflow >>]
-    jobs:
+              ignore: v5.x
       - test_types_next:
           <<: *default-context
           typescript-version: next
-
-  typescript-next-cron:
-    triggers:
-      - schedule:
-          cron: '0 0 * * *'
           filters:
             branches:
-              only:
-                # #target-branch-reference
-                - master
-                - v6.x
-    jobs:
-      - test_types_next:
-          <<: *default-context
-          typescript-version: next
+              ignore: v5.x


### PR DESCRIPTION
The CircleCI config had six separate workflows for the same canary test suite — three manually-triggered (`react-18`, `react-next`, `typescript-next`) and three scheduled (`react-18-cron`, `react-next-cron`, `typescript-next-cron`). Collapse them into two:

- `nightly` — manual; runs the full suite (`react@18` + `react@next` + `typescript@next`) when triggered with `workflow=nightly` on a PR.
- `nightly-cron` — scheduled daily at `0 0 * * *` on `master`, `v5.x`, `v6.x`. `react@18` jobs run on all three branches; `react@next` and `test_types_next` skip `v5.x` via per-job `filters.branches.ignore`, preserving the previous per-branch coverage.

The manually-triggered `react-17` workflow is left as-is (`react-17-cron` was already disabled per the comment in the original config).

This allows us to monitor a single workflow in code-infra