### PR TITLE
[Tabs] Fix React 18 roving tabindex and dedupe invalid-value warning

### DIFF
--- a/packages/mui-material/src/Tabs/Tabs.js
+++ b/packages/mui-material/src/Tabs/Tabs.js
@@ -229,6 +229,11 @@ const TabsScrollbarSize = styled(ScrollbarSize)({
 
 const defaultIndicatorStyle = {};
 
+// Dev-only: tracks per-`Tabs` instance (keyed by its ref) whether the invalid-value warning was
+// already logged, so it isn't repeated across the several effects that call `getTabsMeta`.
+// Only referenced from `process.env.NODE_ENV !== 'production'` blocks; the `@__PURE__` annotation
+// lets minifiers drop it (and the `WeakMap` allocation) entirely from production builds.
+const warnedTabValueInvalid = /* @__PURE__ */ new WeakMap();
 let warnedOnceTabPresent = false;
 
 const Tabs = React.forwardRef(function Tabs(inProps, ref) {
@@ -357,7 +362,9 @@ const Tabs = React.forwardRef(function Tabs(inProps, ref) {
       if (children.length > 0) {
         const tab = children[valueToIndex.get(value)];
         if (process.env.NODE_ENV !== 'production') {
-          if (!tab) {
+          // `getTabsMeta` runs from several effects, so guard against logging the warning repeatedly.
+          if (!tab && !warnedTabValueInvalid.has(tabsRef)) {
+            warnedTabValueInvalid.set(tabsRef, true);
             console.error(
               [
                 `MUI: The \`value\` provided to the Tabs component is invalid.`,

--- a/packages/mui-material/src/Tabs/Tabs.test.js
+++ b/packages/mui-material/src/Tabs/Tabs.test.js
@@ -5,7 +5,6 @@ import {
   act,
   createRenderer,
   fireEvent,
-  reactMajor,
   screen,
   strictModeDoubleLoggingSuppressed,
   waitFor,
@@ -488,16 +487,8 @@ describe.skipIf(isSafari)('<Tabs />', () => {
               <Tab value={3} />
             </Tabs>,
           );
-        }).toErrorDev([
-          'You can provide one of the following values: 1, 3',
-          // React Strict Mode runs mount effects twice
-          reactMajor >= 18 && 'You can provide one of the following values: 1, 3',
-          'You can provide one of the following values: 1, 3',
-          // React Strict Mode runs mount effects twice
-          reactMajor >= 18 && 'You can provide one of the following values: 1, 3',
-          'You can provide one of the following values: 1, 3',
-          'You can provide one of the following values: 1, 3',
-        ]);
+          // The warning is logged only once (see `warnedOnceTabValueInvalid`).
+        }).toErrorDev(['You can provide one of the following values: 1, 3']);
       });
 
       describe.skipIf(!isJsdom())('hidden tab / tabs', () => {

--- a/packages/mui-material/src/Tabs/Tabs.test.js
+++ b/packages/mui-material/src/Tabs/Tabs.test.js
@@ -487,7 +487,7 @@ describe.skipIf(isSafari)('<Tabs />', () => {
               <Tab value={3} />
             </Tabs>,
           );
-          // The warning is logged only once (see `warnedOnceTabValueInvalid`).
+          // The warning is logged only once (see `warnedTabValueInvalid`).
         }).toErrorDev(['You can provide one of the following values: 1, 3']);
       });
 

--- a/packages/mui-utils/src/useRovingTabIndex/useRovingTabIndex.ts
+++ b/packages/mui-utils/src/useRovingTabIndex/useRovingTabIndex.ts
@@ -207,11 +207,13 @@ export function useRovingTabIndexRoot<Key = unknown>(
     activeItemIdProp,
   );
 
-  const previousActiveItemIdPropRef = React.useRef<Key | null | undefined>(activeItemIdProp);
+  const [previousActiveItemIdProp, setPreviousActiveItemIdProp] = React.useState<
+    Key | null | undefined
+  >(activeItemIdProp);
   let activeItemIdCandidate = activeItemIdState;
 
-  if (activeItemIdProp !== previousActiveItemIdPropRef.current) {
-    previousActiveItemIdPropRef.current = activeItemIdProp;
+  if (activeItemIdProp !== previousActiveItemIdProp) {
+    setPreviousActiveItemIdProp(activeItemIdProp);
 
     if (activeItemIdProp !== undefined && activeItemIdProp !== activeItemIdState) {
       activeItemIdCandidate = activeItemIdProp;


### PR DESCRIPTION
Fixes the `nightly-cron` `test_unit-react@18` failures in `Tabs.test.js`. Both reproduce only under React 18 (pass under React 19/next), and have separate causes.

## 1. `useRovingTabIndex`: active item not updating under React 18 (real bug)

`<Tabs>` did not move the roving `tabIndex` to the newly selected tab when the `value` prop changed under React 18 (confirmed with `waitFor` — it never converges, so it's a behavior bug, not test timing). React 18 is a supported peer dependency, so this affects real users.

The hook derived state from the `activeItemId` prop by **mutating a ref during render**:

```ts
const previousActiveItemIdPropRef = React.useRef(activeItemIdProp);
if (activeItemIdProp !== previousActiveItemIdPropRef.current) {
  previousActiveItemIdPropRef.current = activeItemIdProp; // mutating a ref during render
  ...
}
```

That isn't idempotent under StrictMode's double-render: React resets *state* between the two render invocations but preserves *ref* mutations, so on the replay the guard already sees the new value and skips the update. Switched to the documented "store the previous prop in **state**" pattern.

## 2. `Tabs`: invalid `value` warning logged from every effect

The invalid-`value` dev warning lives inside `getTabsMeta`, which runs from several effects, so it logged multiple times per mount and the count varied under React 18 StrictMode. Guarded it with a `WeakMap` keyed by the `Tabs` instance's ref, so the warning is logged once **per instance** (rather than once globally — a global flag would persist across instances/tests and suppress later warnings). The `WeakMap` is only referenced from `process.env.NODE_ENV !== 'production'` blocks and carries a `/* @__PURE__ */` annotation, so minifiers drop it (and the allocation) from production builds. Simplified the test expectation accordingly.

## Verification

`useRovingTabIndex` + `Tabs` + `MenuList` + `Stepper` + `MobileStepper` test suites pass under **both** react@18 (`useReactVersion ^18`) and react@next (`19.3.0-canary`).
