### PR TITLE
[docs-infra] Lazy-load react-runner + sucrase for demo live-edit

### DIFF
--- a/packages-internal/core-docs/src/Demo/Demo.tsx
+++ b/packages-internal/core-docs/src/Demo/Demo.tsx
@@ -16,14 +16,32 @@ import { CodeTab, CodeTabList } from '../HighlightedCodeWithTabs';
 import { DemoSandbox } from './DemoSandbox';
 import { DemoToolbarRoot } from './DemoToolbarRoot';
 import { DemoAiSuggestionHero } from './DemoAiSuggestionHero';
-import { DemoEditor } from './DemoEditor';
 import { DemoEditorError } from './DemoEditorError';
-import { ReactRunner } from './ReactRunner';
 import { useDemoContext } from '../DemoContext/DemoContext';
 import { useCodeVariant } from '../codeVariant/codeVariant';
 import { CODE_VARIANTS, stylingSolutionMapping } from '../constants/constants';
 import { useUserLanguage, useTranslate } from '../i18n';
 import { AdCarbonInline } from '../Ad/AdCarbon';
+
+// `react-runner` (pulls all of sucrase) and `react-simple-code-editor`
+// are only needed when the user enters live-edit mode. Defer the import,
+// but prefetch on hover so the chunks are ready by the time the user clicks.
+let demoEditorPromise: Promise<{ default: React.ComponentType<any> }> | undefined;
+function preloadDemoEditor(): Promise<{ default: React.ComponentType<any> }> {
+  if (!demoEditorPromise) {
+    demoEditorPromise = import('./DemoEditor').then((m) => ({ default: m.DemoEditor })) as any;
+  }
+  return demoEditorPromise!;
+}
+let reactRunnerPromise: Promise<{ default: React.ComponentType<any> }> | undefined;
+function preloadReactRunner(): Promise<{ default: React.ComponentType<any> }> {
+  if (!reactRunnerPromise) {
+    reactRunnerPromise = import('./ReactRunner').then((m) => ({ default: m.ReactRunner })) as any;
+  }
+  return reactRunnerPromise!;
+}
+const ReactRunner = React.lazy(preloadReactRunner);
+const DemoEditor = React.lazy(preloadDemoEditor);
 
 /**
  * Removes leading spaces (indentation) present in the `.tsx` previews
@@ -148,20 +166,22 @@ function useDemoElement({
   );
   const LiveComponent = React.useMemo(
     () => (
-      <ReactRunner
-        scope={demoData.scope}
-        onError={debouncedSetError as any}
-        code={
-          editorCode.isPreview
-            ? trimLeadingSpaces(demoData.raw).replace(
-                trimLeadingSpaces(demoData.jsxPreview),
-                editorCode.value,
-              )
-            : editorCode.value
-        }
-      />
+      <React.Suspense fallback={BundledComponent}>
+        <ReactRunner
+          scope={demoData.scope}
+          onError={debouncedSetError as any}
+          code={
+            editorCode.isPreview
+              ? trimLeadingSpaces(demoData.raw).replace(
+                  trimLeadingSpaces(demoData.jsxPreview),
+                  editorCode.value,
+                )
+              : editorCode.value
+          }
+        />
+      </React.Suspense>
     ),
-    [demoData, debouncedSetError, editorCode.isPreview, editorCode.value],
+    [BundledComponent, demoData, debouncedSetError, editorCode.isPreview, editorCode.value],
   );
 
   // No need for a live environment if the code matches with the component rendered server-side.
@@ -605,8 +625,13 @@ export function Demo(props: DemoProps) {
   };
   const willRenderTabList = demoData.relativeModules && openDemoSource && !editorCode.isPreview;
 
+  const handlePreloadEditor = React.useCallback(() => {
+    preloadDemoEditor();
+    preloadReactRunner();
+  }, []);
+
   return (
-    <Root>
+    <Root onMouseEnter={handlePreloadEditor} onFocus={handlePreloadEditor}>
       {anchorName !== null && <AnchorLink id={anchorName} />}
       <DemoRoot
         hideToolbar={demoOptions.hideToolbar}
@@ -723,41 +748,43 @@ export function Demo(props: DemoProps) {
                       }}
                     />
                   ) : (
-                    <DemoEditor
-                      // Mount a new text editor when the preview mode change to reset the undo/redo history.
-                      key={String(editorCode.isPreview)}
-                      value={editorCode.value}
-                      onChange={
-                        ((value: string) => {
-                          setEditorCode({
-                            ...editorCode,
-                            value,
-                          });
-                        }) as any
-                      }
-                      onFocus={() => {
-                        setLiveDemoActive(true);
-                      }}
-                      id={demoSourceId}
-                      language={demoData.sourceLanguage}
-                      copyButtonProps={
-                        {
-                          'data-ga-event-category': codeOpen ? 'demo-expand' : 'demo',
-                          'data-ga-event-label': demo.gaLabel,
-                          'data-ga-event-action': 'copy-click',
-                        } as any
-                      }
-                      sx={
-                        {
-                          '& .scrollContainer': {
-                            borderBottomLeftRadius: demoOptions.aiSuggestion ? 0 : 12,
-                            borderBottomRightRadius: demoOptions.aiSuggestion ? 0 : 12,
-                          },
-                        } as any
-                      }
-                    >
-                      <DemoEditorError>{debouncedError}</DemoEditorError>
-                    </DemoEditor>
+                    <React.Suspense fallback={null}>
+                      <DemoEditor
+                        // Mount a new text editor when the preview mode change to reset the undo/redo history.
+                        key={String(editorCode.isPreview)}
+                        value={editorCode.value}
+                        onChange={
+                          ((value: string) => {
+                            setEditorCode({
+                              ...editorCode,
+                              value,
+                            });
+                          }) as any
+                        }
+                        onFocus={() => {
+                          setLiveDemoActive(true);
+                        }}
+                        id={demoSourceId}
+                        language={demoData.sourceLanguage}
+                        copyButtonProps={
+                          {
+                            'data-ga-event-category': codeOpen ? 'demo-expand' : 'demo',
+                            'data-ga-event-label': demo.gaLabel,
+                            'data-ga-event-action': 'copy-click',
+                          } as any
+                        }
+                        sx={
+                          {
+                            '& .scrollContainer': {
+                              borderBottomLeftRadius: demoOptions.aiSuggestion ? 0 : 12,
+                              borderBottomRightRadius: demoOptions.aiSuggestion ? 0 : 12,
+                            },
+                          } as any
+                        }
+                      >
+                        <DemoEditorError>{debouncedError}</DemoEditorError>
+                      </DemoEditor>
+                    </React.Suspense>
                   )}
                 </Tabs.Panel>
               ))}

--- a/packages-internal/core-docs/src/MarkdownDocs/RichMarkdownElement.tsx
+++ b/packages-internal/core-docs/src/MarkdownDocs/RichMarkdownElement.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import dynamic from 'next/dynamic';
 import { useTranslate, useUserLanguage } from '../i18n';
 import { HighlightedCodeWithTabs } from '../HighlightedCodeWithTabs';
 import { MarkdownElement } from './MarkdownElement';
-import { Demo, type DemoProps } from '../Demo/Demo';
-import { DemoToolbar } from '../Demo/DemoToolbar';
+import { Demo, type DemoProps, DemoToolbarProps } from '../Demo/Demo';
+
+// `DemoToolbar` is interactive UI rendered below each demo. It pulls in
+// Menu, ToggleButtonGroup, Tooltip and friends and is already wrapped in
+// `<NoSsr>` + `<React.Suspense>` inside `Demo`, so deferring its bundle
+// keeps initial JS smaller and re-introduces a chunk-load yield during
+// hydration (lowers TBT).
+const DemoToolbar = dynamic<DemoToolbarProps>(
+  () => import('../Demo/DemoToolbar').then((m) => m.DemoToolbar),
+  { ssr: false },
+);
 
 function noComponent(moduleID: string) {
   return function NoComponent() {


### PR DESCRIPTION
Convert ReactRunner and DemoEditor from static imports to React.lazy() in Demo.tsx. The live-edit code path (react-runner pulling all of sucrase, plus react-simple-code-editor) only runs after the user focuses/hovers the demo editor — `liveDemoActive` defaults to false on every demo.

Prefetch both chunks on hover (and on keyboard focus into the demo card) so the runtime is already cached by the time the user actually clicks edit: `preloadDemoEditor()` and `preloadReactRunner()` hold cached promises that are also passed to React.lazy(), so a single dynamic import is shared between the prefetch path and the render path.

We could also prefetch these chunks on idle (if desired).

<details>
<summary>Some page-wise data</summary>

| Page | JS gzip master | JS gzip PR | JS gzip Δ | JS decoded master | JS decoded PR | JS decoded Δ |
|---|--:|--:|--:|--:|--:|--:|
| `/` | 767.5 KB | 627.7 KB | **−139.8 KB** | 2660.2 KB | 2108.9 KB | **−551.4 KB** |
| `/material-ui/getting-started/installation/` | 553.8 KB | 485.5 KB | −68.3 KB | 1914.7 KB | 1634.7 KB | −280.0 KB |
| `/material-ui/react-button/` | 570.7 KB | 523.6 KB | −47.1 KB | 1999.5 KB | 1786.2 KB | −213.3 KB |
| `/material-ui/react-text-field/` | 597.7 KB | 550.0 KB | −47.7 KB | 2155.1 KB | 1941.8 KB | −213.3 KB |
| `/material-ui/react-autocomplete/` | 827.5 KB | 779.4 KB | −48.1 KB | 3368.2 KB | 3154.9 KB | −213.4 KB |
| `/material-ui/react-table/` | 847.9 KB | 807.2 KB | −40.7 KB | 2929.8 KB | 2738.8 KB | −191.0 KB |
| `/material-ui/react-dialog/` | 589.7 KB | 541.2 KB | −48.4 KB | 2070.1 KB | 1856.7 KB | −213.4 KB |
| `/system/getting-started/custom-components/` | 573.8 KB | 529.2 KB | −44.6 KB | 1960.9 KB | 1755.9 KB | −205.0 KB |


CSS unchanged: 10.0 KB gzip / 80.7 KB decoded on both.


</details>

CSS unchanged.
Extra chunk size loaded on hover/edit - `50.6 kB transferred
210 kB resources`


Existing live-edit functionality preserved: hovering the demo warms the chunks; clicking "expand" opens the source viewer; focusing the textarea swaps the bundled component for ReactRunner with the edited code.

On hold till https://github.com/mui/material-ui/pull/47821 lands

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
