### PR TITLE
[InitColorSchemeScript] Server-render in tests for React 19.3

### DIFF
--- a/packages/mui-material/src/InitColorSchemeScript/InitColorSchemeScript.test.tsx
+++ b/packages/mui-material/src/InitColorSchemeScript/InitColorSchemeScript.test.tsx
@@ -3,10 +3,10 @@ import { createRenderer } from '@mui/internal-test-utils';
 import InitColorSchemeScript from '@mui/material/InitColorSchemeScript';
 
 describe('InitColorSchemeScript', () => {
-  const { render } = createRenderer();
+  const { renderToString } = createRenderer();
 
   it('should render as expected', () => {
-    const { container } = render(<InitColorSchemeScript />);
+    const { container } = renderToString(<InitColorSchemeScript />);
     expect(container.firstChild).to.have.tagName('script');
   });
 });

--- a/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.test.js
+++ b/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.test.js
@@ -9,7 +9,10 @@ import {
 } from './InitColorSchemeScript';
 
 describe('InitColorSchemeScript', () => {
-  const { render } = createRenderer();
+  // `InitColorSchemeScript` is only ever rendered on the server (Next.js `_document` or the App
+  // Router root layout), so render it to a string here. A client mount of a `<script>` triggers a
+  // React warning (and is a non-executing no-op) starting with React 19.3.
+  const { renderToString } = createRenderer();
   let originalMatchmedia;
   let storage = {};
   const createMatchMedia = (matches) => () => ({
@@ -41,7 +44,7 @@ describe('InitColorSchemeScript', () => {
     storage[DEFAULT_MODE_STORAGE_KEY] = 'light';
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-light`] = 'foo';
 
-    const { container } = render(<InitColorSchemeScript />);
+    const { container } = renderToString(<InitColorSchemeScript />);
     eval(container.firstChild.textContent);
     expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('foo');
   });
@@ -51,7 +54,7 @@ describe('InitColorSchemeScript', () => {
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-light`] = 'foo';
     document.documentElement.classList.remove(...document.documentElement.classList);
 
-    const { container } = render(<InitColorSchemeScript attribute="class" />);
+    const { container } = renderToString(<InitColorSchemeScript attribute="class" />);
     expect(container.firstChild.textContent.replace(/\s/g, '')).not.to.include(
       "setAttribute('.%s',colorScheme)",
     );
@@ -64,7 +67,7 @@ describe('InitColorSchemeScript', () => {
     storage[DEFAULT_MODE_STORAGE_KEY] = 'light';
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-light`] = 'foo';
 
-    const { container } = render(<InitColorSchemeScript attribute="data" />);
+    const { container } = renderToString(<InitColorSchemeScript attribute="data" />);
     eval(container.firstChild.textContent);
     expect(document.documentElement.getAttribute('data-foo')).to.equal('');
   });
@@ -73,7 +76,7 @@ describe('InitColorSchemeScript', () => {
     storage['mui-foo-mode'] = 'light';
     storage[`mui-bar-color-scheme-light`] = 'flash';
 
-    const { container } = render(
+    const { container } = renderToString(
       <InitColorSchemeScript
         modeStorageKey="mui-foo-mode"
         colorSchemeStorageKey="mui-bar-color-scheme"
@@ -89,12 +92,12 @@ describe('InitColorSchemeScript', () => {
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-light`] = 'foo';
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-dark`] = 'bar';
 
-    const { container, rerender } = render(<InitColorSchemeScript attribute=".mode-%s" />);
+    let { container } = renderToString(<InitColorSchemeScript attribute=".mode-%s" />);
     eval(container.firstChild.textContent);
     expect(document.documentElement.classList.value).to.equal('mode-foo');
 
     storage[DEFAULT_MODE_STORAGE_KEY] = 'dark';
-    rerender(<InitColorSchemeScript attribute=".mode-%s" />);
+    ({ container } = renderToString(<InitColorSchemeScript attribute=".mode-%s" />));
     eval(container.firstChild.textContent);
     expect(document.documentElement.classList.value).to.equal('mode-bar');
 
@@ -106,13 +109,13 @@ describe('InitColorSchemeScript', () => {
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-light`] = 'foo';
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-dark`] = 'bar';
 
-    const { container, rerender } = render(<InitColorSchemeScript attribute="[data-mode-%s]" />);
+    let { container } = renderToString(<InitColorSchemeScript attribute="[data-mode-%s]" />);
     eval(container.firstChild.textContent);
     expect(document.documentElement.getAttribute('data-mode-foo')).to.equal('');
     expect(document.documentElement.getAttribute('data-mode-bar')).to.equal(null);
 
     storage[DEFAULT_MODE_STORAGE_KEY] = 'dark';
-    rerender(<InitColorSchemeScript attribute="[data-mode-%s]" />);
+    ({ container } = renderToString(<InitColorSchemeScript attribute="[data-mode-%s]" />));
     eval(container.firstChild.textContent);
     expect(document.documentElement.getAttribute('data-mode-bar')).to.equal('');
     expect(document.documentElement.getAttribute('data-mode-foo')).to.equal(null);
@@ -123,12 +126,12 @@ describe('InitColorSchemeScript', () => {
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-light`] = 'foo';
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-dark`] = 'bar';
 
-    const { container, rerender } = render(<InitColorSchemeScript attribute="[data-mode='%s']" />);
+    let { container } = renderToString(<InitColorSchemeScript attribute="[data-mode='%s']" />);
     eval(container.firstChild.textContent);
     expect(document.documentElement.getAttribute('data-mode')).to.equal('foo');
 
     storage[DEFAULT_MODE_STORAGE_KEY] = 'dark';
-    rerender(<InitColorSchemeScript attribute="[data-mode='%s']" />);
+    ({ container } = renderToString(<InitColorSchemeScript attribute="[data-mode='%s']" />));
     eval(container.firstChild.textContent);
     expect(document.documentElement.getAttribute('data-mode')).to.equal('bar');
   });
@@ -137,7 +140,7 @@ describe('InitColorSchemeScript', () => {
     storage[DEFAULT_MODE_STORAGE_KEY] = 'dark';
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-dark`] = 'bar';
 
-    const { container } = render(<InitColorSchemeScript />);
+    const { container } = renderToString(<InitColorSchemeScript />);
     eval(container.firstChild.textContent);
     expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('bar');
   });
@@ -147,7 +150,7 @@ describe('InitColorSchemeScript', () => {
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-dark`] = 'dim';
     window.matchMedia = createMatchMedia(true);
 
-    const { container } = render(<InitColorSchemeScript />);
+    const { container } = renderToString(<InitColorSchemeScript />);
     eval(container.firstChild.textContent);
     expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('dim');
   });
@@ -157,7 +160,7 @@ describe('InitColorSchemeScript', () => {
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-light`] = 'bright';
     window.matchMedia = createMatchMedia(false);
 
-    const { container } = render(<InitColorSchemeScript />);
+    const { container } = renderToString(<InitColorSchemeScript />);
     eval(container.firstChild.textContent);
     expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('bright');
   });
