### PR TITLE
[code-infra] Fix duplicate resource_class in test_regressions CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,11 +260,10 @@ jobs:
             PLAYWRIGHT_TEST_BASE_URL: << parameters.e2e-base-url >>
   test_regressions:
     <<: *default-job
-    resource_class: medium
+    resource_class: medium+
     executor:
       name: code-infra/mui-node-browser
       playwright-img-version: v1.59.1-noble
-    resource_class: 'medium+'
     steps:
       - checkout
       - install-deps:


### PR DESCRIPTION
## Problem

CircleCI fails to parse `.circleci/config.yml` — every pipeline on `master` errors before any job runs (e.g. [pipeline 175531](https://app.circleci.com/pipelines/github/mui/material-ui/175531)):

```
Unable to parse YAML
  found duplicate key resource_class
  in 'string', line 267
```

The `test_regressions` job has two `resource_class` keys:

```yaml
  test_regressions:
    <<: *default-job
    resource_class: medium       # ← #48593
    executor:
      name: code-infra/mui-node-browser
      playwright-img-version: v1.59.1-noble
    resource_class: 'medium+'    # ← #48557
    steps:
```

YAML forbids duplicate keys in a mapping, so the whole config is rejected.

## Root cause

A logical merge conflict between two PRs that landed ~3h apart, both editing `test_regressions`'s resource class on different lines (so no textual git conflict):

| Time (May 29) | PR | Change |
|---|---|---|
| 11:37 | #48557 | adds `resource_class: 'medium+'` after the executor block |
| 14:57 | #48593 | adds `resource_class: medium` after `<<: *default-job` |

#48593 branched before #48557 landed, so each PR was green in isolation; the duplicate only materialized once both were on `master`.

## Fix

Consolidate to a single `resource_class: medium+`, placed directly under `<<: *default-job` (unquoted) to match the other executor jobs (`test_browser`, `test_browser_legacy`, `test_e2e`, `test_e2e_website`):

```yaml
  test_regressions:
    <<: *default-job
    resource_class: medium+
    executor:
      name: code-infra/mui-node-browser
      playwright-img-version: v1.59.1-noble
    steps:
```

- `medium+` is still a Gen1 class, so #48593's intent (revert this job off Gen2) is preserved.
- It keeps #48557's bump for the now-parallelized visual regression screenshots.

`test_regressions` was the only job with a duplicate — and the only one placing `resource_class` after `executor` and quoting the value. The other reverted jobs had no pre-existing override.

## Test plan

- [x] Reproduced CircleCI's exact error against `master`'s config with a strict node-level YAML check.
- [x] Confirmed the patched config parses with no duplicate keys.
- [ ] CircleCI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
