### PR TITLE
[core] Fix typescript@next typecheck

### DIFF
--- a/docs/types/css.d.ts
+++ b/docs/types/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/packages/mui-material/src/Slider/useSlider.ts
+++ b/packages/mui-material/src/Slider/useSlider.ts
@@ -152,10 +152,10 @@ function focusThumb(
           preventScroll: true,
           // Prevent pointer-driven focus rings in browsers that support this option.
           // Chrome 144+ supports `focusVisible` in `HTMLElement.focus()` options.
+          focusVisible,
           // Cast required for TypeScript 5.9; remove once stable TypeScript includes
           // `focusVisible` in lib.dom FocusOptions (already present in typescript@next).
-          focusVisible,
-        } as FocusOptions & { focusVisible?: boolean });
+        } as FocusOptions & { focusVisible?: boolean | undefined });
       }
     }
   }

--- a/packages/mui-material/src/Slider/useSlider.ts
+++ b/packages/mui-material/src/Slider/useSlider.ts
@@ -153,8 +153,7 @@ function focusThumb(
           // Prevent pointer-driven focus rings in browsers that support this option.
           // Chrome 144+ supports `focusVisible` in `HTMLElement.focus()` options.
           focusVisible,
-          // Cast required for TypeScript 5.9; remove once stable TypeScript includes
-          // `focusVisible` in lib.dom FocusOptions (already present in typescript@next).
+          // Cast can be removed once TypeScript >= 6.0 (added `focusVisible` to lib.dom FocusOptions).
         } as FocusOptions & { focusVisible?: boolean | undefined });
       }
     }

--- a/packages/mui-material/src/Slider/useSlider.ts
+++ b/packages/mui-material/src/Slider/useSlider.ts
@@ -152,9 +152,10 @@ function focusThumb(
           preventScroll: true,
           // Prevent pointer-driven focus rings in browsers that support this option.
           // Chrome 144+ supports `focusVisible` in `HTMLElement.focus()` options.
-          // @ts-expect-error `focusVisible` is not yet in TypeScript's lib.dom FocusOptions.
+          // Cast required for TypeScript 5.9; remove once stable TypeScript includes
+          // `focusVisible` in lib.dom FocusOptions (already present in typescript@next).
           focusVisible,
-        });
+        } as FocusOptions & { focusVisible?: boolean });
       }
     }
   }


### PR DESCRIPTION
## Summary

The `typescript-next` CI workflow (job 934651) was failing on two packages:

- **`@mui/material`** — `src/Slider/useSlider.ts:155` raised `TS2578: Unused '@ts-expect-error' directive` because typescript@next now includes `focusVisible` in lib.dom's `FocusOptions`. Replaced the directive with a localized `as FocusOptions & { focusVisible?: boolean }` cast that compiles under both stable TS 5.9 and typescript@next. The comment notes when the cast can be removed.
- **`docs`** — `pages/_app.tsx:40-41` raised `TS2882: Cannot find module or type declarations for side-effect import` on `./global.css` and `../public/static/components-gallery/base-theme.css`. typescript@next appears to enable side-effect import checking by default. Added `docs/types/css.d.ts` with `declare module '*.css';`, mirroring the existing `docs/types/webpack.d.ts` pattern.

Verified locally with `pnpm typescript:ci` on both stable TS 5.9.3 and typescript@next (6.0.0-dev.20260416); all 19 projects pass.