### PR TITLE
[autocomplete] Fix `freeSolo` controlled values cleared by initial `null`

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -3161,6 +3161,33 @@ describe('<Autocomplete />', () => {
   });
 
   describe('prop: freeSolo', () => {
+    it('should not reset a controlled inputValue on mount', () => {
+      const handleInputChange = spy();
+
+      function App() {
+        const [inputValue, setInputValue] = React.useState('Option 1');
+
+        return (
+          <Autocomplete
+            freeSolo
+            value={null}
+            inputValue={inputValue}
+            options={['Option 1', 'Option 2']}
+            onInputChange={(event, newInputValue, reason) => {
+              handleInputChange(event, newInputValue, reason);
+              setInputValue(newInputValue);
+            }}
+            renderInput={(params) => <TextField {...params} />}
+          />
+        );
+      }
+
+      render(<App />);
+
+      expect(screen.getByRole('combobox').value).to.equal('Option 1');
+      expect(handleInputChange.callCount).to.equal(0);
+    });
+
     it('should reset input when controlled value changes to null', async () => {
       function App() {
         const [value, setValue] = React.useState('foo');

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -306,8 +306,11 @@ function useAutocomplete(props) {
       return;
     }
 
-    // Only reset the input's value when freeSolo if the component's value changes.
-    if (freeSolo && !valueChange) {
+    // In freeSolo mode, only reset the input after a real value change.
+    // Also prevent the initial default value of `null` from clearing controlled values.
+    const shouldSkipFreeSoloReset =
+      freeSolo && (!valueChange || (value == null && previousProps.value === undefined));
+    if (shouldSkipFreeSoloReset) {
       return;
     }
 


### PR DESCRIPTION
Before: https://stackblitz.com/edit/nqyvhhjz?file=src%2FDemo.tsx
After: https://stackblitz.com/edit/nqyvhhjz-ayskbqfs?file=package.json

Fixes https://github.com/mui/material-ui/issues/48610

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
