### PR TITLE
[website] Fix Material theme dark mode demos

### DIFF
--- a/docs/src/components/home/MaterialDesignComponents.tsx
+++ b/docs/src/components/home/MaterialDesignComponents.tsx
@@ -520,7 +520,7 @@ export function buildTheme(): ThemeOptions {
 
 const { palette: lightPalette, typography, ...designTokens } = getDesignTokens('light');
 const { palette: darkPalette } = getDesignTokens('dark');
-const defaultTheme = extendTheme({
+export const defaultTheme = extendTheme({
   colorSchemes: { light: true, dark: true },
   colorSchemeSelector: 'data-mui-color-scheme',
 });

--- a/docs/src/components/productMaterial/MaterialComponents.tsx
+++ b/docs/src/components/productMaterial/MaterialComponents.tsx
@@ -33,7 +33,7 @@ import {
   MaterialVsCustomToggle,
 } from '@mui/internal-core-docs/AppLayout';
 import { ShowcaseCodeWrapper } from 'docs/src/components/home/ShowcaseContainer';
-import { customTheme } from 'docs/src/components/home/MaterialDesignComponents';
+import { customTheme, defaultTheme } from 'docs/src/components/home/MaterialDesignComponents';
 import { HighlightedCode } from '@mui/internal-core-docs/HighlightedCode';
 import { ROUTES } from '@mui/internal-core-docs/constants';
 
@@ -143,7 +143,7 @@ export default function MaterialComponents() {
         <Grid size={{ xs: 12, md: 6 }}>
           <Frame sx={{ height: '100%' }}>
             <Frame.Demo className="mui-default-theme" sx={{ flexGrow: 1 }}>
-              <CssVarsProvider theme={customized ? customTheme : undefined}>
+              <CssVarsProvider theme={customized ? customTheme : defaultTheme}>
                 {demo === 'Button' && (
                   <Box
                     sx={{


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Problem

Demo components were not displaying correctly in dark mode.

## What Changed

- Updated homepage demos to use `defaultTheme`.
- Fixed dark-mode rendering issues for demo components.

## Screenshots

| Before | After |
|---------|--------|
|<img width="731" height="296" alt="image" src="https://github.com/user-attachments/assets/4eab9184-19a0-4790-bb5b-f6fd7e9f1ec1" />|<img width="695" height="305" alt="image" src="https://github.com/user-attachments/assets/d358979f-f465-4824-a4d5-9ef3b74cd108" />|
|<img width="589" height="161" alt="image" src="https://github.com/user-attachments/assets/800ed4ea-ce5c-47a6-a59e-389f9efc7342" />|<img width="518" height="158" alt="image" src="https://github.com/user-attachments/assets/bda60f8d-8f36-4ea9-978b-c5c3b941137b" />|
|<img width="699" height="274" alt="image" src="https://github.com/user-attachments/assets/409a55da-d6c8-4791-9196-991ed11cb251" />|<img width="686" height="269" alt="image" src="https://github.com/user-attachments/assets/b77f75db-274d-4be6-971e-a03647c0a086" />|
|<img width="699" height="184" alt="image" src="https://github.com/user-attachments/assets/d841dd89-7749-41de-9011-538cd26ce017" />|<img width="699" height="180" alt="image" src="https://github.com/user-attachments/assets/29fdb4c1-9005-4c0e-9dfd-9124ba29c89f" />|
|<img width="690" height="172" alt="image" src="https://github.com/user-attachments/assets/5f3c8462-8448-480c-b140-fa20b39fb0fe" />|<img width="666" height="164" alt="image" src="https://github.com/user-attachments/assets/9966279f-afea-4413-8e94-b40353ee7260" />|




