### PR TITLE
[core-docs] Tighten service worker host check

### DIFF
--- a/packages-internal/core-docs/src/DocsApp/serviceWorker.ts
+++ b/packages-internal/core-docs/src/DocsApp/serviceWorker.ts
@@ -53,10 +53,11 @@ function forcePageReload(registration: ServiceWorkerRegistration) {
 }
 
 export async function registerServiceWorker(swPath: string): Promise<void> {
+  const { host } = window.location;
   if (
     'serviceWorker' in navigator &&
     process.env.NODE_ENV === 'production' &&
-    window.location.host.includes('mui.com')
+    (host === 'mui.com' || host.endsWith('.mui.com'))
   ) {
     // register() automatically attempts to refresh the sw.js.
     const registration = await navigator.serviceWorker.register(swPath);


### PR DESCRIPTION
## Summary

Closes CodeQL alert "Incomplete URL substring sanitization" on `serviceWorker.ts`.

`window.location.host.includes('mui.com')` matches any host where `mui.com` appears anywhere in the string. Switch to an exact-or-subdomain check so the service worker only registers on the real mui.com deployment.

Two-character semantic improvement; not a meaningful attack vector since `window.location.host` is browser-provided, but the new code is more correct.