### PR TITLE
[code-infra] Make @mui/internal-docs-utils compatible with TypeScript 6

### DIFF
--- a/packages-internal/docs-utils/package.json
+++ b/packages-internal/docs-utils/package.json
@@ -16,8 +16,7 @@
     "release:publish:dry-run": "pnpm build && pnpm publish --tag latest --registry=\"http://localhost:4873/\""
   },
   "dependencies": {
-    "rimraf": "^6.1.3",
-    "typescript": "^5.9.3"
+    "rimraf": "^6.1.3"
   },
   "publishConfig": {
     "access": "public",
@@ -25,5 +24,11 @@
   },
   "exports": {
     ".": "./src/index.ts"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
+  },
+  "peerDependencies": {
+    "typescript": "^5.9.3 || ^6.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -818,8 +818,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+    devDependencies:
       typescript:
-        specifier: ^5.9.3
+        specifier: 5.9.3
         version: 5.9.3
     publishDirectory: build
 


### PR DESCRIPTION
## Summary

Makes `@mui/internal-docs-utils` compatible with TypeScript 6 ahead of the repo-wide TS 6 upgrade.

The package re-exports the TypeScript compiler API types (`ts.Symbol`, `ts.Type`, `ts.Program`, `ts.Node`) in its public API and operates on AST nodes its consumers create. So it must share a **single** `typescript` instance with whoever consumes it — a bundled `dependencies` copy invites duplicate-typescript type incompatibilities and `SyntaxKind` enum mismatches.

- Move `typescript` from `dependencies` to `peerDependencies` with range `^5.9.3 || ^6.0.0` (admits TS 6 while keeping 5.9 working).
- Add a pinned `typescript` `devDependency` (`5.9.3`) so the package still typechecks/builds standalone.

The previous `^5.9.3` direct dependency excluded `6.x`, which would have caused pnpm to resolve a separate `typescript@5.9.3` for this package — silently keeping its typecheck on 5.9 and creating a version mismatch for consumers on TS 6.

The source itself required no changes: it already typechecks and emits declarations cleanly against `typescript@6.0.0-dev` (verified locally).

### Downstream note

This is a published package also consumed by `mui-x`. Moving `typescript` to `peerDependencies` is a (minor) change to the published dependency contract, but both in-repo consumers (`api-docs-builder`, `scripts`) and `mui-x` already depend on `typescript`, so the peer requirement stays satisfied.