### PR TITLE
[mui-system] Include CustomSystemProps in SystemProps

### DIFF
--- a/packages/mui-material/src/Box/Box.spec.tsx
+++ b/packages/mui-material/src/Box/Box.spec.tsx
@@ -29,7 +29,8 @@ const defaultTheme = createTheme({});
 const CustomBox = createBox({ defaultTheme });
 expectType<typeof Box, typeof CustomBox>(CustomBox);
 
-expectType<typeof SystemBox, typeof CustomBox>(CustomBox);
+const CustomSystemBox = createBox();
+expectType<typeof SystemBox, typeof CustomSystemBox>(CustomSystemBox);
 
 function ColorTest() {
   <Box

--- a/packages/mui-system/src/Box/Box.d.ts
+++ b/packages/mui-system/src/Box/Box.d.ts
@@ -46,15 +46,17 @@ type StandardSystemKeys = Extract<SimpleSystemKeys, keyof AllSystemCSSProperties
 
 type CustomSystemKeys = Exclude<keyof CustomSystemProps, StandardSystemKeys>;
 
-export type SystemProps<Theme extends object = {}> = {
-  [K in StandardSystemKeys]?:
-    | ResponsiveStyleValue<AllSystemCSSProperties[K]>
-    | ((theme: Theme) => ResponsiveStyleValue<AllSystemCSSProperties[K]>);
-} & {
+type CustomSystemPropsFor<Theme extends object = {}> = {
   [K in CustomSystemKeys]?:
     | ResponsiveStyleValue<CustomSystemProps[K]>
     | ((theme: Theme) => ResponsiveStyleValue<CustomSystemProps[K]>);
 };
+
+export type SystemProps<Theme extends object = {}> = {
+  [K in StandardSystemKeys]?:
+    | ResponsiveStyleValue<AllSystemCSSProperties[K]>
+    | ((theme: Theme) => ResponsiveStyleValue<AllSystemCSSProperties[K]>);
+} & CustomSystemPropsFor<Theme>;
 
 export interface BoxOwnProps<Theme extends object = SystemTheme> {
   children?: React.ReactNode;
@@ -70,7 +72,7 @@ export interface BoxTypeMap<
   RootComponent extends React.ElementType = 'div',
   Theme extends object = SystemTheme,
 > {
-  props: AdditionalProps & BoxOwnProps<Theme> & SystemProps<Theme>;
+  props: AdditionalProps & BoxOwnProps<Theme> & CustomSystemPropsFor<Theme>;
   defaultComponent: RootComponent;
 }
 

--- a/packages/mui-system/src/Box/Box.d.ts
+++ b/packages/mui-system/src/Box/Box.d.ts
@@ -70,7 +70,7 @@ export interface BoxTypeMap<
   RootComponent extends React.ElementType = 'div',
   Theme extends object = SystemTheme,
 > {
-  props: AdditionalProps & BoxOwnProps<Theme>;
+  props: AdditionalProps & BoxOwnProps<Theme> & SystemProps<Theme>;
   defaultComponent: RootComponent;
 }
 

--- a/packages/mui-system/src/Box/Box.d.ts
+++ b/packages/mui-system/src/Box/Box.d.ts
@@ -44,10 +44,16 @@ export type SimpleSystemKeys = keyof PropsFor<
 // This is needed as these are used as keys inside AllSystemCSSProperties
 type StandardSystemKeys = Extract<SimpleSystemKeys, keyof AllSystemCSSProperties>;
 
+type CustomSystemKeys = Exclude<keyof CustomSystemProps, StandardSystemKeys>;
+
 export type SystemProps<Theme extends object = {}> = {
   [K in StandardSystemKeys]?:
     | ResponsiveStyleValue<AllSystemCSSProperties[K]>
     | ((theme: Theme) => ResponsiveStyleValue<AllSystemCSSProperties[K]>);
+} & {
+  [K in CustomSystemKeys]?:
+    | ResponsiveStyleValue<CustomSystemProps[K]>
+    | ((theme: Theme) => ResponsiveStyleValue<CustomSystemProps[K]>);
 };
 
 export interface BoxOwnProps<Theme extends object = SystemTheme> {

--- a/packages/mui-system/test/typescript/moduleAugmentation/customSystemProps.spec.tsx
+++ b/packages/mui-system/test/typescript/moduleAugmentation/customSystemProps.spec.tsx
@@ -21,6 +21,7 @@ const invalidProps: SystemProps = {
 };
 
 <Box customProp={2} />;
+<Box m={4} />;
 
 // @ts-expect-error customProp only accepts numbers.
 const invalidBox = <Box customProp="2" />;

--- a/packages/mui-system/test/typescript/moduleAugmentation/customSystemProps.spec.tsx
+++ b/packages/mui-system/test/typescript/moduleAugmentation/customSystemProps.spec.tsx
@@ -1,4 +1,4 @@
-import { SystemProps } from '@mui/system/Box';
+import Box, { SystemProps } from '@mui/system/Box';
 
 declare module '@mui/system/Box' {
   interface CustomSystemProps {
@@ -19,3 +19,8 @@ const invalidProps: SystemProps = {
   // @ts-expect-error customProp only accepts numbers.
   customProp: '2',
 };
+
+<Box customProp={2} />;
+
+// @ts-expect-error customProp only accepts numbers.
+const invalidBox = <Box customProp="2" />;

--- a/packages/mui-system/test/typescript/moduleAugmentation/customSystemProps.spec.tsx
+++ b/packages/mui-system/test/typescript/moduleAugmentation/customSystemProps.spec.tsx
@@ -21,6 +21,8 @@ const invalidProps: SystemProps = {
 };
 
 <Box customProp={2} />;
+
+// @ts-expect-error Standard system aliases are not direct Box props.
 <Box m={4} />;
 
 // @ts-expect-error customProp only accepts numbers.

--- a/packages/mui-system/test/typescript/moduleAugmentation/customSystemProps.spec.tsx
+++ b/packages/mui-system/test/typescript/moduleAugmentation/customSystemProps.spec.tsx
@@ -1,0 +1,21 @@
+import { SystemProps } from '@mui/system/Box';
+
+declare module '@mui/system/Box' {
+  interface CustomSystemProps {
+    customProp?: number;
+  }
+}
+
+const props: SystemProps = {
+  customProp: 2,
+  m: [1, 2],
+};
+
+const themedProps: SystemProps<{ factor: number }> = {
+  customProp: (theme) => theme.factor,
+};
+
+const invalidProps: SystemProps = {
+  // @ts-expect-error customProp only accepts numbers.
+  customProp: '2',
+};

--- a/packages/mui-system/test/typescript/moduleAugmentation/customSystemProps.tsconfig.json
+++ b/packages/mui-system/test/typescript/moduleAugmentation/customSystemProps.tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "files": ["customSystemProps.spec.tsx"]
+}


### PR DESCRIPTION
Closes #35565

- Includes keys added through `CustomSystemProps` in `SystemProps`.
- Preserves the existing responsive and theme-function typing for standard system props.
- Adds isolated module-augmentation type coverage.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).