### PR TITLE
[code-infra] Shard test_unit tests across CPUs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,22 @@ jobs:
           react-version: << parameters.react-version >>
       - run:
           name: Tests fake browser
-          command: pnpm test:node --no-isolate --no-file-parallelism
+          # Shard the suite into one run per vCPU (medium.gen2 = 2) and run the
+          # shards concurrently to saturate the CPUs. Each shard stays serial and
+          # non-isolated (`--no-isolate --no-file-parallelism`) — turning isolation
+          # back on is dramatically slower — so the parallelism comes from the
+          # shards, not from vitest's in-process pool. Ported from mui/mui-x#20179.
+          # `--reporter=blob` lets `vitest run --merge-reports` stitch the shard
+          # results back together; `--reporter=dot` keeps output flowing so the
+          # CircleCI step doesn't hit the no-output timeout (mui/mui-x#20193).
+          command: |
+            pnpm exec concurrently \
+              "pnpm test:node --no-isolate --no-file-parallelism --reporter=blob --reporter=dot --shard=1/2" \
+              "pnpm test:node --no-isolate --no-file-parallelism --reporter=blob --reporter=dot --shard=2/2" \
+              || TEST_EXIT_CODE=$?
+            pnpm exec vitest run --merge-reports
+            # Reports merged — exit with the stored shard exit code.
+            exit ${TEST_EXIT_CODE:-0}
       - run:
           name: internal-scripts
           command: |


### PR DESCRIPTION
## Summary

Pivoted from the regression-cleanup idea (which landed separately as #48601) to the real prize: **`test_unit` runs serially on a 2-vCPU box, using only one core.** This shards it into 2 concurrent runs to saturate both — **no resource-class change, so it's credit-neutral** (same per-minute rate, fewer minutes).

Ported from mui/mui-x#20179.

## Why sharding, not vitest's in-process parallelism

mui-x established that **re-enabling isolation is dramatically slower** — mui/mui-x#22434 (*Enable isolation*) was closed, not merged. So the win comes from **process-level sharding**, each shard kept `--no-isolate --no-file-parallelism`, rather than vitest's isolated worker pool:

- mui/mui-x#20179 — shard to saturate idle CPUs → ~35% faster + credits down
- mui/mui-x#21558 — `large` + 4 shards → another ~40%, *"scales linearly by CPU"*
- mui/mui-x#20193 — add `--reporter=dot` so blob's buffered output doesn't trip the CircleCI no-output timeout

## Change

`test_unit` → "Tests fake browser" now runs:

```bash
pnpm exec concurrently \
  "pnpm test:node --no-isolate --no-file-parallelism --reporter=blob --reporter=dot --shard=1/2" \
  "pnpm test:node --no-isolate --no-file-parallelism --reporter=blob --reporter=dot --shard=2/2" \
  || TEST_EXIT_CODE=$?
pnpm exec vitest run --merge-reports
exit ${TEST_EXIT_CODE:-0}
```

Still on `medium.gen2` (2 vCPU). `--merge-reports` re-applies the configured reporters, so `store_test_results` output is preserved.

## Measuring

- [ ] `test_unit` duration vs master median (~122s)
- [ ] both shards green; merged report intact
- [ ] peak RAM stays under 4 GB (2 concurrent jsdom processes)
- [ ] if it pays → follow-up: `large.gen2` + 4 shards (mui/mui-x#21558)

> [!NOTE]
> Branch name (`test-regressions-concurrency`) is stale — kept to preserve this PR thread after pivoting from the regression experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
