### PR TITLE
[step button] Choose higher contrast ripple color for dark mode focus

### DIFF
--- a/packages/mui-material/src/StepButton/StepButton.js
+++ b/packages/mui-material/src/StepButton/StepButton.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled } from '../zero-styled';
+import memoTheme from '../utils/memoTheme';
 import { useDefaultProps } from '../DefaultPropsProvider';
 import ButtonBase from '../ButtonBase';
 import StepLabel from '../StepLabel';
@@ -36,25 +37,30 @@ const StepButtonRoot = styled(ButtonBase, {
       styles[ownerState.orientation],
     ];
   },
-})({
-  width: '100%',
-  padding: '24px 16px',
-  margin: '-24px -16px',
-  boxSizing: 'content-box',
-  [`& .${stepButtonClasses.touchRipple}`]: {
-    color: 'rgba(0, 0, 0, 0.3)',
-  },
-  variants: [
-    {
-      props: { orientation: 'vertical' },
-      style: {
-        justifyContent: 'flex-start',
-        padding: '8px',
-        margin: '-8px',
-      },
+})(
+  memoTheme(({ theme }) => ({
+    width: '100%',
+    padding: '24px 16px',
+    margin: '-24px -16px',
+    boxSizing: 'content-box',
+    [`& .${stepButtonClasses.touchRipple}`]: {
+      color: 'rgba(0, 0, 0, 0.3)',
+      ...theme.applyStyles('dark', {
+        color: 'rgba(255, 255, 255, 0.3)',
+      }),
     },
-  ],
-});
+    variants: [
+      {
+        props: { orientation: 'vertical' },
+        style: {
+          justifyContent: 'flex-start',
+          padding: '8px',
+          margin: '-8px',
+        },
+      },
+    ],
+  })),
+);
 
 const RovingStepButton = React.forwardRef(function RovingStepButton(props, ref) {
   // eslint-disable-next-line react/prop-types


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/44054.

Adjust dark mode color for step button focus ripple.

Before:
<img width="1592" height="242" alt="image" src="https://github.com/user-attachments/assets/ba662e2c-e3c2-48cc-89b6-2392c3ebf4a4" />

After:
<img width="802" height="200" alt="image" src="https://github.com/user-attachments/assets/0727bc0a-f527-4991-8aa0-dab7261b5c94" />