@@ -166,7 +169,9 @@ describe('InitColorSchemeScript', () => {
     it('should set dark color scheme to body, given prefers-color-scheme is `dark`', () => {
       window.matchMedia = createMatchMedia(true);
 
-      const { container } = render(<InitColorSchemeScript defaultDarkColorScheme="trueDark" />);
+      const { container } = renderToString(
+        <InitColorSchemeScript defaultDarkColorScheme="trueDark" />,
+      );
       eval(container.firstChild.textContent);
       expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('trueDark');
     });
@@ -174,7 +179,9 @@ describe('InitColorSchemeScript', () => {
     it('should set light color scheme to body, given prefers-color-scheme is NOT `dark`', () => {
       window.matchMedia = createMatchMedia(false);
 
-      const { container } = render(<InitColorSchemeScript defaultLightColorScheme="yellow" />);
+      const { container } = renderToString(
+        <InitColorSchemeScript defaultLightColorScheme="yellow" />,
+      );
       eval(container.firstChild.textContent);
       expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('yellow');
     });


### PR DESCRIPTION
The `nightly-cron` `react@next` jobs (`test_unit-react@next`, `test_browser-react@next`) fail on `InitColorSchemeScript`:

> Encountered a script tag while rendering React component. Scripts inside React components are never executed when rendering on the client. Consider using template tag instead.

This is a new dev-only error in React 19.3 (`react-dom@19.3.0-canary`), emitted when a `<script>` is created during a **fresh client mount**. It does **not** fire during SSR or hydration (React adopts the existing node), so it never triggers in documented usage — `InitColorSchemeScript` is only rendered server-side (Next.js `_document` or the App Router root layout). The only thing client-mounting it is the test suite (`createRenderer().render`), where the script is also a non-executing no-op.

The fix renders the component the way it's actually used: swap `render` → the existing `renderToString` helper. No component/runtime changes — `InitColorSchemeScript` stays hook-free with zero client runtime.

Verified green under `react@next` (`19.3.0-canary-d5736f09`) and pinned React, in both the node and chromium environments.
