### PR TITLE
[styled-engine-sc] Fix compatibility with Vite and Vitest

### DIFF
--- a/packages/mui-styled-engine-sc/src/index.js
+++ b/packages/mui-styled-engine-sc/src/index.js
@@ -1,4 +1,4 @@
-import scStyled from 'styled-components';
+import { styled as scStyled } from 'styled-components';
 
 export default function styled(tag, options) {
   let stylesFactory;


### PR DESCRIPTION
Preview: https://stackblitz.com/edit/6m4j77c8-fh3enqae?file=src%2FDemo.test.tsx
- `Ctrl+C` to kill the app in the Stackblitz terminal, then run `npm run test` and see the test passes.

Without the fix ([v9 repro](https://stackblitz.com/edit/6m4j77c8?file=src%2FDemo.test.tsx)) a `scStyled is not a function` error will be thrown 

Fixes https://github.com/mui/material-ui/issues/46586

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
