### PR TITLE
[code-infra] Run nightly-cron on v7.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -640,6 +640,7 @@ workflows:
                 - master
                 - v5.x
                 - v6.x
+                - v7.x
     jobs:
       - test_unit:
           <<: *default-context


### PR DESCRIPTION
Follow-up to #48556. Adds `v7.x` to the `nightly-cron` workflow's branch filter so the consolidated canary suite also runs against the v7 release line.