### PR TITLE
[docs] Add accessibility guidance for Popper, Popover, and Portal

### DIFF
--- a/docs/data/material/components/popover/popover.md
+++ b/docs/data/material/components/popover/popover.md
@@ -69,6 +69,14 @@ This is different from virtual elements used for the [`Popper`](/material-ui/rea
 Popover uses [Grow](/material-ui/transitions/#grow) by default.
 Use `slots.transition` and `slotProps.transition` to replace it with another transition or to pass transition props.
 
+## Accessibility
+
+The Popover component is built on top of the [Modal](/material-ui/react-modal/) component.
+It does not automatically describe the purpose of the popover content, so add an accessible label or description when the content needs context.
+
+Make sure the element that opens the popover can be reached and operated with the keyboard.
+If the popover contains interactive content, follow the WAI-ARIA pattern for the interaction, such as a [dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) or [menu](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/).
+
 ## Supplementary projects
 
 For more advanced use cases, you might be able to take advantage of:

--- a/docs/data/material/components/popper/popper.md
+++ b/docs/data/material/components/popper/popper.md
@@ -63,6 +63,13 @@ Highlight part of the text to see the popper:
 
 {{"demo": "VirtualElementPopper.js"}}
 
+## Accessibility
+
+The Popper component is a positioning utility and does not add roles, focus management, or keyboard behavior on its own.
+When you use it to build an interactive widget, follow the WAI-ARIA pattern for that widget, such as a [tooltip](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/), [menu](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/), or [dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/).
+
+If the popper should close when users interact outside of it, use the [Click-Away Listener](/material-ui/react-click-away-listener/) and make sure the trigger can be reached and operated with the keyboard.
+
 ## Supplementary projects
 
 For more advanced use cases you might be able to take advantage of:

--- a/docs/data/material/components/portal/portal.md
+++ b/docs/data/material/components/portal/portal.md
@@ -55,3 +55,11 @@ The Portal component cannot be used to render child elements on the server—cli
 This is because React doesn't support the [`createPortal()` API](https://react.dev/reference/react-dom/createPortal) on the server.
 See [this GitHub issue](https://github.com/facebook/react/issues/13097) for details.
 :::
+
+## Accessibility
+
+The Portal component only changes where its children are mounted in the DOM.
+It does not add roles, focus management, or keyboard behavior.
+
+When you render interactive content through a Portal, make sure users can reach it with the keyboard and move focus back to the trigger when the interaction is complete.
+For modal experiences, use the [Modal](/material-ui/react-modal/) component or follow the WAI-ARIA [dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/).


### PR DESCRIPTION
Addresses part of #20600.

This PR adds accessibility guidance to three overlay/positioning utility pages:

- Popper
- Popover
- Portal

These sections clarify that these utilities do not add roles, focus management, or keyboard behavior by themselves, and point users to the relevant WAI-ARIA patterns or MUI components.

Verification:
- `grep -n "^## Accessibility$" docs/data/material/components/popper/popper.md docs/data/material/components/popover/popover.md docs/data/material/components/portal/portal.md`
- `git diff --check`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).