### PR TITLE
[docs][icons] Add named import option to the icon click-to-copy dialog

### DIFF
--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -347,10 +347,16 @@ const DialogDetails = React.memo(function DialogDetails(props) {
   const t = useTranslate();
   const [copied1, setCopied1] = React.useState(false);
   const [copied2, setCopied2] = React.useState(false);
+  const [copied3, setCopied3] = React.useState(false);
 
   const handleClick = (tooltip) => async (event) => {
     await copy(event.currentTarget.textContent);
-    const setCopied = tooltip === 1 ? setCopied1 : setCopied2;
+    let setCopied = setCopied1;
+    if (tooltip === 2) {
+      setCopied = setCopied2;
+    } else if (tooltip === 3) {
+      setCopied = setCopied3;
+    }
 
     setCopied(true);
   };
@@ -398,6 +404,20 @@ const DialogDetails = React.memo(function DialogDetails(props) {
               copyButtonHidden
               onClick={handleClick(2)}
               code={`import ${selectedIcon.importName}Icon from '@mui/icons-material/${selectedIcon.importName}';`}
+              language="js"
+            />
+          </Tooltip>
+          <Tooltip
+            placement="bottom"
+            title={copied3 ? t('copied') : t('clickToCopy')}
+            slotProps={{
+              transition: { onExited: () => setCopied3(false) },
+            }}
+          >
+            <Markdown
+              copyButtonHidden
+              onClick={handleClick(3)}
+              code={`import { ${selectedIcon.importName} as ${selectedIcon.importName}Icon } from '@mui/icons-material';`}
               language="js"
             />
           </Tooltip>


### PR DESCRIPTION
## Summary

Closes #29212

The icon click-to-copy dialog on the [Material Icons page](https://mui.com/components/material-icons/) only offered the path import:

```js
import MenuIcon from '@mui/icons-material/Menu';
```

The [usage docs](https://mui.com/material-ui/icons/#usage) document a second import style as well:

```js
import { Menu as MenuIcon } from '@mui/icons-material';
```

This PR adds that second style as an additional click-to-copy block in the same dialog, so users can grab whichever import fits their setup. Both options stay visible — nothing is removed or re-ordered.

## Changes

- Added a `copied3` state and extended `handleClick` to track the new block.
- Added a second `Markdown` click-to-copy block rendering the named import, mirroring the existing one's styling and tooltip behaviour.

Scope is limited to `docs/data/material/components/material-icons/SearchIcons.js`.