### PR TITLE
[code-infra] Migrate CircleCI jobs to Gen2 resource classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ default-job: &default-job
   executor:
     name: code-infra/mui-node
     node-version: '22.18'
-  resource_class: medium
+  resource_class: medium.gen2
 
 default-context: &default-context
   context:
@@ -132,7 +132,7 @@ jobs:
             git add -A && git diff --exit-code --staged
   test_types:
     <<: *default-job
-    resource_class: medium+
+    resource_class: medium+.gen2
     steps:
       - checkout
       - install-deps
@@ -152,7 +152,7 @@ jobs:
           command: pnpm typescript:module-augmentation
   test_types_next:
     <<: *default-job
-    resource_class: medium+
+    resource_class: medium+.gen2
     steps:
       - checkout
       - install-deps:
@@ -176,7 +176,7 @@ jobs:
             node scripts/testBuiltTypes.mjs
   test_browser_legacy:
     <<: *default-job
-    resource_class: medium+
+    resource_class: medium+.gen2
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.49.1-noble
@@ -206,7 +206,7 @@ jobs:
           path: test-results
   test_browser:
     <<: *default-job
-    resource_class: medium+
+    resource_class: medium+.gen2
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.59.1-noble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,7 @@ jobs:
           path: test-results
   test_e2e:
     <<: *default-job
+    resource_class: medium
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.59.1-noble
@@ -244,6 +245,7 @@ jobs:
   test_e2e_website:
     # NOTE: This workflow runs after successful docs deploy. See /test/e2e-website/README.md#ci
     <<: *default-job
+    resource_class: medium
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.59.1-noble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
       - code-infra/valelint
   test_static:
     <<: *default-job
+    resource_class: medium
     steps:
       - checkout
       - install-deps
@@ -259,6 +260,7 @@ jobs:
             PLAYWRIGHT_TEST_BASE_URL: << parameters.e2e-base-url >>
   test_regressions:
     <<: *default-job
+    resource_class: medium
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.59.1-noble
@@ -448,6 +450,7 @@ jobs:
           command: pnpm start
   test_bundle_size_monitor:
     <<: *default-job
+    resource_class: medium
     steps:
       - checkout
       - install-deps

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13663,7 +13663,7 @@ snapshots:
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1))
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1))
       eslint-plugin-compat: 7.0.1(eslint@10.3.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.3.0(jiti@2.6.1))
       eslint-plugin-mdx: 3.7.0(eslint@10.3.0(jiti@2.6.1))
       eslint-plugin-mocha: 11.2.0(eslint@10.3.0(jiti@2.6.1))
@@ -17478,7 +17478,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.9.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -17528,7 +17528,7 @@ snapshots:
       lodash: 4.18.1
       pkg-dir: 5.0.0
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1)))(eslint@10.3.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@10.3.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary

CircleCI shipped Gen2 x86 Docker resource classes (GA 2026-05-04). They cost +20% per minute over Gen1 but advertise ~1.4× wall-clock speedup, so anything faster than 1.2× is a net credit win.

We just landed the same migration on mui-x in mui/mui-x#22610 (~21% credit reduction). This PR replicates that for material-ui: an all-Gen2 lift, then revert any job that doesn't clear 1.20× comfortably.

## Per-job results

Four PR runs on this branch (one with a partial failure on test_browser_legacy, excluded from that row only). PR averages vs master 24h Insights median.

| Job | Final class | Master median | PR avg (Gen2) | Speedup | Decision |
|---|---|---:|---:|---:|---|
| test_browser | medium+.gen2 | 399s | 196.3s | **2.03×** | Keep Gen2 |
| test_browser_legacy | medium+.gen2 | 378s | 227.9s | **1.66×** | Keep Gen2 |
| test_unit | medium.gen2 | 180s | 114.1s | **1.58×** | Keep Gen2 |
| test_lint | medium.gen2 | 116s | 76.3s* | **1.52×** | Keep Gen2 |
| test_types | medium+.gen2 | 460s | 321.2s | **1.43×** | Keep Gen2 |
| test_regressions | medium (Gen1) | 276s | 226.2s | 1.22× | **Revert** |
| test_bundle_size_monitor | medium (Gen1) | 186s | 151.4s | 1.23× | **Revert** |
| test_static | medium (Gen1) | 200s | 181.3s | 1.10×† | **Revert** |
| test_e2e | medium (Gen1) | 69s | 60.5s | 1.14× | **Revert** |
| test_e2e_website | medium (Gen1) | — | 83.2s | n/a | **Revert**‡ |

\* test_lint run #2 had a 150s ESLint step (vs 9-20s normally on every other run including master) — treated as a transient infra hiccup and excluded.
† test_static N=2 valid Gen2 runs (run #1 failed at the dedupe check, fixed in `485751e6`).
‡ test_e2e_website doesn't run on master (triggered after docs deploy), so no master baseline. Reverted in line with the rest of the e2e jobs — all IO-bound (image pull + pnpm install + Playwright dominates wall-clock).

Run #4 (commit `cf72803021`) validates the five reverts — each ran on its expected `medium` Gen1 executor.

## Credit math

Per pipeline run, using master medians × Gen1 rates vs PR Gen2 averages × Gen2 rates (Gen1 jobs use master median as the steady-state estimate).

| | Per pipeline run |
|---|---:|
| Master baseline (Gen1 everywhere) | **480 cr** |
| This PR (Gen2 for 5 CPU-bound jobs, Gen1 elsewhere) | **383 cr** |
| **Reduction** | **−97 cr (−20.2%)** |

Where the savings come from:

| Job | Master Gen1 | Post-PR | Δ |
|---|---:|---:|---:|
| test_browser | 100 cr | 59 cr | −41 cr |
| test_browser_legacy | 95 cr | 68 cr | −27 cr |
| test_types | 115 cr | 96 cr | −19 cr |
| test_unit | 30 cr | 23 cr | −7 cr |
| test_lint | 19 cr | 15 cr | −4 cr |
| 5 reverted jobs | 121 cr | 121 cr | ±0 cr |

In line with mui-x's −21 to −23% range.

## Caveats / follow-ups

- N=3-4 PR runs is still a small sample. The three borderline reverts (test_static / test_bundle_size_monitor / test_regressions) sat between 1.10× and 1.23×; if a future iteration sees them consistently above 1.25× on master, flipping them back to Gen2 in a follow-up is a one-line change each.
- test_lint had a one-run ESLint outlier (150s vs ~10-20s normally). If it recurs on master, it's a Gen2-specific issue to investigate, not a Gen1 reversion candidate.

## Test plan

- [x] CI green on `pipeline` workflow across 4 PR runs.
- [x] Per-job medians collected from CircleCI Insights API + 4 PR runs.
- [x] Sub-1.25× jobs reverted to Gen1 explicit override.
- [x] Run #4 confirms the reverted jobs use `medium` Gen1 executor.
- [x] Credit estimate documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
