### PR TITLE
[material-ui] Keep CSS theme variables out of the default theme

### DIFF
--- a/packages/mui-material/src/styles/defaultTheme.js
+++ b/packages/mui-material/src/styles/defaultTheme.js
@@ -1,6 +1,11 @@
 'use client';
-import createTheme from './createTheme';
+// `createTheme()` with no arguments is definitionally identical to `createThemeNoVars()`
+// (the public `createTheme` returns `createThemeNoVars(options)` for the default
+// `cssVariables: false` path). Importing `createThemeNoVars` directly keeps the CSS
+// theme-variables machinery (`createThemeWithVars` and friends) out of every component
+// bundle that only needs this default fallback theme.
+import createThemeNoVars from './createThemeNoVars';
 
-const defaultTheme = createTheme();
+const defaultTheme = createThemeNoVars();
 
 export default defaultTheme;


### PR DESCRIPTION
`defaultTheme` is built through the public `createTheme()`, which statically imports **both** `createThemeNoVars` and `createThemeWithVars` and selects one at runtime based on the `cssVariables` option. Because that dispatch is a runtime branch, bundlers can't tree-shake the unused CSS-variables path, so the whole `createThemeWithVars` machinery (and its helpers: `createColorScheme`, `createGetSelector`, `excludeVariablesFromRoot`, `getOverlayAlpha`, `prepareTypographyVars`) ends up in every component bundle that only needs the default fallback theme.

`createTheme()` with no arguments is definitionally identical to `createThemeNoVars()` — the default `cssVariables: false` path returns `createThemeNoVars(options)`, and `createThemeNoVars` does not depend on `createThemeWithVars`. Importing it directly produces a byte-identical default theme while letting the dead CSS-vars code be dropped.

The public `createTheme` export is untouched, so consumers who opt into CSS theme variables are unaffected.

## Bundle size impact

Measured with `test/bundle-size` (gzip):

| bundle | before | after | change |
| --- | ---: | ---: | ---: |
| `@mui/material/Button` | 25.29 kB | 20.55 kB | **-18.8%** |
| `@mui/material/Typography` | 18.76 kB | 14.07 kB | **-25.0%** |
| `@mui/material/IconButton` | 24.27 kB | 19.54 kB | -19.5% |
| `@mui/material/Checkbox` | 25.53 kB | 20.76 kB | -18.7% |
| `@mui/material/Slider` | 25.33 kB | 20.57 kB | -18.8% |
| `@mui/material/Switch` | 25.20 kB | 20.45 kB | -18.8% |
| `@mui/material` (barrel) | 148.92 kB | 148.92 kB | unchanged |
| `@mui/material/styles#createTheme` | 14.57 kB | 14.57 kB | unchanged |

~4.7 kB gzip (~18 kB parsed) off essentially [every component](https://code-infra-dashboard.onrender.com/size-comparison/mui/material-ui/diff?sha=9763acef2ba6f046f8b3f9529c6834173c6bef97&base=7e015debaef9d51e79995855cb5f008eb7680df9&prNumber=48607&baseRef=master), while the `@mui/material` barrel and the public `createTheme` entry are unchanged.
