### PR TITLE
[docs-infra] Support turbopack for docs

### DIFF
--- a/babel.config.mjs
+++ b/babel.config.mjs
@@ -25,6 +25,10 @@ function resolveAliasPath(relativeToBabelConf) {
 export default function getBabelConfig(api) {
   const baseConfig = getBaseConfig(api);
 
+  // Covers: docs prod build (NODE_ENV=production), package esm build (BABEL_ENV=stable),
+  // package cjs build (BABEL_ENV=node). Excludes docs dev, tests, coverage.
+  const isProductionBuild = api.env(['production', 'stable', 'node']);
+
   const defaultAlias = {
     '@mui/material': resolveAliasPath('./packages/mui-material/src'),
     '@mui/internal-core-docs': resolveAliasPath('./packages-internal/core-docs/src'),
@@ -43,7 +47,7 @@ export default function getBabelConfig(api) {
   };
 
   /** @type {babel.PluginItem[]} */
-  const plugins = [
+  const prodOnlyPlugins = [
     [
       '@mui/internal-babel-plugin-minify-errors',
       {
@@ -55,21 +59,34 @@ export default function getBabelConfig(api) {
     ],
   ];
 
+  const excludedBasePlugins = new Set([
+    '@mui/internal-babel-plugin-display-name',
+    // Inlining MUI_VERSION, etc only matters for shipped bundles.
+    // Dev reads process.env at runtime without needing substitution.
+    ...(isProductionBuild ? [] : ['babel-plugin-transform-inline-environment-variables']),
+  ]);
+
   const basePlugins = (baseConfig.plugins || []).filter(
     (/** @type {[unknown, unknown, string]} */ [, , pluginName]) =>
-      pluginName !== '@mui/internal-babel-plugin-display-name',
+      !excludedBasePlugins.has(pluginName),
   );
-  basePlugins.push(...plugins);
+
+  if (isProductionBuild) {
+    basePlugins.push(...prodOnlyPlugins);
+  }
 
   return {
     ...baseConfig,
     plugins: basePlugins,
-    overrides: [
-      {
-        exclude: /\.test\.(m?js|ts|tsx)$/,
-        plugins: ['@babel/plugin-transform-react-constant-elements'],
-      },
-    ],
+    // `@babel/plugin-transform-react-constant-elements` hoists static JSX — prod-only optimization.
+    overrides: isProductionBuild
+      ? [
+          {
+            exclude: /\.test\.(m?js|ts|tsx)$/,
+            plugins: ['@babel/plugin-transform-react-constant-elements'],
+          },
+        ]
+      : [],
     env: {
       development: {
         plugins: [

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -26,11 +26,6 @@ export default withDocsInfra({
       '@mui/material': '../packages/mui-material/src',
       '@mui/material/package.json': '../packages/mui-material/package.json',
       '@mui/internal-core-docs': '../packages-internal/core-docs/src',
-      // Pin bare `@mui/icons-material` to the ESM index.mjs (mirrors the
-      // webpack `@mui/icons-material$` exact-match alias). Turbopack directory
-      // resolution can otherwise land on the CJS `index.js`, which breaks
-      // `import * as mui from '@mui/icons-material'` (namespace members end up
-      // as `{ default: Component }` under CJS-ESM interop).
       '@mui/icons-material': '../packages/mui-icons-material/lib/index.mjs',
       '@mui/lab': '../packages/mui-lab/src',
       '@mui/styled-engine': '../packages/mui-styled-engine/src',
@@ -39,13 +34,10 @@ export default withDocsInfra({
       '@mui/private-theming': '../packages/mui-private-theming/src',
       '@mui/utils': '../packages/mui-utils/src',
       '@mui/material-nextjs': '../packages/mui-material-nextjs/src',
-      // Mirrors the `docs` alias from babel.config.mjs / babel-plugin-module-resolver.
       docs: '.',
     },
     resolveExtensions: ['.mjs', '.tsx', '.ts', '.jsx', '.js', '.json'],
     rules: {
-      // Turbopack requires serializable loader options, so `ignoreLanguagePages`
-      // (a function) is omitted. Safe while docs is English-only in SSR.
       '*.md': [
         // `.md?muiMarkdown` → markdown loader (mirrors the webpack `oneOf` first branch).
         {

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -3,8 +3,6 @@ import * as path from 'path';
 import * as url from 'url';
 import * as fs from 'fs';
 import * as semver from 'semver';
-// @ts-ignore
-import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import { createRequire } from 'module';
 import { NextConfig } from 'next';
 import { findPages } from './src/modules/utils/find';
@@ -45,15 +43,6 @@ export default withDocsInfra({
       docs: '.',
     },
     resolveExtensions: ['.mjs', '.tsx', '.ts', '.jsx', '.js', '.json'],
-    // Suppress turbopack's over-strict pages-router global-CSS check. Our
-    // global CSS imports are all in `pages/_app.tsx`, which is the documented
-    // allowed location — turbopack's check misfires here.
-    ignoreIssue: [
-      { path: /_app\.tsx/, title: /Global CSS/ },
-      { path: /_app\.tsx/, description: /Global CSS/ },
-      { path: /global\.css$/ },
-      { path: /components-gallery\/base-theme\.css$/ },
-    ],
     rules: {
       // Turbopack requires serializable loader options, so `ignoreLanguagePages`
       // (a function) is omitted. Safe while docs is English-only in SSR.
@@ -96,167 +85,6 @@ export default withDocsInfra({
         },
       ],
     },
-  },
-  webpack: (
-    config: Parameters<NonNullable<NextConfig['webpack']>>[0],
-    options: Parameters<NonNullable<NextConfig['webpack']>>[1],
-  ) => {
-    const plugins = config.plugins.slice();
-
-    if (process.env.DOCS_STATS_ENABLED && !options.isServer) {
-      plugins.push(
-        // For all options see https://github.com/th0r/webpack-bundle-analyzer#as-plugin
-        new BundleAnalyzerPlugin({
-          analyzerMode: 'static',
-          generateStatsFile: true,
-          analyzerPort: options.isServer ? 8888 : 8889,
-          reportTitle: `${options.isServer ? 'server' : 'client'} docs bundle`,
-          // Will be available at `.next/${statsFilename}`
-          statsFilename: `stats-${options.isServer ? 'server' : 'client'}.json`,
-        }),
-      );
-    }
-
-    // If a module is an webpack "external" the webpack aliases configured are not used.
-    // Next.js includes node_modules in webpack externals, some of those have dependencies
-    // on the aliases we defined above.
-    // So we need tell webpack to not consider those packages as externals.
-    if (
-      options.isServer &&
-      // Next.js executes this twice on the server with React 18 (once per runtime).
-      // We only care about Node runtime at this point.
-      (options.nextRuntime === undefined || options.nextRuntime === 'nodejs')
-    ) {
-      const externals = config.externals.slice(0, -1);
-      const nextExternals = config.externals.at(-1);
-
-      config.externals = [
-        // @ts-ignore
-        (ctx, callback) => {
-          const { request } = ctx;
-          const hasDependencyOnRepoPackages = [
-            'material-ui-popup-state',
-            // Assume any X dependencies depend on a package defined in this repository.
-            '@mui/x-',
-            '@toolpad/core',
-          ].some((dep) => request.startsWith(dep));
-
-          if (hasDependencyOnRepoPackages) {
-            return callback(null);
-          }
-          return nextExternals(ctx, callback);
-        },
-        ...externals,
-      ];
-    }
-
-    // @ts-ignore
-    config.module.rules.forEach((rule) => {
-      rule.resourceQuery = { not: [/raw/] };
-    });
-
-    return {
-      ...config,
-      plugins,
-      resolve: {
-        ...config.resolve,
-        // resolve .tsx first
-        alias: {
-          ...config.resolve.alias,
-
-          // for 3rd party packages with dependencies in this repository
-          '@mui/material$': path.resolve(workspaceRoot, 'packages/mui-material/src/index.js'),
-          '@mui/material/package.json': path.resolve(
-            workspaceRoot,
-            'packages/mui-material/package.json',
-          ),
-          '@mui/material': path.resolve(workspaceRoot, 'packages/mui-material/src'),
-
-          '@mui/internal-core-docs': path.resolve(workspaceRoot, 'packages-internal/core-docs/src'),
-          '@mui/icons-material$': path.resolve(
-            workspaceRoot,
-            'packages/mui-icons-material/lib/index.mjs',
-          ),
-          '@mui/icons-material': path.resolve(workspaceRoot, 'packages/mui-icons-material/lib'),
-          '@mui/lab': path.resolve(workspaceRoot, 'packages/mui-lab/src'),
-          '@mui/styled-engine': path.resolve(workspaceRoot, 'packages/mui-styled-engine/src'),
-          '@mui/system/package.json': path.resolve(
-            workspaceRoot,
-            'packages/mui-system/package.json',
-          ),
-          '@mui/system': path.resolve(workspaceRoot, 'packages/mui-system/src'),
-          '@mui/private-theming': path.resolve(workspaceRoot, 'packages/mui-private-theming/src'),
-          '@mui/utils': path.resolve(workspaceRoot, 'packages/mui-utils/src'),
-          '@mui/material-nextjs': path.resolve(workspaceRoot, 'packages/mui-material-nextjs/src'),
-        },
-        extensions: [
-          '.mjs',
-          '.tsx',
-          // @ts-ignore
-          ...config.resolve.extensions.filter(
-            (extension: string) => extension !== '.tsx' && extension !== '.mjs',
-          ),
-        ],
-      },
-      module: {
-        ...config.module,
-        rules: config.module.rules.concat([
-          {
-            test: /\.md$/,
-            oneOf: [
-              {
-                resourceQuery: /muiMarkdown/,
-                use: [
-                  options.defaultLoaders.babel,
-                  {
-                    loader: require.resolve('@mui/internal-markdown/loader'),
-                    options: {
-                      workspaceRoot,
-                      ignoreLanguagePages: () => false,
-                      languagesInProgress: [],
-                      packages: [
-                        {
-                          productId: 'material-ui',
-                          paths: [
-                            path.join(workspaceRoot, 'packages/mui-lab/src'),
-                            path.join(workspaceRoot, 'packages/mui-material/src'),
-                          ],
-                        },
-                      ],
-                      env: {
-                        SOURCE_CODE_REPO: options.config.env.SOURCE_CODE_REPO,
-                        LIB_VERSION: options.config.env.LIB_VERSION,
-                      },
-                    },
-                  },
-                ],
-              },
-              {
-                // used in some /getting-started/templates
-                type: 'asset/source',
-              },
-            ],
-          },
-          // required to transpile ../packages/
-          {
-            test: /\.(js|mjs|tsx|ts)$/,
-            resourceQuery: { not: [/raw/] },
-            // Narrow the scope to fixed directories
-            include: [
-              path.join(workspaceRoot, 'docs'),
-              path.join(workspaceRoot, 'packages'),
-              path.join(workspaceRoot, 'packages-internal'),
-            ],
-            exclude: /(node_modules|mui-icons-material)/,
-            use: options.defaultLoaders.babel,
-          },
-          {
-            resourceQuery: /raw/,
-            type: 'asset/source',
-          },
-        ]),
-      },
-    };
   },
   env: {
     // docs-infra

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -20,7 +20,84 @@ const pkgContent = fs.readFileSync(path.resolve(workspaceRoot, 'package.json'), 
 const pkg = JSON.parse(pkgContent);
 
 export default withDocsInfra({
-  webpack: (config: NextConfig, options): NextConfig => {
+  turbopack: {
+    resolveAlias: {
+      '@mui/material': '../packages/mui-material/src',
+      '@mui/material/package.json': '../packages/mui-material/package.json',
+      '@mui/internal-core-docs': '../packages-internal/core-docs/src',
+      // Pin bare `@mui/icons-material` to the ESM index.mjs (mirrors the
+      // webpack `@mui/icons-material$` exact-match alias). Turbopack directory
+      // resolution can otherwise land on the CJS `index.js`, which breaks
+      // `import * as mui from '@mui/icons-material'` (namespace members end up
+      // as `{ default: Component }` under CJS-ESM interop).
+      '@mui/icons-material': '../packages/mui-icons-material/lib/index.mjs',
+      '@mui/lab': '../packages/mui-lab/src',
+      '@mui/styled-engine': '../packages/mui-styled-engine/src',
+      '@mui/system': '../packages/mui-system/src',
+      '@mui/system/package.json': '../packages/mui-system/package.json',
+      '@mui/private-theming': '../packages/mui-private-theming/src',
+      '@mui/utils': '../packages/mui-utils/src',
+      '@mui/material-nextjs': '../packages/mui-material-nextjs/src',
+      // Mirrors the `docs` alias from babel.config.mjs / babel-plugin-module-resolver.
+      docs: '.',
+    },
+    resolveExtensions: ['.mjs', '.tsx', '.ts', '.jsx', '.js', '.json'],
+    // Suppress turbopack's over-strict pages-router global-CSS check. Our
+    // global CSS imports are all in `pages/_app.tsx`, which is the documented
+    // allowed location — turbopack's check misfires here.
+    ignoreIssue: [
+      { path: /_app\.tsx/, title: /Global CSS/ },
+      { path: /_app\.tsx/, description: /Global CSS/ },
+      { path: /global\.css$/ },
+      { path: /components-gallery\/base-theme\.css$/ },
+    ],
+    rules: {
+      // Turbopack requires serializable loader options, so `ignoreLanguagePages`
+      // (a function) is omitted. Safe while docs is English-only in SSR.
+      '*.md': [
+        // `.md?muiMarkdown` → markdown loader (mirrors the webpack `oneOf` first branch).
+        {
+          condition: { query: /[?&]muiMarkdown(?=&|$)/ },
+          loaders: [
+            {
+              loader: '@mui/internal-markdown/loader',
+              options: {
+                workspaceRoot,
+                languagesInProgress: [],
+                packages: [
+                  {
+                    productId: 'material-ui',
+                    paths: [
+                      path.join(workspaceRoot, 'packages/mui-lab/src'),
+                      path.join(workspaceRoot, 'packages/mui-material/src'),
+                    ],
+                  },
+                ],
+                env: {
+                  SOURCE_CODE_REPO: 'https://github.com/mui/material-ui',
+                  LIB_VERSION: pkg.version,
+                },
+              },
+            },
+          ],
+          as: '*.js',
+        },
+        // Non-muiMarkdown `.md` (e.g. `import terms from './terms.md'`) → raw source.
+        // `{ not: 'foreign' }` keeps raw-loader away from node_modules / Next.js internals.
+        {
+          condition: {
+            all: [{ not: 'foreign' }, { not: { query: /[?&]muiMarkdown(?=&|$)/ } }],
+          },
+          loaders: ['raw-loader'],
+          as: '*.js',
+        },
+      ],
+    },
+  },
+  webpack: (
+    config: Parameters<NonNullable<NextConfig['webpack']>>[0],
+    options: Parameters<NonNullable<NextConfig['webpack']>>[1],
+  ) => {
     const plugins = config.plugins.slice();
 
     if (process.env.DOCS_STATS_ENABLED && !options.isServer) {
@@ -161,7 +238,12 @@ export default withDocsInfra({
           {
             test: /\.(js|mjs|tsx|ts)$/,
             resourceQuery: { not: [/raw/] },
-            include: [workspaceRoot],
+            // Narrow the scope to fixed directories
+            include: [
+              path.join(workspaceRoot, 'docs'),
+              path.join(workspaceRoot, 'packages'),
+              path.join(workspaceRoot, 'packages-internal'),
+            ],
             exclude: /(node_modules|mui-icons-material)/,
             use: options.defaultLoaders.babel,
           },

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -19,14 +19,12 @@ const workspaceRoot = path.join(currentDirectory, '../');
 const pkgContent = fs.readFileSync(path.resolve(workspaceRoot, 'package.json'), 'utf8');
 const pkg = JSON.parse(pkgContent);
 
-// Shared alias list. Used by both turbopack (relative paths from `docs/`)
-// and webpack (absolute paths via `path.resolve`).
+// Shared alias list, paths relative to the workspace root. For turbopack, prefixed
+// with `../` (relative to `docs/`), and for webpack, resolved absolute.
 const aliasEntries: ReadonlyArray<readonly [string, string]> = [
   ['@mui/material', 'packages/mui-material/src'],
   ['@mui/material/package.json', 'packages/mui-material/package.json'],
   ['@mui/internal-core-docs', 'packages-internal/core-docs/src'],
-  ['@mui/icons-material', 'packages/mui-icons-material/lib/index.mjs'],
-  ['@mui/lab', 'packages/mui-lab/src'],
   ['@mui/styled-engine', 'packages/mui-styled-engine/src'],
   ['@mui/system', 'packages/mui-system/src'],
   ['@mui/system/package.json', 'packages/mui-system/package.json'],
@@ -37,6 +35,9 @@ const aliasEntries: ReadonlyArray<readonly [string, string]> = [
 
 const turbopackResolveAlias: Record<string, string> = {
   ...Object.fromEntries(aliasEntries.map(([name, rel]) => [name, `../${rel}`])),
+  // Bare `@mui/icons-material` → ESM index for namespace interop; deep imports
+  // (`@mui/icons-material/Add`) fall through to the installed package.
+  '@mui/icons-material': '../packages/mui-icons-material/lib/index.mjs',
   // Mirrors the `docs` alias from babel.config.mjs / babel-plugin-module-resolver.
   docs: '.',
 };
@@ -152,18 +153,11 @@ export default withDocsInfra({
       .map(([name, rel]) => [name, path.resolve(workspaceRoot, rel)] as const);
 
     const webpackAliases: Record<string, string> = {
-      // Exact-match overrides (with the `$` suffix) for bare imports.
-      // Pin `@mui/material` to its compiled `index.js` and `@mui/icons-material`
-      // to the ESM index so `import * as mui from '@mui/icons-material'`
-      // doesn't land on the CJS index and break namespace interop.
-      '@mui/material$': path.resolve(workspaceRoot, 'packages/mui-material/src/index.js'),
+      ...Object.fromEntries(sharedWebpackAliases),
       '@mui/icons-material$': path.resolve(
         workspaceRoot,
         'packages/mui-icons-material/lib/index.mjs',
       ),
-      ...Object.fromEntries(sharedWebpackAliases),
-      // Bare `@mui/icons-material` should resolve to the lib dir (not the ESM
-      // index), so deep imports `@mui/icons-material/Add` work.
       '@mui/icons-material': path.resolve(workspaceRoot, 'packages/mui-icons-material/lib'),
     };
 

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -20,6 +20,9 @@ const pkgContent = fs.readFileSync(path.resolve(workspaceRoot, 'package.json'), 
 const pkg = JSON.parse(pkgContent);
 
 export default withDocsInfra({
+  experimental: {
+    turbopackFileSystemCacheForBuild: true,
+  },
   turbopack: {
     resolveAlias: {
       '@mui/material': '../packages/mui-material/src',
@@ -269,7 +272,20 @@ export default withDocsInfra({
   },
   // Ensure CSS from the Data Grid packages is included in the build:
   // https://github.com/mui/mui-x/issues/17427#issuecomment-2813967605
-  transpilePackages: ['@mui/x-data-grid', '@mui/x-data-grid-pro', '@mui/x-data-grid-premium'],
+  // `@mui/x-*` entries: keep their `@mui/material/*` subpath imports
+  // inside the bundler so the turbopack source aliases win; otherwise
+  // resolution falls back to the pnpm symlink (→ `packages/mui-material/build/`),
+  // which is empty unless the package has been built.
+  transpilePackages: [
+    '@mui/x-charts',
+    '@mui/x-data-grid',
+    '@mui/x-data-grid-pro',
+    '@mui/x-data-grid-premium',
+    '@mui/x-tree-view',
+    '@mui/x-date-pickers',
+    '@mui/x-date-pickers-pro',
+    '@mui/x-data-grid-generator',
+  ],
   distDir: 'export',
   // Next.js provides a `defaultPathMap` argument, we could simplify the logic.
   // However, we don't in order to prevent any regression in the `findPages()` method.

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import * as url from 'url';
 import * as fs from 'fs';
 import * as semver from 'semver';
+// @ts-ignore
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import { createRequire } from 'module';
 import { NextConfig } from 'next';
 import { findPages } from './src/modules/utils/find';
@@ -17,53 +19,58 @@ const workspaceRoot = path.join(currentDirectory, '../');
 const pkgContent = fs.readFileSync(path.resolve(workspaceRoot, 'package.json'), 'utf8');
 const pkg = JSON.parse(pkgContent);
 
-export default withDocsInfra({
-  experimental: {
-    turbopackFileSystemCacheForBuild: true,
-  },
-  turbopack: {
-    resolveAlias: {
-      '@mui/material': '../packages/mui-material/src',
-      '@mui/material/package.json': '../packages/mui-material/package.json',
-      '@mui/internal-core-docs': '../packages-internal/core-docs/src',
-      '@mui/icons-material': '../packages/mui-icons-material/lib/index.mjs',
-      '@mui/lab': '../packages/mui-lab/src',
-      '@mui/styled-engine': '../packages/mui-styled-engine/src',
-      '@mui/system': '../packages/mui-system/src',
-      '@mui/system/package.json': '../packages/mui-system/package.json',
-      '@mui/private-theming': '../packages/mui-private-theming/src',
-      '@mui/utils': '../packages/mui-utils/src',
-      '@mui/material-nextjs': '../packages/mui-material-nextjs/src',
-      docs: '.',
+// Shared alias list. Used by both turbopack (relative paths from `docs/`)
+// and webpack (absolute paths via `path.resolve`).
+const aliasEntries: ReadonlyArray<readonly [string, string]> = [
+  ['@mui/material', 'packages/mui-material/src'],
+  ['@mui/material/package.json', 'packages/mui-material/package.json'],
+  ['@mui/internal-core-docs', 'packages-internal/core-docs/src'],
+  ['@mui/icons-material', 'packages/mui-icons-material/lib/index.mjs'],
+  ['@mui/lab', 'packages/mui-lab/src'],
+  ['@mui/styled-engine', 'packages/mui-styled-engine/src'],
+  ['@mui/system', 'packages/mui-system/src'],
+  ['@mui/system/package.json', 'packages/mui-system/package.json'],
+  ['@mui/private-theming', 'packages/mui-private-theming/src'],
+  ['@mui/utils', 'packages/mui-utils/src'],
+  ['@mui/material-nextjs', 'packages/mui-material-nextjs/src'],
+];
+
+const turbopackResolveAlias: Record<string, string> = {
+  ...Object.fromEntries(aliasEntries.map(([name, rel]) => [name, `../${rel}`])),
+  // Mirrors the `docs` alias from babel.config.mjs / babel-plugin-module-resolver.
+  docs: '.',
+};
+
+const markdownLoaderBase = {
+  workspaceRoot,
+  languagesInProgress: [],
+  packages: [
+    {
+      productId: 'material-ui',
+      paths: [
+        path.join(workspaceRoot, 'packages/mui-lab/src'),
+        path.join(workspaceRoot, 'packages/mui-material/src'),
+      ],
     },
+  ],
+  env: {
+    SOURCE_CODE_REPO: 'https://github.com/mui/material-ui',
+    LIB_VERSION: pkg.version,
+  },
+};
+
+export default withDocsInfra({
+  turbopack: {
+    resolveAlias: turbopackResolveAlias,
     resolveExtensions: ['.mjs', '.tsx', '.ts', '.jsx', '.js', '.json'],
     rules: {
+      // Turbopack requires serializable loader options, so `ignoreLanguagePages`
+      // (a function) is omitted. Safe while docs is English-only in SSR.
       '*.md': [
         // `.md?muiMarkdown` → markdown loader (mirrors the webpack `oneOf` first branch).
         {
           condition: { query: /[?&]muiMarkdown(?=&|$)/ },
-          loaders: [
-            {
-              loader: '@mui/internal-markdown/loader',
-              options: {
-                workspaceRoot,
-                languagesInProgress: [],
-                packages: [
-                  {
-                    productId: 'material-ui',
-                    paths: [
-                      path.join(workspaceRoot, 'packages/mui-lab/src'),
-                      path.join(workspaceRoot, 'packages/mui-material/src'),
-                    ],
-                  },
-                ],
-                env: {
-                  SOURCE_CODE_REPO: 'https://github.com/mui/material-ui',
-                  LIB_VERSION: pkg.version,
-                },
-              },
-            },
-          ],
+          loaders: [{ loader: '@mui/internal-markdown/loader', options: markdownLoaderBase }],
           as: '*.js',
         },
         // Non-muiMarkdown `.md` (e.g. `import terms from './terms.md'`) → raw source.
@@ -77,6 +84,158 @@ export default withDocsInfra({
         },
       ],
     },
+  },
+  webpack: (
+    config: Parameters<NonNullable<NextConfig['webpack']>>[0],
+    options: Parameters<NonNullable<NextConfig['webpack']>>[1],
+  ) => {
+    const plugins = config.plugins.slice();
+
+    if (process.env.DOCS_STATS_ENABLED && !options.isServer) {
+      plugins.push(
+        // For all options see https://github.com/th0r/webpack-bundle-analyzer#as-plugin
+        new BundleAnalyzerPlugin({
+          analyzerMode: 'static',
+          generateStatsFile: true,
+          analyzerPort: options.isServer ? 8888 : 8889,
+          reportTitle: `${options.isServer ? 'server' : 'client'} docs bundle`,
+          // Will be available at `.next/${statsFilename}`
+          statsFilename: `stats-${options.isServer ? 'server' : 'client'}.json`,
+        }),
+      );
+    }
+
+    // If a module is an webpack "external" the webpack aliases configured are not used.
+    // Next.js includes node_modules in webpack externals, some of those have dependencies
+    // on the aliases we defined above.
+    // So we need tell webpack to not consider those packages as externals.
+    if (
+      options.isServer &&
+      // Next.js executes this twice on the server with React 18 (once per runtime).
+      // We only care about Node runtime at this point.
+      (options.nextRuntime === undefined || options.nextRuntime === 'nodejs')
+    ) {
+      const externals = config.externals.slice(0, -1);
+      const nextExternals = config.externals.at(-1);
+
+      config.externals = [
+        // @ts-ignore
+        (ctx, callback) => {
+          const { request } = ctx;
+          const hasDependencyOnRepoPackages = [
+            'material-ui-popup-state',
+            // Assume any X dependencies depend on a package defined in this repository.
+            '@mui/x-',
+            '@toolpad/core',
+          ].some((dep) => request.startsWith(dep));
+
+          if (hasDependencyOnRepoPackages) {
+            return callback(null);
+          }
+          return nextExternals(ctx, callback);
+        },
+        ...externals,
+      ];
+    }
+
+    // @ts-ignore
+    config.module.rules.forEach((rule) => {
+      rule.resourceQuery = { not: [/raw/] };
+    });
+
+    // Webpack alias matching is order-sensitive (first match wins for prefix
+    // aliases), so list more specific paths (`@mui/material/package.json`)
+    // before broader ones (`@mui/material`). We sort by key length desc to
+    // guarantee this regardless of how `aliasEntries` is declared.
+    const sharedWebpackAliases = [...aliasEntries]
+      .sort(([a], [b]) => b.length - a.length)
+      .map(([name, rel]) => [name, path.resolve(workspaceRoot, rel)] as const);
+
+    const webpackAliases: Record<string, string> = {
+      // Exact-match overrides (with the `$` suffix) for bare imports.
+      // Pin `@mui/material` to its compiled `index.js` and `@mui/icons-material`
+      // to the ESM index so `import * as mui from '@mui/icons-material'`
+      // doesn't land on the CJS index and break namespace interop.
+      '@mui/material$': path.resolve(workspaceRoot, 'packages/mui-material/src/index.js'),
+      '@mui/icons-material$': path.resolve(
+        workspaceRoot,
+        'packages/mui-icons-material/lib/index.mjs',
+      ),
+      ...Object.fromEntries(sharedWebpackAliases),
+      // Bare `@mui/icons-material` should resolve to the lib dir (not the ESM
+      // index), so deep imports `@mui/icons-material/Add` work.
+      '@mui/icons-material': path.resolve(workspaceRoot, 'packages/mui-icons-material/lib'),
+    };
+
+    return {
+      ...config,
+      plugins,
+      resolve: {
+        ...config.resolve,
+        alias: {
+          ...config.resolve.alias,
+          ...webpackAliases,
+        },
+        extensions: [
+          '.mjs',
+          '.tsx',
+          // @ts-ignore
+          ...config.resolve.extensions.filter(
+            (extension: string) => extension !== '.tsx' && extension !== '.mjs',
+          ),
+        ],
+      },
+      module: {
+        ...config.module,
+        rules: config.module.rules.concat([
+          {
+            test: /\.md$/,
+            oneOf: [
+              {
+                resourceQuery: /muiMarkdown/,
+                use: [
+                  options.defaultLoaders.babel,
+                  {
+                    loader: require.resolve('@mui/internal-markdown/loader'),
+                    options: {
+                      ...markdownLoaderBase,
+                      // Function form is allowed under webpack; turbopack
+                      // requires serialisable options so it's omitted there.
+                      ignoreLanguagePages: () => false,
+                      env: {
+                        SOURCE_CODE_REPO: options.config.env.SOURCE_CODE_REPO,
+                        LIB_VERSION: options.config.env.LIB_VERSION,
+                      },
+                    },
+                  },
+                ],
+              },
+              {
+                // used in some /getting-started/templates
+                type: 'asset/source',
+              },
+            ],
+          },
+          // required to transpile ../packages/
+          {
+            test: /\.(js|mjs|tsx|ts)$/,
+            resourceQuery: { not: [/raw/] },
+            // Narrow the scope to fixed directories
+            include: [
+              path.join(workspaceRoot, 'docs'),
+              path.join(workspaceRoot, 'packages'),
+              path.join(workspaceRoot, 'packages-internal'),
+            ],
+            exclude: /(node_modules|mui-icons-material)/,
+            use: options.defaultLoaders.babel,
+          },
+          {
+            resourceQuery: /raw/,
+            type: 'asset/source',
+          },
+        ]),
+      },
+    };
   },
   env: {
     // docs-infra
@@ -93,9 +252,9 @@ export default withDocsInfra({
   // Ensure CSS from the Data Grid packages is included in the build:
   // https://github.com/mui/mui-x/issues/17427#issuecomment-2813967605
   // `@mui/x-*` entries: keep their `@mui/material/*` subpath imports
-  // inside the bundler so the turbopack source aliases win; otherwise
-  // resolution falls back to the pnpm symlink (→ `packages/mui-material/build/`),
-  // which is empty unless the package has been built.
+  // inside the bundler so the source aliases above win; otherwise resolution
+  // falls back to the pnpm symlink (→ `packages/mui-material/build/`), which
+  // is empty unless the package has been built.
   transpilePackages: [
     '@mui/x-charts',
     '@mui/x-data-grid',

--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -85,10 +85,6 @@ function withDocsInfra(nextConfig) {
         : {}),
       ...nextConfig.experimental,
     },
-    eslint: {
-      ignoreDuringBuilds: true,
-      ...nextConfig.eslint,
-    },
     typescript: {
       // Motivated by https://github.com/vercel/next.js/issues/7687
       ignoreBuildErrors: true,

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,10 +3,11 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build && pnpm build-sw",
+    "build": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build --webpack && pnpm build-sw",
+    "build:turbopack": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build --turbopack && pnpm build-sw",
     "build:clean": "rimraf .next && pnpm build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
-    "dev": "next dev",
+    "dev": "next dev --turbopack",
     "deploy": "git fetch upstream master && git push -f material-ui-docs FETCH_HEAD:latest",
     "icons": "rimraf --glob public/static/icons/* && node ./scripts/buildIcons.js",
     "start": "serve ./export",
@@ -95,7 +96,8 @@
     "semver": "^7.7.4",
     "styled-components": "^6.4.1",
     "stylis": "catalog:docs",
-    "use-count-up": "^3.0.1"
+    "use-count-up": "^3.0.1",
+    "webpack-bundle-analyzer": "^5.3.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-react-constant-elements": "7.27.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -71,7 +71,7 @@
     "lz-string": "^1.5.0",
     "markdown-to-jsx": "^9.7.16",
     "material-ui-popup-state": "^5.3.7",
-    "next": "^16.2.6",
+    "next": "16.2.7",
     "notistack": "3.0.2",
     "nprogress": "^0.2.0",
     "postcss": "^8.5.14",
@@ -126,6 +126,7 @@
     "cross-fetch": "4.1.0",
     "gm": "1.25.1",
     "prettier": "3.8.3",
+    "raw-loader": "4.0.2",
     "tailwindcss": "4.2.4",
     "yargs": "18.0.0"
   }

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build && pnpm build-sw",
+    "build": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build --webpack && pnpm build-sw",
+    "build:turbopack": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build --turbopack && pnpm build-sw",
     "build:clean": "rimraf .next && pnpm build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "next dev",
@@ -70,7 +71,7 @@
     "lz-string": "^1.5.0",
     "markdown-to-jsx": "^9.7.16",
     "material-ui-popup-state": "^5.3.7",
-    "next": "^15.5.16",
+    "next": "^16.2.6",
     "notistack": "3.0.2",
     "nprogress": "^0.2.0",
     "postcss": "^8.5.14",

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,8 +3,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build --webpack && pnpm build-sw",
-    "build:turbopack": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build --turbopack && pnpm build-sw",
+    "build": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build && pnpm build-sw",
     "build:clean": "rimraf .next && pnpm build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "next dev",

--- a/docs/package.json
+++ b/docs/package.json
@@ -95,8 +95,7 @@
     "semver": "^7.7.4",
     "styled-components": "^6.4.1",
     "stylis": "catalog:docs",
-    "use-count-up": "^3.0.1",
-    "webpack-bundle-analyzer": "^5.3.0"
+    "use-count-up": "^3.0.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-react-constant-elements": "7.27.1",

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -46,6 +46,7 @@ import './global.css';
 // `export ... from`, or `import { x } from ...; export { x }`), causing
 // the global CSS imports above to be rejected. Re-export as a fresh local
 // binding to keep the file recognized as the Custom App.
+// Related issue - https://github.com/vercel/next.js/issues/93162
 export const fontClasses = _fontClasses;
 
 // Remove the license warning from demonstration purposes

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -5,7 +5,6 @@ import { AdConfig } from '@mui/internal-core-docs/Ad';
 import { SandboxConfig } from '@mui/internal-core-docs/DemoContext';
 import {
   DocsApp,
-  createGetInitialProps,
   printConsoleBanner,
   reportWebVitals as _reportWebVitals,
 } from '@mui/internal-core-docs/DocsApp';
@@ -38,6 +37,7 @@ import {
 
 import { fontClasses as _fontClasses } from '@mui/internal-core-docs/nextFonts';
 import versionsJson from '../versions.json';
+import translationsJson from '../translations/translations.json';
 import '../public/static/components-gallery/base-theme.css';
 import './global.css';
 
@@ -52,6 +52,12 @@ export const fontClasses = _fontClasses;
 LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUI_LICENSE!);
 
 printConsoleBanner();
+
+// Translations and versions are static, so resolve them once at module scope and
+// pass them straight to the page props. Doing this in `_app.getInitialProps`
+// would opt every page out of Next.js Automatic Static Optimization.
+const translations: Translations = { en: translationsJson };
+const allVersions = versionsJson.versions;
 
 const docsConfig: DocsConfig = {
   ...DEFAULT_DOCS_CONFIG,
@@ -285,10 +291,17 @@ function useDemoDisplayName() {
   }, [productId]);
 }
 
-export default function MyApp(
-  props: AppProps<{ userLanguage: string; translations: Translations; versions: VersionEntry[] }>,
-) {
-  const { Component, pageProps } = props;
+export default function MyApp(props: AppProps) {
+  const { Component } = props;
+  const pageProps = React.useMemo(
+    () => ({
+      userLanguage: 'en',
+      translations,
+      versions: allVersions,
+      ...props.pageProps,
+    }),
+    [props.pageProps],
+  );
   const {
     activePage,
     activePageParents,
@@ -318,11 +331,6 @@ export default function MyApp(
     />
   );
 }
-
-MyApp.getInitialProps = createGetInitialProps({
-  translationsContext: require.context('../translations', false, /\.\/translations.*\.json$/),
-  versions: versionsJson.versions,
-});
 
 // See note above about turbopack re-export detection — wrap rather than
 // `export { reportWebVitals }` so _app.tsx stays the Custom App.

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -7,7 +7,7 @@ import {
   DocsApp,
   createGetInitialProps,
   printConsoleBanner,
-  reportWebVitals,
+  reportWebVitals as _reportWebVitals,
 } from '@mui/internal-core-docs/DocsApp';
 import {
   DEFAULT_DOCS_CONFIG,
@@ -36,11 +36,17 @@ import {
   muiSvgWordmarkString,
 } from '@mui/internal-core-docs/svgIcons';
 
+import { fontClasses as _fontClasses } from '@mui/internal-core-docs/nextFonts';
 import versionsJson from '../versions.json';
 import '../public/static/components-gallery/base-theme.css';
 import './global.css';
 
-export { fontClasses } from '@mui/internal-core-docs/nextFonts';
+// Workaround: turbopack's pages-router Custom App detection misfires when
+// `_app.tsx` contains a re-export of an imported binding (either
+// `export ... from`, or `import { x } from ...; export { x }`), causing
+// the global CSS imports above to be rejected. Re-export as a fresh local
+// binding to keep the file recognized as the Custom App.
+export const fontClasses = _fontClasses;
 
 // Remove the license warning from demonstration purposes
 LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUI_LICENSE!);
@@ -318,4 +324,6 @@ MyApp.getInitialProps = createGetInitialProps({
   versions: versionsJson.versions,
 });
 
-export { reportWebVitals };
+// See note above about turbopack re-export detection — wrap rather than
+// `export { reportWebVitals }` so _app.tsx stays the Custom App.
+export const reportWebVitals: typeof _reportWebVitals = (...args) => _reportWebVitals(...args);

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "prettier": "3.8.3",
     "pretty-quick": "4.2.2",
     "process": "0.11.10",
-    "raw-loader": "^4.0.2",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "rimraf": "6.1.3",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@mui/internal-test-utils": "2.0.18-canary.23",
     "@mui/material": "workspace:^",
     "@mui/utils": "workspace:^",
-    "@next/eslint-plugin-next": "15.5.16",
+    "@next/eslint-plugin-next": "16.2.7",
     "@octokit/rest": "22.0.1",
     "@pigment-css/react": "0.0.30",
     "@playwright/test": "1.59.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "docs:deploy": "pnpm --filter docs run deploy",
     "docs:dev": "pnpm --filter docs dev",
     "docs:icons": "pnpm --filter docs icons",
-    "docs:size-why": "cross-env DOCS_STATS_ENABLED=true pnpm docs:build",
+    "docs:size-why": "cross-env DOCS_STATS_ENABLED=true pnpm -F docs exec next experimental-analyze",
     "docs:start": "pnpm --filter docs start",
     "docs:create-playground": "pnpm --filter docs create-playground",
     "docs:link-check": "pnpm --filter docs link-check",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "prettier": "3.8.3",
     "pretty-quick": "4.2.2",
     "process": "0.11.10",
+    "raw-loader": "^4.0.2",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "rimraf": "6.1.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "docs:deploy": "pnpm --filter docs run deploy",
     "docs:dev": "pnpm --filter docs dev",
     "docs:icons": "pnpm --filter docs icons",
-    "docs:size-why": "cross-env DOCS_STATS_ENABLED=true pnpm -F docs exec next experimental-analyze",
+    "docs:size-why": "cross-env DOCS_STATS_ENABLED=true pnpm docs:build",
     "docs:start": "pnpm --filter docs start",
     "docs:create-playground": "pnpm --filter docs create-playground",
     "docs:link-check": "pnpm --filter docs link-check",

--- a/packages-internal/markdown/loader.mjs
+++ b/packages-internal/markdown/loader.mjs
@@ -660,9 +660,19 @@ export default async function demoLoader() {
   );
 
   componentNames.forEach((componentName) => {
-    const moduleID = componentName.startsWith('@mui/internal-core-docs/')
-      ? componentName
-      : path.join(this.rootContext, 'src', componentName).replace(/\\/g, '/');
+    let moduleID;
+    if (componentName.startsWith('@mui/internal-core-docs/')) {
+      moduleID = componentName;
+    } else {
+      // Emit a relative path from the markdown file's directory. Turbopack
+      // rejects absolute paths emitted by loaders (interpreted as server-relative
+      // URLs); relative paths resolve correctly under both webpack and turbopack.
+      const componentAbsolute = path.join(this.rootContext, 'src', componentName);
+      const relative = path
+        .relative(path.dirname(this.resourcePath), componentAbsolute)
+        .replace(/\\/g, '/');
+      moduleID = relative.startsWith('.') ? relative : `./${relative}`;
+    }
 
     components[moduleID] = componentName;
     componentModuleIDs.add(moduleID);

--- a/packages/mui-material-nextjs/package.json
+++ b/packages/mui-material-nextjs/package.json
@@ -37,7 +37,7 @@
     "@emotion/react": "11.14.0",
     "@emotion/server": "11.11.0",
     "@types/react": "19.2.14",
-    "next": "15.5.16",
+    "next": "16.2.6",
     "react": "19.2.6"
   },
   "peerDependencies": {

--- a/packages/mui-material-nextjs/tsconfig.json
+++ b/packages/mui-material-nextjs/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["es2020", "es2024.promise", "dom", "dom.iterable"],
     "types": ["react", "vitest/globals", "node", "next"]
   },
   "include": ["src/**/*"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,9 +494,6 @@ importers:
       use-count-up:
         specifier: ^3.0.1
         version: 3.0.1(react@19.2.6)
-      webpack-bundle-analyzer:
-        specifier: ^5.3.0
-        version: 5.3.0
     devDependencies:
       '@babel/plugin-transform-react-constant-elements':
         specifier: 7.27.1
@@ -2533,10 +2530,6 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
-
-  '@discoveryjs/json-ext@0.6.3':
-    resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
-    engines: {node: '>=14.17.0'}
 
   '@docsearch/css@3.9.0':
     resolution: {integrity: sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==}
@@ -5797,10 +5790,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.2.0:
-    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
-    engines: {node: '>=0.4.0'}
-
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -6445,10 +6434,6 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
-
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -7895,9 +7880,6 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
-
-  html-escaper@3.0.3:
-    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
   html-tags@5.1.0:
     resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
@@ -9601,10 +9583,6 @@ packages:
 
   openapi-typescript-helpers@0.1.0:
     resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
-
-  opener@1.5.2:
-    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
-    hasBin: true
 
   optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
@@ -11741,11 +11719,6 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
-  webpack-bundle-analyzer@5.3.0:
-    resolution: {integrity: sha512-PEhAoqiJ+47d0uLMx/+zo5XOvaU+Vk6N2ZLht7H3n09QLy/fhyvqGNwjdRUHJDgMN8crBR2ZwVHkIswT3Xuawg==}
-    engines: {node: '>= 20.9.0'}
-    hasBin: true
-
   webpack-sources@3.5.0:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
     engines: {node: '>=10.13.0'}
@@ -13089,8 +13062,6 @@ snapshots:
 
   '@date-fns/tz@1.4.1':
     optional: true
-
-  '@discoveryjs/json-ext@0.6.3': {}
 
   '@docsearch/css@3.9.0': {}
 
@@ -16387,8 +16358,6 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  acorn-walk@8.2.0: {}
-
   acorn@8.16.0: {}
 
   add-stream@1.0.0: {}
@@ -17082,8 +17051,6 @@ snapshots:
   commander@10.0.1: {}
 
   commander@11.1.0: {}
-
-  commander@14.0.3: {}
 
   commander@2.20.3: {}
 
@@ -18782,8 +18749,6 @@ snapshots:
       whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
-
-  html-escaper@3.0.3: {}
 
   html-tags@5.1.0: {}
 
@@ -20930,8 +20895,6 @@ snapshots:
       openapi-typescript-helpers: 0.1.0
 
   openapi-typescript-helpers@0.1.0: {}
-
-  opener@1.5.2: {}
 
   optionator@0.9.3:
     dependencies:
@@ -23395,22 +23358,6 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
-
-  webpack-bundle-analyzer@5.3.0:
-    dependencies:
-      '@discoveryjs/json-ext': 0.6.3
-      acorn: 8.16.0
-      acorn-walk: 8.2.0
-      commander: 14.0.3
-      escape-string-regexp: 5.0.0
-      html-escaper: 3.0.3
-      opener: 1.5.2
-      picocolors: 1.1.1
-      sirv: 3.0.2
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   webpack-sources@3.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,9 +218,6 @@ importers:
       process:
         specifier: 0.11.10
         version: 0.11.10
-      raw-loader:
-        specifier: ^4.0.2
-        version: 4.0.2(webpack@5.107.1(esbuild@0.27.2)(lightningcss@1.32.0)(postcss@8.5.14))
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -417,8 +414,8 @@ importers:
         specifier: ^5.3.7
         version: 5.3.7(@mui/material@packages+mui-material+build)(@types/react@19.2.14)(react@19.2.6)
       next:
-        specifier: ^16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.8.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 16.2.7
+        version: 16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.8.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       notistack:
         specifier: 3.0.2
         version: 3.0.2(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -576,6 +573,9 @@ importers:
       prettier:
         specifier: 3.8.3
         version: 3.8.3
+      raw-loader:
+        specifier: 4.0.2
+        version: 4.0.2(webpack@5.107.1(esbuild@0.27.2)(lightningcss@1.32.0)(postcss@8.5.14))
       tailwindcss:
         specifier: 4.2.4
         version: 4.2.4
@@ -1560,7 +1560,7 @@ importers:
         version: link:../packages/mui-utils/build
       '@tailwindcss/vite':
         specifier: ^4.2.4
-        version: 4.3.0(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 4.3.0(vite@7.3.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -4073,6 +4073,9 @@ packages:
   '@next/env@16.2.6':
     resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
+  '@next/env@16.2.7':
+    resolution: {integrity: sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==}
+
   '@next/eslint-plugin-next@15.5.16':
     resolution: {integrity: sha512-pXa+4smRrgzea94YeAR8txf2CYg4pc1HkcoLUigrE5a0j70dVdUYMKfsOGCe8ulDSLvqnm2keMoxKss5RxHokg==}
 
@@ -4084,6 +4087,12 @@ packages:
 
   '@next/swc-darwin-arm64@16.2.6':
     resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-arm64@16.2.7':
+    resolution: {integrity: sha512-vm1EDI/pVaBNNiychmxk3fft+OhQPVD9cIM/tReLZIQ3TfQ4kqI9DwKk00dzuS1ulC7icbrzCFrmRRlk9PfNdw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -4100,6 +4109,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@next/swc-darwin-x64@16.2.7':
+    resolution: {integrity: sha512-O3IRSv1ZBL1zs0WrIgefTEcTKFVn+ryxBNe54erJ6KsD+2f/Mmt7g2jOYh8PSBdUwPtKQJuCsTMlZ7tIu2AcsQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@next/swc-linux-arm64-gnu@15.5.16':
     resolution: {integrity: sha512-Jl0IL9P7S8uNl5oI1TqrQmfmLp7OqjWM58000pVnUVIsHrvPP6m9QDW/uNWYUbmd+8IYvc6MTeZKICstBMBpew==}
     engines: {node: '>= 10'}
@@ -4109,6 +4124,13 @@ packages:
 
   '@next/swc-linux-arm64-gnu@16.2.6':
     resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-gnu@16.2.7':
+    resolution: {integrity: sha512-Re6PZtjBDd0aMU+VcZcC/PrIvj4WhrjDYtMhhCVQamWN4L90EVP0pcEOBQD25prSlw7OzNw5QpHLWMilRLsRNw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -4128,6 +4150,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-arm64-musl@16.2.7':
+    resolution: {integrity: sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@next/swc-linux-x64-gnu@15.5.16':
     resolution: {integrity: sha512-HCDDU1TRLeUDV180QQTWrs5Oa4lIcI7XH9nF0UVUVmYLN/boZ6LqyFtm3814gc1fv+lOVyKaw5B6bVC9BpXTSQ==}
     engines: {node: '>= 10'}
@@ -4137,6 +4166,13 @@ packages:
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-gnu@16.2.7':
+    resolution: {integrity: sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -4156,6 +4192,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-x64-musl@16.2.7':
+    resolution: {integrity: sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@next/swc-win32-arm64-msvc@15.5.16':
     resolution: {integrity: sha512-zpOQuF+eyENMXRjglp2hZCIrUjTdO37suEBnDn1mX4PXSuetXZDMLpjKOh4dYSw3SiDTnOoOUwBl5i5Elr6nnQ==}
     engines: {node: '>= 10'}
@@ -4168,6 +4211,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@next/swc-win32-arm64-msvc@16.2.7':
+    resolution: {integrity: sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@next/swc-win32-x64-msvc@15.5.16':
     resolution: {integrity: sha512-LnwKYpiSmIzXlTq76hMeeIzZoDcFwu848p6H+QBkGFJIbZphgzNUPdHruJcHM/bFnaFeco0l1Frie5I27VKglA==}
     engines: {node: '>= 10'}
@@ -4176,6 +4225,12 @@ packages:
 
   '@next/swc-win32-x64-msvc@16.2.6':
     resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.2.7':
+    resolution: {integrity: sha512-J4WlM72NMk076Qsg0jTdK3SNXatlSdnjW7L7oNGLst1tAGjHrJh/FYi+pw9wyIjEtGRKDNzD0zuiY16oWYWVaw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -9313,6 +9368,27 @@ packages:
 
   next@16.2.6:
     resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  next@16.2.7:
+    resolution: {integrity: sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -14645,6 +14721,8 @@ snapshots:
 
   '@next/env@16.2.6': {}
 
+  '@next/env@16.2.7': {}
+
   '@next/eslint-plugin-next@15.5.16':
     dependencies:
       fast-glob: 3.3.1
@@ -14655,10 +14733,16 @@ snapshots:
   '@next/swc-darwin-arm64@16.2.6':
     optional: true
 
+  '@next/swc-darwin-arm64@16.2.7':
+    optional: true
+
   '@next/swc-darwin-x64@15.5.16':
     optional: true
 
   '@next/swc-darwin-x64@16.2.6':
+    optional: true
+
+  '@next/swc-darwin-x64@16.2.7':
     optional: true
 
   '@next/swc-linux-arm64-gnu@15.5.16':
@@ -14667,10 +14751,16 @@ snapshots:
   '@next/swc-linux-arm64-gnu@16.2.6':
     optional: true
 
+  '@next/swc-linux-arm64-gnu@16.2.7':
+    optional: true
+
   '@next/swc-linux-arm64-musl@15.5.16':
     optional: true
 
   '@next/swc-linux-arm64-musl@16.2.6':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.2.7':
     optional: true
 
   '@next/swc-linux-x64-gnu@15.5.16':
@@ -14679,10 +14769,16 @@ snapshots:
   '@next/swc-linux-x64-gnu@16.2.6':
     optional: true
 
+  '@next/swc-linux-x64-gnu@16.2.7':
+    optional: true
+
   '@next/swc-linux-x64-musl@15.5.16':
     optional: true
 
   '@next/swc-linux-x64-musl@16.2.6':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.2.7':
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.5.16':
@@ -14691,10 +14787,16 @@ snapshots:
   '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
+  '@next/swc-win32-arm64-msvc@16.2.7':
+    optional: true
+
   '@next/swc-win32-x64-msvc@15.5.16':
     optional: true
 
   '@next/swc-win32-x64-msvc@16.2.6':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.2.7':
     optional: true
 
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
@@ -15599,12 +15701,12 @@ snapshots:
       postcss: 8.5.14
       tailwindcss: 4.2.4
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@tailwindcss/vite@4.3.0(vite@7.3.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.10(@types/node@20.19.39)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 7.3.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0)
 
   '@tanstack/query-core@5.100.9': {}
 
@@ -20521,6 +20623,33 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
+      '@opentelemetry/api': 1.8.0
+      '@playwright/test': 1.59.1
+      babel-plugin-react-compiler: 1.0.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.8.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@next/env': 16.2.7
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001792
+      postcss: 8.4.31
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@19.2.6)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.7
+      '@next/swc-darwin-x64': 16.2.7
+      '@next/swc-linux-arm64-gnu': 16.2.7
+      '@next/swc-linux-arm64-musl': 16.2.7
+      '@next/swc-linux-x64-gnu': 16.2.7
+      '@next/swc-linux-x64-musl': 16.2.7
+      '@next/swc-win32-arm64-msvc': 16.2.7
+      '@next/swc-win32-x64-msvc': 16.2.7
       '@opentelemetry/api': 1.8.0
       '@playwright/test': 1.59.1
       babel-plugin-react-compiler: 1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,6 +494,9 @@ importers:
       use-count-up:
         specifier: ^3.0.1
         version: 3.0.1(react@19.2.6)
+      webpack-bundle-analyzer:
+        specifier: ^5.3.0
+        version: 5.3.0
     devDependencies:
       '@babel/plugin-transform-react-constant-elements':
         specifier: 7.27.1
@@ -2530,6 +2533,10 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@discoveryjs/json-ext@0.6.3':
+    resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
+    engines: {node: '>=14.17.0'}
 
   '@docsearch/css@3.9.0':
     resolution: {integrity: sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==}
@@ -5790,6 +5797,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -6434,6 +6445,10 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -7880,6 +7895,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
   html-tags@5.1.0:
     resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
@@ -9583,6 +9601,10 @@ packages:
 
   openapi-typescript-helpers@0.1.0:
     resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
+
+  opener@1.5.2:
+    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
+    hasBin: true
 
   optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
@@ -11719,6 +11741,11 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
+  webpack-bundle-analyzer@5.3.0:
+    resolution: {integrity: sha512-PEhAoqiJ+47d0uLMx/+zo5XOvaU+Vk6N2ZLht7H3n09QLy/fhyvqGNwjdRUHJDgMN8crBR2ZwVHkIswT3Xuawg==}
+    engines: {node: '>= 20.9.0'}
+    hasBin: true
+
   webpack-sources@3.5.0:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
     engines: {node: '>=10.13.0'}
@@ -13062,6 +13089,8 @@ snapshots:
 
   '@date-fns/tz@1.4.1':
     optional: true
+
+  '@discoveryjs/json-ext@0.6.3': {}
 
   '@docsearch/css@3.9.0': {}
 
@@ -16358,6 +16387,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.16.0: {}
 
   add-stream@1.0.0: {}
@@ -17051,6 +17084,8 @@ snapshots:
   commander@10.0.1: {}
 
   commander@11.1.0: {}
+
+  commander@14.0.3: {}
 
   commander@2.20.3: {}
 
@@ -18749,6 +18784,8 @@ snapshots:
       whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
+
+  html-escaper@3.0.3: {}
 
   html-tags@5.1.0: {}
 
@@ -20895,6 +20932,8 @@ snapshots:
       openapi-typescript-helpers: 0.1.0
 
   openapi-typescript-helpers@0.1.0: {}
+
+  opener@1.5.2: {}
 
   optionator@0.9.3:
     dependencies:
@@ -23358,6 +23397,22 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
+
+  webpack-bundle-analyzer@5.3.0:
+    dependencies:
+      '@discoveryjs/json-ext': 0.6.3
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      commander: 14.0.3
+      escape-string-regexp: 5.0.0
+      html-escaper: 3.0.3
+      opener: 1.5.2
+      picocolors: 1.1.1
+      sirv: 3.0.2
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   webpack-sources@3.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 1.0.9-canary.78(@types/node@20.19.39)(esbuild@0.27.2)(jiti@2.6.1)(rolldown@1.0.0-rc.17)(rollup@4.46.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0)
       '@mui/internal-code-infra':
         specifier: 0.0.4-canary.50
-        version: 0.0.4-canary.50(@next/eslint-plugin-next@15.5.16)(@types/node@20.19.39)(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(jest-diff@30.2.0)(postcss@8.5.14)(prettier@3.8.3)(stylelint@17.11.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.0.13)
+        version: 0.0.4-canary.50(@next/eslint-plugin-next@16.2.7)(@types/node@20.19.39)(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(jest-diff@30.2.0)(postcss@8.5.14)(prettier@3.8.3)(stylelint@17.11.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.0.13)
       '@mui/internal-docs-utils':
         specifier: workspace:^
         version: link:packages-internal/docs-utils/build
@@ -111,8 +111,8 @@ importers:
         specifier: workspace:^
         version: link:packages/mui-utils/build
       '@next/eslint-plugin-next':
-        specifier: 15.5.16
-        version: 15.5.16
+        specifier: 16.2.7
+        version: 16.2.7
       '@octokit/rest':
         specifier: 22.0.1
         version: 22.0.1
@@ -4082,8 +4082,8 @@ packages:
   '@next/env@16.2.7':
     resolution: {integrity: sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==}
 
-  '@next/eslint-plugin-next@15.5.16':
-    resolution: {integrity: sha512-pXa+4smRrgzea94YeAR8txf2CYg4pc1HkcoLUigrE5a0j70dVdUYMKfsOGCe8ulDSLvqnm2keMoxKss5RxHokg==}
+  '@next/eslint-plugin-next@16.2.7':
+    resolution: {integrity: sha512-VbS+QgMHqvIDMTIqD2xMBKK1otIpdAUKA8VLHFwR9h6OfU/mOm7w/69nQcvdmI8hCk99Wr2AsGLn/PJ/tMHw1w==}
 
   '@next/swc-darwin-arm64@15.5.16':
     resolution: {integrity: sha512-wzdER4JZj+31vNkhaZ1Ght3IsNI8DMwj7VqadfIOqJB5sh8FiOqNSopYADQn6mgEPomzDd/DHqBcfo2fmVMYtg==}
@@ -13949,7 +13949,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@mui/internal-code-infra@0.0.4-canary.50(@next/eslint-plugin-next@15.5.16)(@types/node@20.19.39)(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(jest-diff@30.2.0)(postcss@8.5.14)(prettier@3.8.3)(stylelint@17.11.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.0.13)':
+  '@mui/internal-code-infra@0.0.4-canary.50(@next/eslint-plugin-next@16.2.7)(@types/node@20.19.39)(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(jest-diff@30.2.0)(postcss@8.5.14)(prettier@3.8.3)(stylelint@17.11.0(typescript@6.0.3))(typescript@6.0.3)(vitest@4.0.13)':
     dependencies:
       '@argos-ci/core': 6.0.0
       '@babel/cli': 7.28.6(@babel/core@7.29.0)
@@ -13970,7 +13970,7 @@ snapshots:
       '@mui/internal-babel-plugin-minify-errors': 2.0.8-canary.27(@babel/core@7.29.0)
       '@mui/internal-babel-plugin-resolve-imports': 2.0.7-canary.36(@babel/core@7.29.0)
       '@napi-rs/keyring': 1.3.0
-      '@next/eslint-plugin-next': 15.5.16
+      '@next/eslint-plugin-next': 16.2.7
       '@octokit/auth-action': 6.0.2
       '@octokit/oauth-methods': 6.0.2
       '@octokit/rest': 22.0.1
@@ -14742,7 +14742,7 @@ snapshots:
 
   '@next/env@16.2.7': {}
 
-  '@next/eslint-plugin-next@15.5.16':
+  '@next/eslint-plugin-next@16.2.7':
     dependencies:
       fast-glob: 3.3.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       process:
         specifier: 0.11.10
         version: 0.11.10
+      raw-loader:
+        specifier: ^4.0.2
+        version: 4.0.2(webpack@5.107.1(esbuild@0.27.2)(lightningcss@1.32.0)(postcss@8.5.14))
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -414,8 +417,8 @@ importers:
         specifier: ^5.3.7
         version: 5.3.7(@mui/material@packages+mui-material+build)(@types/react@19.2.14)(react@19.2.6)
       next:
-        specifier: ^15.5.16
-        version: 15.5.16(@babel/core@7.29.0)(@opentelemetry/api@1.8.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^16.2.6
+        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.8.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       notistack:
         specifier: 3.0.2
         version: 3.0.2(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1220,8 +1223,8 @@ importers:
         specifier: 19.2.14
         version: 19.2.14
       next:
-        specifier: 15.5.16
-        version: 15.5.16(@babel/core@7.29.0)(@opentelemetry/api@1.8.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 16.2.6
+        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.8.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1557,7 +1560,7 @@ importers:
         version: link:../packages/mui-utils/build
       '@tailwindcss/vite':
         specifier: ^4.2.4
-        version: 4.3.0(vite@7.3.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))
+        version: 4.3.0(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -4067,11 +4070,20 @@ packages:
   '@next/env@15.5.16':
     resolution: {integrity: sha512-9QMKolCl+JnJtaRAQSXy4RQrhgfe8W7/G1+Hl3QSB/HZY7zQMzTwPDdTRwwio8BS96ps1MHpHhbS8qxoNV3JIQ==}
 
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
+
   '@next/eslint-plugin-next@15.5.16':
     resolution: {integrity: sha512-pXa+4smRrgzea94YeAR8txf2CYg4pc1HkcoLUigrE5a0j70dVdUYMKfsOGCe8ulDSLvqnm2keMoxKss5RxHokg==}
 
   '@next/swc-darwin-arm64@15.5.16':
     resolution: {integrity: sha512-wzdER4JZj+31vNkhaZ1Ght3IsNI8DMwj7VqadfIOqJB5sh8FiOqNSopYADQn6mgEPomzDd/DHqBcfo2fmVMYtg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -4082,8 +4094,21 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@next/swc-linux-arm64-gnu@15.5.16':
     resolution: {integrity: sha512-Jl0IL9P7S8uNl5oI1TqrQmfmLp7OqjWM58000pVnUVIsHrvPP6m9QDW/uNWYUbmd+8IYvc6MTeZKICstBMBpew==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -4096,8 +4121,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@next/swc-linux-x64-gnu@15.5.16':
     resolution: {integrity: sha512-HCDDU1TRLeUDV180QQTWrs5Oa4lIcI7XH9nF0UVUVmYLN/boZ6LqyFtm3814gc1fv+lOVyKaw5B6bVC9BpXTSQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -4110,14 +4149,33 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@next/swc-win32-arm64-msvc@15.5.16':
     resolution: {integrity: sha512-zpOQuF+eyENMXRjglp2hZCIrUjTdO37suEBnDn1mX4PXSuetXZDMLpjKOh4dYSw3SiDTnOoOUwBl5i5Elr6nnQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@next/swc-win32-x64-msvc@15.5.16':
     resolution: {integrity: sha512-LnwKYpiSmIzXlTq76hMeeIzZoDcFwu848p6H+QBkGFJIbZphgzNUPdHruJcHM/bFnaFeco0l1Frie5I27VKglA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -5627,6 +5685,51 @@ packages:
   '@vitest/utils@4.0.15':
     resolution: {integrity: sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA==}
 
+  '@webassemblyjs/ast@1.14.1':
+    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2':
+    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
+
+  '@webassemblyjs/helper-api-error@1.13.2':
+    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
+
+  '@webassemblyjs/helper-buffer@1.14.1':
+    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
+    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
+
+  '@webassemblyjs/ieee754@1.13.2':
+    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
+
+  '@webassemblyjs/leb128@1.13.2':
+    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
+
+  '@webassemblyjs/utf8@1.13.2':
+    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
   '@wyw-in-js/processor-utils@0.5.5':
     resolution: {integrity: sha512-L3IcAfoowhM0fw9Cnv2CNzfjWNLKpYl2CFqam6NvwpiXNR1kXz/GpO0AOiKvCs5h4Ps5kWxE2e8knXLpk8q/2g==}
     engines: {node: '>=16.0.0'}
@@ -5638,6 +5741,12 @@ packages:
   '@wyw-in-js/transform@0.5.5':
     resolution: {integrity: sha512-XMZjhS8poHpxfPg41rkc6eh3Mr2BZAFM7OzYN4jPZUicpJKv7uQAU2dLEqnyDcDllo04LbZIryb2fXwpr+pqPw==}
     engines: {node: '>=16.0.0'}
+
+  '@xtuc/ieee754@1.2.0':
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+
+  '@xtuc/long@4.2.2':
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
@@ -5677,6 +5786,12 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      acorn: ^8.14.0
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -5701,6 +5816,24 @@ packages:
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
+
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-keywords@3.5.2:
+    resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
+    peerDependencies:
+      ajv: ^6.9.1
+
+  ajv-keywords@5.1.0:
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -5968,8 +6101,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.9.11:
-    resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
+  baseline-browser-mapping@2.10.32:
+    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   before-after-hook@2.2.3:
@@ -5980,6 +6114,9 @@ packages:
 
   bezier-easing@2.1.0:
     resolution: {integrity: sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==}
+
+  big.js@5.2.2:
+    resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
   bin-links@5.0.0:
     resolution: {integrity: sha512-sdleLVfCjBtgO5cNjA2HVRvWBJAHs4zwenaCPMNJAJU0yNxpzj80IpjOIimkpkr+mhlA+how5poQtt53PygbHA==}
@@ -6163,6 +6300,10 @@ packages:
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  chrome-trace-event@1.0.4:
+    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
+    engines: {node: '>=6.0'}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -6856,6 +6997,10 @@ packages:
   emojilib@2.4.0:
     resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
 
+  emojis-list@3.0.0:
+    resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
+    engines: {node: '>= 4'}
+
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
@@ -6935,6 +7080,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -7102,6 +7250,10 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -7147,6 +7299,10 @@ packages:
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
@@ -7550,6 +7706,9 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -8242,6 +8401,10 @@ packages:
     resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-worker@27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
+    engines: {node: '>= 10.13.0'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -8553,6 +8716,14 @@ packages:
 
   load-plugin@6.0.3:
     resolution: {integrity: sha512-kc0X2FEUZr145odl68frm+lMJuQ23+rTXYmR6TImqPtbpmXC4vVXbWKDQ9IzndA0HfyQamWfKLhzsqGSTxE63w==}
+
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
+    engines: {node: '>=6.11.5'}
+
+  loader-utils@2.0.4:
+    resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
+    engines: {node: '>=8.9.0'}
 
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
@@ -9122,6 +9293,27 @@ packages:
   next@15.5.16:
     resolution: {integrity: sha512-aZExBk/V6JCu3NCFc90twdj9L/M3y0+ukeQwUAZbOiqRhAX+h2oMEa0NZFhcpj6HYRYjVS3V2/3xvyOpNnmw7A==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
+    engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -9946,6 +10138,12 @@ packages:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
+  raw-loader@4.0.2:
+    resolution: {integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -10406,6 +10604,14 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  schema-utils@3.3.0:
+    resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
+    engines: {node: '>= 10.13.0'}
+
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
+    engines: {node: '>= 10.13.0'}
 
   search-insights@2.13.0:
     resolution: {integrity: sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==}
@@ -10902,6 +11108,49 @@ packages:
   tar@7.5.11:
     resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
     engines: {node: '>=18'}
+
+  terser-webpack-plugin@5.6.0:
+    resolution: {integrity: sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@minify-html/node': '*'
+      '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
+      esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
+      '@swc/core':
+        optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
+      esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
+        optional: true
+      uglify-js:
+        optional: true
 
   terser@5.39.0:
     resolution: {integrity: sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==}
@@ -11475,6 +11724,10 @@ packages:
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
+  watchpack@2.5.1:
+    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
+    engines: {node: '>=10.13.0'}
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -11492,6 +11745,20 @@ packages:
     resolution: {integrity: sha512-PEhAoqiJ+47d0uLMx/+zo5XOvaU+Vk6N2ZLht7H3n09QLy/fhyvqGNwjdRUHJDgMN8crBR2ZwVHkIswT3Xuawg==}
     engines: {node: '>= 20.9.0'}
     hasBin: true
+
+  webpack-sources@3.5.0:
+    resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
+    engines: {node: '>=10.13.0'}
+
+  webpack@5.107.1:
+    resolution: {integrity: sha512-mvdIWxj/H6QsfgDdH9djne3a5dYcmEmtsXGESkypaGN5jXjF/b+9KDlmTDQ2TKlFUeA2fI9Y65kihD30JOdB+Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -13446,7 +13713,6 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-    optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -14377,6 +14643,8 @@ snapshots:
 
   '@next/env@15.5.16': {}
 
+  '@next/env@16.2.6': {}
+
   '@next/eslint-plugin-next@15.5.16':
     dependencies:
       fast-glob: 3.3.1
@@ -14384,25 +14652,49 @@ snapshots:
   '@next/swc-darwin-arm64@15.5.16':
     optional: true
 
+  '@next/swc-darwin-arm64@16.2.6':
+    optional: true
+
   '@next/swc-darwin-x64@15.5.16':
+    optional: true
+
+  '@next/swc-darwin-x64@16.2.6':
     optional: true
 
   '@next/swc-linux-arm64-gnu@15.5.16':
     optional: true
 
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    optional: true
+
   '@next/swc-linux-arm64-musl@15.5.16':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
   '@next/swc-linux-x64-gnu@15.5.16':
     optional: true
 
+  '@next/swc-linux-x64-gnu@16.2.6':
+    optional: true
+
   '@next/swc-linux-x64-musl@15.5.16':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.5.16':
     optional: true
 
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    optional: true
+
   '@next/swc-win32-x64-msvc@15.5.16':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
@@ -15307,12 +15599,12 @@ snapshots:
       postcss: 8.5.14
       tailwindcss: 4.2.4
 
-  '@tailwindcss/vite@4.3.0(vite@7.3.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 7.3.1(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0)
+      vite: 8.0.10(@types/node@20.19.39)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0)
 
   '@tanstack/query-core@5.100.9': {}
 
@@ -15938,6 +16230,82 @@ snapshots:
       '@vitest/pretty-format': 4.0.15
       tinyrainbow: 3.1.0
 
+  '@webassemblyjs/ast@1.14.1':
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
+
+  '@webassemblyjs/helper-api-error@1.13.2': {}
+
+  '@webassemblyjs/helper-buffer@1.14.1': {}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.13.2
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/wasm-gen': 1.14.1
+
+  '@webassemblyjs/ieee754@1.13.2':
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+
+  '@webassemblyjs/leb128@1.13.2':
+    dependencies:
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/utf8@1.13.2': {}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/helper-wasm-section': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-opt': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      '@webassemblyjs/wast-printer': 1.14.1
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@xtuc/long': 4.2.2
+
   '@wyw-in-js/processor-utils@0.5.5':
     dependencies:
       '@babel/generator': 7.29.1
@@ -15974,6 +16342,10 @@ snapshots:
       - supports-color
       - typescript
 
+  '@xtuc/ieee754@1.2.0': {}
+
+  '@xtuc/long@4.2.2': {}
+
   '@yarnpkg/lockfile@1.1.0': {}
 
   '@yarnpkg/parsers@3.0.2':
@@ -16007,6 +16379,10 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn-import-phases@1.0.4(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -16023,6 +16399,19 @@ snapshots:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
+
+  ajv-formats@2.1.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv-keywords@3.5.2(ajv@6.14.0):
+    dependencies:
+      ajv: 6.14.0
+
+  ajv-keywords@5.1.0(ajv@8.18.0):
+    dependencies:
+      ajv: 8.18.0
+      fast-deep-equal: 3.1.3
 
   ajv@6.14.0:
     dependencies:
@@ -16350,13 +16739,15 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.9.11: {}
+  baseline-browser-mapping@2.10.32: {}
 
   before-after-hook@2.2.3: {}
 
   before-after-hook@4.0.0: {}
 
   bezier-easing@2.1.0: {}
+
+  big.js@5.2.2: {}
 
   bin-links@5.0.0:
     dependencies:
@@ -16423,7 +16814,7 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.9.11
+      baseline-browser-mapping: 2.10.32
       caniuse-lite: 1.0.30001792
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
@@ -16567,6 +16958,8 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  chrome-trace-event@1.0.4: {}
+
   ci-info@3.9.0: {}
 
   ci-info@4.3.1: {}
@@ -16692,8 +17085,7 @@ snapshots:
 
   commander@14.0.3: {}
 
-  commander@2.20.3:
-    optional: true
+  commander@2.20.3: {}
 
   commander@4.1.1: {}
 
@@ -17227,6 +17619,8 @@ snapshots:
 
   emojilib@2.4.0: {}
 
+  emojis-list@3.0.0: {}
+
   encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
@@ -17355,6 +17749,8 @@ snapshots:
       safe-array-concat: 1.1.3
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -17624,6 +18020,11 @@ snapshots:
       - supports-color
       - typescript
 
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
@@ -17695,6 +18096,8 @@ snapshots:
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
+
+  estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
 
@@ -18167,6 +18570,8 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob-to-regexp@0.4.1: {}
 
   glob@10.5.0:
     dependencies:
@@ -18825,6 +19230,12 @@ snapshots:
 
   jest-get-type@29.6.3: {}
 
+  jest-worker@27.5.1:
+    dependencies:
+      '@types/node': 20.19.39
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
   jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
@@ -19240,6 +19651,14 @@ snapshots:
       import-meta-resolve: 4.2.0
     transitivePeerDependencies:
       - bluebird
+
+  loader-runner@4.3.2: {}
+
+  loader-utils@2.0.4:
+    dependencies:
+      big.js: 5.2.2
+      emojis-list: 3.0.0
+      json5: 2.2.3
 
   locate-path@2.0.0:
     dependencies:
@@ -20073,6 +20492,33 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.16
       '@next/swc-win32-arm64-msvc': 15.5.16
       '@next/swc-win32-x64-msvc': 15.5.16
+      '@opentelemetry/api': 1.8.0
+      '@playwright/test': 1.59.1
+      babel-plugin-react-compiler: 1.0.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.8.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@next/env': 16.2.6
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001792
+      postcss: 8.4.31
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@19.2.6)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
       '@opentelemetry/api': 1.8.0
       '@playwright/test': 1.59.1
       babel-plugin-react-compiler: 1.0.0
@@ -21011,6 +21457,12 @@ snapshots:
       iconv-lite: 0.6.3
       unpipe: 1.0.0
 
+  raw-loader@4.0.2(webpack@5.107.1(esbuild@0.27.2)(lightningcss@1.32.0)(postcss@8.5.14)):
+    dependencies:
+      loader-utils: 2.0.4
+      schema-utils: 3.3.0
+      webpack: 5.107.1(esbuild@0.27.2)(lightningcss@1.32.0)(postcss@8.5.14)
+
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -21692,6 +22144,19 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  schema-utils@3.3.0:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 6.14.0
+      ajv-keywords: 3.5.2(ajv@6.14.0)
+
+  schema-utils@4.3.3:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv-keywords: 5.1.0(ajv@8.18.0)
+
   search-insights@2.13.0: {}
 
   semver@5.7.2: {}
@@ -22314,13 +22779,24 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  terser-webpack-plugin@5.6.0(esbuild@0.27.2)(lightningcss@1.32.0)(postcss@8.5.14)(webpack@5.107.1(esbuild@0.27.2)(lightningcss@1.32.0)(postcss@8.5.14)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.39.0
+      webpack: 5.107.1(esbuild@0.27.2)(lightningcss@1.32.0)(postcss@8.5.14)
+    optionalDependencies:
+      esbuild: 0.27.2
+      lightningcss: 1.32.0
+      postcss: 8.5.14
+
   terser@5.39.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
-    optional: true
 
   text-decoder@1.2.3:
     dependencies:
@@ -22905,6 +23381,11 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  watchpack@2.5.1:
+    dependencies:
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.3
@@ -22930,6 +23411,47 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  webpack-sources@3.5.0: {}
+
+  webpack@5.107.1(esbuild@0.27.2)(lightningcss@1.32.0)(postcss@8.5.14):
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.22.0
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.0(esbuild@0.27.2)(lightningcss@1.32.0)(postcss@8.5.14)(webpack@5.107.1(esbuild@0.27.2)(lightningcss@1.32.0)(postcss@8.5.14))
+      watchpack: 2.5.1
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
 
   whatwg-encoding@3.1.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -728,10 +728,10 @@ importers:
         version: 7.3.8(stylis@4.2.0)
       '@mui/system':
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^9.0.0 || ^9.0.0-alpha || ^9.0.0-beta
-        version: 9.0.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
+        version: 9.1.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@mui/utils':
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^9.0.0 || ^9.0.0-alpha || ^9.0.0-beta
-        version: 9.0.1(@types/react@19.2.14)(react@19.2.6)
+        version: 9.1.0(@types/react@19.2.14)(react@19.2.6)
       '@types/stylis':
         specifier: ^4.2.7
         version: 4.2.7
@@ -985,7 +985,7 @@ importers:
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@mui/material':
         specifier: 9.0.0
-        version: 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@mui/material-pigment-css@9.1.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@pigment-css/react@0.0.30(@types/react@19.2.14)(react@19.2.6)(typescript@6.0.3))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -3433,6 +3433,12 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/material-pigment-css@9.1.0':
+    resolution: {integrity: sha512-y1z8sVrxdm7OD7hQ4HqbiG6uUlj3kxq6RdwrTQcZzz7pruugjfB4pVW9JS3C+BCGfM6Yzz0RxLZ4HLVJt2QpYQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@pigment-css/react': 0.0.30
+
   '@mui/material@5.18.0':
     resolution: {integrity: sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==}
     engines: {node: '>=12.0.0'}
@@ -3490,8 +3496,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/private-theming@9.0.1':
-    resolution: {integrity: sha512-pSIGq4Yw749KHEwlkYZWVERgHgwJELP6ODtBNUfV8V4oIb5H+h7IQDFXuk/b2oQccODK1enJAtiEzlgLZmq+8g==}
+  '@mui/private-theming@9.1.0':
+    resolution: {integrity: sha512-U/5n2BcqAQ6gNehYqjuyRY8pHx5/TmWk2r5kpHJ/8F+YE+QomVXGJXK/ozsIRy760LQkVxWWVFcSa+sIFquV/g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3526,8 +3532,8 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/styled-engine@9.0.0':
-    resolution: {integrity: sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==}
+  '@mui/styled-engine@9.1.0':
+    resolution: {integrity: sha512-kRplQAga6cQ5uKwJEAh6Mx/NLxnK2Zitas5B1osv1y2MAX97OV/5BTupEBYDbAbTwo4d+t+aDa5CqeGvSpxXgw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.4.1
@@ -3577,8 +3583,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/system@9.0.1':
-    resolution: {integrity: sha512-WvlioaLxk6ewUIOfh0StxUvOPDS1mCfzaulcudsL1brZNXuh0N9FMk7RpH7ImJKjEz412SEy/V/yvqmtxbqxCQ==}
+  '@mui/system@9.1.0':
+    resolution: {integrity: sha512-zZExEpvOpvE/XuhLN9fABOVngR8KInCRwcEPI7cQBccqen6nkMyZWhiKf3GQ+3WHreAVLqbGYJwUSXGPGHrcmg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -3647,8 +3653,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/utils@9.0.1':
-    resolution: {integrity: sha512-f3UO3jNN1pYg5zxqXC81Bvv8hx5ACcYc0387382ZI7M5ono1heIwHYLrKsz85myguWdeVKPRZGmDdynWUBjK2g==}
+  '@mui/utils@9.1.0':
+    resolution: {integrity: sha512-ECZGCOdL+CtYrvfBsRx/gb0zSQjXIpAPF6Uk/0EHgGysHnedK1HBfONsOqCOsdPB59rv8S52U/8aVoNlO/c9jQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -14094,6 +14100,18 @@ snapshots:
       '@emotion/server': 11.11.0(@emotion/css@11.13.4)
       '@types/react': 19.2.14
 
+  '@mui/material-pigment-css@9.1.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@pigment-css/react@0.0.30(@types/react@19.2.14)(react@19.2.6)(typescript@6.0.3))(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@mui/system': 9.1.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
+      '@pigment-css/react': 0.0.30(@types/react@19.2.14)(react@19.2.6)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@emotion/react'
+      - '@emotion/styled'
+      - '@types/react'
+      - react
+    optional: true
+
   '@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -14115,13 +14133,13 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@types/react': 19.2.14
 
-  '@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@mui/material-pigment-css@9.1.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@pigment-css/react@0.0.30(@types/react@19.2.14)(react@19.2.6)(typescript@6.0.3))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@mui/core-downloads-tracker': 9.0.0
-      '@mui/system': 9.0.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
+      '@mui/system': 9.1.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@mui/types': 9.0.0(@types/react@19.2.14)
-      '@mui/utils': 9.0.1(@types/react@19.2.14)(react@19.2.6)
+      '@mui/utils': 9.1.0(@types/react@19.2.14)(react@19.2.6)
       '@popperjs/core': 2.11.8
       '@types/react-transition-group': 4.4.12(@types/react@19.2.14)
       clsx: 2.1.1
@@ -14134,6 +14152,7 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
+      '@mui/material-pigment-css': 9.1.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@pigment-css/react@0.0.30(@types/react@19.2.14)(react@19.2.6)(typescript@6.0.3))(@types/react@19.2.14)(react@19.2.6)
       '@types/react': 19.2.14
 
   '@mui/private-theming@5.17.1(@types/react@19.2.14)(react@19.2.6)':
@@ -14154,10 +14173,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@mui/private-theming@9.0.1(@types/react@19.2.14)(react@19.2.6)':
+  '@mui/private-theming@9.1.0(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@mui/utils': 9.0.1(@types/react@19.2.14)(react@19.2.6)
+      '@mui/utils': 9.1.0(@types/react@19.2.14)(react@19.2.6)
       prop-types: 15.8.1
       react: 19.2.6
     optionalDependencies:
@@ -14188,7 +14207,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
 
-  '@mui/styled-engine@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
+  '@mui/styled-engine@9.1.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@emotion/cache': 11.14.0
@@ -14239,13 +14258,13 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@types/react': 19.2.14
 
-  '@mui/system@9.0.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)':
+  '@mui/system@9.1.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@mui/private-theming': 9.0.1(@types/react@19.2.14)(react@19.2.6)
-      '@mui/styled-engine': 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      '@mui/private-theming': 9.1.0(@types/react@19.2.14)(react@19.2.6)
+      '@mui/styled-engine': 9.1.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@mui/types': 9.0.0(@types/react@19.2.14)
-      '@mui/utils': 9.0.1(@types/react@19.2.14)(react@19.2.6)
+      '@mui/utils': 9.1.0(@types/react@19.2.14)(react@19.2.6)
       clsx: 2.1.1
       csstype: 3.2.3
       prop-types: 15.8.1
@@ -14307,7 +14326,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@mui/utils@9.0.1(@types/react@19.2.14)(react@19.2.6)':
+  '@mui/utils@9.1.0(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@mui/types': 9.0.0(@types/react@19.2.14)


### PR DESCRIPTION
A followup to https://github.com/mui/material-ui/pull/48370

TLDR: Even though we gain on prod build times with turbopack, it affects the end user experience with increased bundle size and slightly impacted page perf.
So, we should use it on dev for better DX and use webpack on prod to not impact the end-user experience.

## Impact of moving prod build to turbopack

### Perf compare — webpack vs turbopack (deploy previews)

Both targets on Netlify Edge:

- webpack:   https://deploy-preview-48370--material-ui.netlify.app/
- turbopack: https://deploy-preview-48569--material-ui.netlify.app/

Methodology: Playwright Chromium headless, fresh context per run, CDP `Network.setCacheDisabled`, first-party only, `domcontentloaded` → `load` → 300 ms, transferred bytes via `Network.loadingFinished.encodedDataLength`. 5 runs/page, median reported.

### Summary

- **JS: webpack ships less by 3,034 kB (~33% smaller) across 10 pages.** Per-page Δ ranges +18% to +74%; biggest deltas on simple pages (install, dark-mode, how-to-customize) where turbopack ships ~400 kB extra — points at worse common-chunk dedupe / finer per-route splitting.
- **CSS: webpack ships less by 6.7 kB (~7%).** Constant ~700-byte delta on every page → fixed overhead, not content diff.
- **RUM: within bundler-noise floor.** FCP mean Δ = −21 ms; LCP mean Δ = +121 ms but skewed by `react-table` (+1032 ms outlier, webpack LCP==FCP on that page suggests LCP candidate flickers between runs). Excluding table, LCP mean Δ ≈ +20 ms = noise. User-visible perf effectively no visible winner despite turbopack shipping more bytes — HTTP/2 + parallel fetch absorbs it on this network.

<details>
  <summary>See Raw Data</summary>

#### JS bytes (median, first-party)

| page | webpack (kB) | turbopack (kB) | Δ% |
|---|---:|---:|---:|
| / | 656.0 | 1058.2 | +61.3% |
| /material-ui/getting-started/installation/ | 545.7 | 948.6 | +73.8% |
| /material-ui/getting-started/usage/ | 544.3 | 685.1 | +25.9% |
| /material-ui/react-button/ | 565.2 | 672.4 | +19.0% |
| /material-ui/react-autocomplete/ | 817.1 | 1183.4 | +44.8% |
| /material-ui/react-text-field/ | 591.6 | 949.9 | +60.6% |
| /material-ui/react-table/ | 830.5 | 1186.9 | +42.9% |
| /material-ui/customization/how-to-customize/ | 560.1 | 969.9 | +73.2% |
| /material-ui/customization/dark-mode/ | 550.7 | 939.5 | +70.6% |
| /material-ui/all-components/ | 558.9 | 660.4 | +18.2% |
| **TOTAL** | **6220.1** | **9254.2** | **+48.8%** |

#### CSS bytes (median, first-party)

| page | webpack (kB) | turbopack (kB) | Δ% |
|---|---:|---:|---:|
| / | 9.2 | 9.9 | +7.5% |
| /material-ui/getting-started/installation/ | 9.2 | 9.9 | +7.4% |
| /material-ui/getting-started/usage/ | 9.2 | 9.9 | +7.4% |
| /material-ui/react-button/ | 9.2 | 9.9 | +7.3% |
| /material-ui/react-autocomplete/ | 9.2 | 9.9 | +7.4% |
| /material-ui/react-text-field/ | 9.2 | 9.9 | +7.2% |
| /material-ui/react-table/ | 9.2 | 9.9 | +7.4% |
| /material-ui/customization/how-to-customize/ | 9.2 | 9.9 | +6.9% |
| /material-ui/customization/dark-mode/ | 9.2 | 9.9 | +7.2% |
| /material-ui/all-components/ | 9.2 | 9.9 | +7.2% |
| **TOTAL** | **92.3** | **99.0** | **+7.3%** |

#### Total bytes (median, first-party)

| page | webpack (kB) | turbopack (kB) | Δ% |
|---|---:|---:|---:|
| / | 1377.3 | 1621.7 | +17.7% |
| /material-ui/getting-started/installation/ | 1086.9 | 1443.3 | +32.8% |
| /material-ui/getting-started/usage/ | 1087.0 | 1177.8 | +8.4% |
| /material-ui/react-button/ | 1320.7 | 1384.9 | +4.9% |
| /material-ui/react-autocomplete/ | 1392.8 | 1722.8 | +23.7% |
| /material-ui/react-text-field/ | 1177.5 | 1495.8 | +27.0% |
| /material-ui/react-table/ | 1382.0 | 1697.6 | +22.8% |
| /material-ui/customization/how-to-customize/ | 1138.0 | 1502.0 | +32.0% |
| /material-ui/customization/dark-mode/ | 1859.4 | 2211.0 | +18.9% |
| /material-ui/all-components/ | 2523.6 | 2577.2 | +2.1% |
| **TOTAL** | **14345.1** | **16834.2** | **+17.4%** |

#### FCP / LCP (median, ms)

| page | FCP wp | FCP tp | FCP Δms | LCP wp | LCP tp | LCP Δms |
|---|---:|---:|---:|---:|---:|---:|
| / | 832 | 784 | -48 | 832 | 784 | -48 |
| /material-ui/getting-started/installation/ | 780 | 788 | +8 | 1328 | 1348 | +20 |
| /material-ui/getting-started/usage/ | 792 | 732 | -60 | 1328 | 1340 | +12 |
| /material-ui/react-button/ | 812 | 864 | +52 | 1476 | 1536 | +60 |
| /material-ui/react-autocomplete/ | 856 | 804 | -52 | 1568 | 1568 | 0 |
| /material-ui/react-text-field/ | 804 | 836 | +32 | 1484 | 1532 | +48 |
| /material-ui/react-table/ | 852 | 816 | -36 | 852 | 1884 | +1032 |
| /material-ui/customization/how-to-customize/ | 776 | 796 | +20 | 1404 | 1424 | +20 |
| /material-ui/customization/dark-mode/ | 828 | 788 | -40 | 828 | 788 | -40 |
| /material-ui/all-components/ | 796 | 708 | -88 | 1360 | 1468 | +108 |
</details>

## Gains on moving prod build to turbopack

Overall prod build on Netlfiy -

Previous - 5m45sec
New - 1m45sec

### Bundler benchmark: webpack vs turbopack

- Host: Brijeshs-MacBook-Pro.local (darwin arm64, 14 cores, 38.7 GB RAM)
- Node: v24.14.0
- Next.js: 16.2.6
- Date: 2026-05-25
- Runs per metric: 10 (HMR: + 2 warmup discarded)
- Component page: `/material-ui/react-button/`
- HMR edit target: `docs/data/material/components/buttons/BasicButtons.js`. First `>WORD<` JSX text child rewritten to a fresh marker each run (cascade, no reset between runs).
- HMR timing: `writeFile` → first `[Fast Refresh] done in Xms` console event seen in a headless Chrome tab (Playwright).

### Summary

| Metric | webpack (mean) | turbopack (mean) | turbopack vs webpack |
|---|---:|---:|---:|
| Cold prod build | 98.43 s | 36.03 s | **2.73× faster** |
| Dev startup (process boot → `Ready in`) | 408 ms | 368 ms | 1.11× faster |
| Home `/` cold first-load | 5.68 s | 4.77 s | 1.19× faster |
| Component cold first-load | 2.06 s | 1.32 s | **1.56× faster** |
| HMR — driver wall clock (edit → event) | 416 ms | 282 ms | **1.47× faster** |
| HMR — bundler-reported (`Fast Refresh done in Xms`) | 402 ms | 111 ms | **3.64× faster** |

<details>
<summary>See Raw Data</summary>

### Cold prod build (`next build`)

| bundler | n | mean | stddev | min | median | p95 | max |
|---|---:|---:|---:|---:|---:|---:|---:|
| webpack | 10 | 98.43 s | 4.06 s | 93.40 s | 97.25 s | 108.51 s | 108.51 s |
| turbopack | 10 | 36.03 s | 2.51 s | 32.16 s | 36.34 s | 39.20 s | 39.20 s |

_turbopack mean **2.73× faster** than webpack._

<details><summary>raw samples (ms)</summary>

- **webpack**: `97644, 96750, 93396, 101528, 108506, 97228, 96482, 97265, 97160, 98348`
- **turbopack**: `32157, 32827, 33746, 35170, 35528, 37154, 37905, 38132, 38482, 39204`

</details>

### Dev startup (process boot → `Ready in`)

| bundler | n | mean | stddev | min | median | p95 | max |
|---|---:|---:|---:|---:|---:|---:|---:|
| webpack | 10 | 408 ms | 90 ms | 350 ms | 372 ms | 642 ms | 642 ms |
| turbopack | 10 | 368 ms | 15 ms | 354 ms | 367 ms | 403 ms | 403 ms |

_turbopack mean **1.11× faster** than webpack._

<details><summary>raw samples (ms)</summary>

- **webpack**: `642, 382, 464, 434, 356, 383, 359, 350, 362, 352`
- **turbopack**: `362, 403, 371, 358, 356, 382, 356, 371, 354, 371`

</details>

### Home `/` cold first-load

| bundler | n | mean | stddev | min | median | p95 | max |
|---|---:|---:|---:|---:|---:|---:|---:|
| webpack | 10 | 5.68 s | 1.69 s | 4.74 s | 5.11 s | 10.41 s | 10.41 s |
| turbopack | 10 | 4.77 s | 151 ms | 4.54 s | 4.74 s | 5.05 s | 5.05 s |

_turbopack mean **1.19× faster** than webpack._

<details><summary>raw samples (ms)</summary>

- **webpack**: `10412, 5940, 5449, 4992, 5071, 4966, 5139, 4927, 4737, 5198`
- **turbopack**: `4728, 4873, 5054, 4847, 4695, 4542, 4882, 4753, 4594, 4704`

</details>

### Component `/material-ui/react-button/` cold first-load

| bundler | n | mean | stddev | min | median | p95 | max |
|---|---:|---:|---:|---:|---:|---:|---:|
| webpack | 10 | 2.06 s | 742 ms | 1.68 s | 1.74 s | 3.85 s | 3.85 s |
| turbopack | 10 | 1.32 s | 41 ms | 1.27 s | 1.32 s | 1.39 s | 1.39 s |

_turbopack mean **1.56× faster** than webpack._

<details><summary>raw samples (ms)</summary>

- **webpack**: `3849, 2973, 1775, 1749, 1680, 1685, 1726, 1710, 1690, 1764`
- **turbopack**: `1277, 1385, 1315, 1326, 1289, 1266, 1350, 1349, 1375, 1295`

</details>

### HMR — edit → `[Fast Refresh] done` (driver wall clock)

Real HMR via Playwright: edit demo file, observe the next `[Fast Refresh] done` console event in the open browser tab.

| bundler | n | mean | stddev | min | median | p95 | max |
|---|---:|---:|---:|---:|---:|---:|---:|
| webpack | 10 | 416 ms | 48 ms | 341 ms | 421 ms | 482 ms | 482 ms |
| turbopack | 10 | 282 ms | 57 ms | 212 ms | 290 ms | 358 ms | 358 ms |

_turbopack mean **1.47× faster** than webpack._

<details><summary>raw samples (ms)</summary>

- **webpack**: `453, 396, 448, 382, 446, 366, 482, 381, 463, 341`
- **turbopack**: `358, 212, 319, 215, 328, 230, 336, 236, 329, 260`

</details>

### HMR — bundler-reported (`[Fast Refresh] done in Xms`)

Parses the `Xms` value printed by Next's Fast Refresh runtime — bundler-side recompile only, excludes WS round-trip and Playwright console plumbing.

| bundler | n | mean | stddev | min | median | p95 | max |
|---|---:|---:|---:|---:|---:|---:|---:|
| webpack | 10 | 402 ms | 48 ms | 327 ms | 408 ms | 469 ms | 469 ms |
| turbopack | 10 | 111 ms | 75 ms | 71 ms | 87 ms | 320 ms | 320 ms |

_turbopack mean **3.64× faster** than webpack._

<details><summary>raw samples (ms)</summary>

- **webpack**: `440, 382, 435, 369, 433, 353, 469, 366, 449, 327`
- **turbopack**: `99, 74, 71, 77, 82, 91, 320, 99, 71, 121`

</details>
</details>

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
