### PR TITLE
[utils] Prevent prototype pollution in fastDeepAssign

### DIFF
--- a/packages/mui-utils/src/fastDeepAssign/fastDeepAssign.test.ts
+++ b/packages/mui-utils/src/fastDeepAssign/fastDeepAssign.test.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import fastDeepAssign from './fastDeepAssign';
+
+describe('fastDeepAssign', () => {
+  it('merges shallow objects', () => {
+    expect(fastDeepAssign({ a: 1 } as Record<string, unknown>, { b: 2 })).to.deep.equal({
+      a: 1,
+      b: 2,
+    });
+  });
+
+  it('merges nested objects', () => {
+    expect(
+      fastDeepAssign({ a: { b: 1 } } as Record<string, unknown>, { a: { c: 2 } }),
+    ).to.deep.equal({ a: { b: 1, c: 2 } });
+  });
+
+  describe('prototype pollution', () => {
+    afterEach(() => {
+      // Defensive cleanup in case any assertion below leaves a polluted prototype.
+      delete (Object.prototype as Record<string, unknown>).polluted;
+    });
+
+    it('does not pollute Object.prototype via __proto__', () => {
+      const malicious = JSON.parse('{"__proto__":{"polluted":true}}');
+      fastDeepAssign({} as Record<string, unknown>, malicious);
+      expect(({} as Record<string, unknown>).polluted).to.equal(undefined);
+    });
+
+    it('does not pollute Object.prototype via nested __proto__', () => {
+      const malicious = JSON.parse('{"a":{"__proto__":{"polluted":true}}}');
+      fastDeepAssign({} as Record<string, unknown>, malicious);
+      expect(({} as Record<string, unknown>).polluted).to.equal(undefined);
+    });
+
+    it('does not allow overwriting constructor', () => {
+      const target = {} as Record<string, unknown>;
+      fastDeepAssign(target, JSON.parse('{"constructor":{"name":"Pwned"}}'));
+      expect(target.constructor).to.equal(Object);
+    });
+  });
+});

--- a/packages/mui-utils/src/fastDeepAssign/fastDeepAssign.ts
+++ b/packages/mui-utils/src/fastDeepAssign/fastDeepAssign.ts
@@ -3,7 +3,6 @@
 // MIT License
 // Copyright (c) 2012 - 2022 James Halliday, Josh Duff, and other contributors of deepmerge
 
-/* eslint-disable guard-for-in */
 /* eslint-disable no-else-return */
 
 /**
@@ -41,6 +40,9 @@ function cloneObject(target: any) {
   const result = {} as any;
 
   for (const key in target) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
     result[key] = clone(target[key]);
   }
   return result;
@@ -84,6 +86,9 @@ function clone(entry: any) {
 
 function mergeObject(target: any, source: any) {
   for (const key in source) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
     if (key in target) {
       target[key] = fastDeepAssign(target[key], source[key]);
     } else {


### PR DESCRIPTION
## Summary

Closes the prototype-pollution code-scanning alert against `fastDeepAssign`. `JSON.parse` creates a literal `__proto__` own property without triggering the prototype setter; `for (const key in source)` then enumerates that key and `target[key] = ...` triggers the setter on `Object.prototype`, polluting the global prototype.

`unstable_fastDeepAssign` is exported from `@mui/utils` and used by `@mui/system` for `sx`/`compose`/`breakpoints`, where the source object can be application-provided at runtime — so this is reachable from real consumer code, not just tests.

The fix skips `__proto__`, `constructor`, and `prototype` in both `mergeObject` and `cloneObject`. Same pattern used by reputable deepmerge implementations.