### PR TITLE
fix-Use context to remove need for manual id assigments

### DIFF
--- a/packages/mui-material/src/Accordion/Accordion.js
+++ b/packages/mui-material/src/Accordion/Accordion.js
@@ -216,14 +216,17 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
     ownerState,
   });
 
+  const autoId = React.useId();
+  const summaryId = `${autoId}-header`;
+  const regionId = `${autoId}-content`;
   const [AccordionRegionSlot, accordionRegionProps] = useSlot('region', {
     elementType: AccordionRegion,
     externalForwardedProps,
     ownerState,
     className: classes.region,
     additionalProps: {
-      'aria-labelledby': summary.props.id,
-      id: summary.props['aria-controls'],
+      'aria-labelledby': summaryId,
+      id: regionId,
       role: 'region',
     },
   });
@@ -231,7 +234,12 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
   return (
     <RootSlot {...rootProps}>
       <AccordionHeadingSlot {...accordionProps}>
-        <AccordionContext.Provider value={contextValue}>{summary}</AccordionContext.Provider>
+        <AccordionContext.Provider value={contextValue}>
+          {React.cloneElement(summary, {
+          id: summaryId,
+          'aria-controls': regionId,
+          })}
+          </AccordionContext.Provider>
       </AccordionHeadingSlot>
       <TransitionSlot in={expanded} timeout="auto" {...transitionProps}>
         <AccordionRegionSlot {...accordionRegionProps}>{children}</AccordionRegionSlot>

--- a/packages/mui-material/src/Accordion/Accordion.js
+++ b/packages/mui-material/src/Accordion/Accordion.js
@@ -235,10 +235,8 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
     <RootSlot {...rootProps}>
       <AccordionHeadingSlot {...accordionProps}>
         <AccordionContext.Provider value={contextValue}>
-          {React.cloneElement(summary, {
-          id: summaryId,
-          'aria-controls': regionId,
-          })}
+          id: summary.props.id || summaryId,
+          'aria-controls': summary.props['aria-controls'] || regionId,
           </AccordionContext.Provider>
       </AccordionHeadingSlot>
       <TransitionSlot in={expanded} timeout="auto" {...transitionProps}>


### PR DESCRIPTION
Added automatic accessibility ID generation for Accordion using `React.useId()`.

This removes the need to manually provide:

* `id`
* `aria-controls`

while maintaining proper accessibility behavior.

