### PR TITLE
[select] Allow spacebar to select elements

### DIFF
--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -449,6 +449,36 @@ describe('<Select />', () => {
     expect(options[1]).to.have.attribute('data-value', '20');
   });
 
+  it('should select an option when the space key is pressed', () => {
+    const handleChange = spy();
+    const handleKeyDown = spy();
+    render(
+      <Select value="0" onChange={handleChange}>
+        <MenuItem value="0" onKeyDown={handleKeyDown}>
+          Zero
+        </MenuItem>
+        <MenuItem value="1" onKeyDown={handleKeyDown}>
+          One
+        </MenuItem>
+        <MenuItem value="2" onKeyDown={handleKeyDown}>
+          Two
+        </MenuItem>
+      </Select>,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    fireEvent.mouseDown(trigger);
+
+    const options = screen.getAllByRole('option');
+    fireEvent.keyDown(options[0], { key: 'ArrowDown' });
+    fireEvent.keyDown(options[1], { key: 'ArrowDown' });
+    fireEvent.keyDown(options[2], { key: ' ' });
+
+    expect(handleChange.callCount).to.equal(1);
+    expect(handleKeyDown.callCount).to.equal(3);
+    expect(handleChange.firstCall.args[0].target.value).to.equal('2');
+  });
+
   [' ', 'ArrowUp', 'ArrowDown', 'Enter'].forEach((key) => {
     it(`should open menu when pressed ${key} key on select`, async () => {
       render(

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -524,7 +524,9 @@ describe('<Select />', () => {
     await act(async () => {
       // Dispatch directly to bypass testing-library's active-element guard so that
       // event.target (span) !== event.currentTarget (li) inside the React handler.
-      innerSpan.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }));
+      innerSpan.dispatchEvent(
+        new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }),
+      );
     });
 
     expect(handleChange.callCount).to.equal(0);

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -479,6 +479,79 @@ describe('<Select />', () => {
     expect(handleChange.firstCall.args[0].target.value).to.equal('2');
   });
 
+  it('should call item onKeyDown before triggering selection on space', () => {
+    const callOrder = [];
+    const handleChange = spy(() => callOrder.push('change'));
+    const handleKeyDown = spy(() => callOrder.push('keydown'));
+
+    render(
+      <Select value="" onChange={handleChange}>
+        <MenuItem value="1" onKeyDown={handleKeyDown}>
+          One
+        </MenuItem>
+      </Select>,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    fireEvent.mouseDown(trigger);
+
+    const option = screen.getByRole('option');
+    fireEvent.keyDown(option, { key: ' ' });
+
+    expect(handleKeyDown.callCount).to.equal(1);
+    expect(handleChange.callCount).to.equal(1);
+    expect(callOrder).to.deep.equal(['keydown', 'change']);
+  });
+
+  it('should not select an option when space is pressed on a non-target element', async () => {
+    const handleChange = spy();
+    const handleKeyDown = spy();
+
+    render(
+      <Select value="" onChange={handleChange}>
+        <MenuItem value="1" onKeyDown={handleKeyDown}>
+          <span>One</span>
+        </MenuItem>
+      </Select>,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    fireEvent.mouseDown(trigger);
+
+    const option = screen.getByRole('option');
+    const innerSpan = option.querySelector('span');
+
+    await act(async () => {
+      // Dispatch directly to bypass testing-library's active-element guard so that
+      // event.target (span) !== event.currentTarget (li) inside the React handler.
+      innerSpan.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }));
+    });
+
+    expect(handleChange.callCount).to.equal(0);
+  });
+
+  it('should not select an option when onKeyDown calls preventDefault', () => {
+    const handleChange = spy();
+    const handleKeyDown = spy((event) => event.preventDefault());
+
+    render(
+      <Select value="" onChange={handleChange}>
+        <MenuItem value="1" onKeyDown={handleKeyDown}>
+          One
+        </MenuItem>
+      </Select>,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    fireEvent.mouseDown(trigger);
+
+    const option = screen.getByRole('option');
+    fireEvent.keyDown(option, { key: ' ' });
+
+    expect(handleKeyDown.callCount).to.equal(1);
+    expect(handleChange.callCount).to.equal(0);
+  });
+
   [' ', 'ArrowUp', 'ArrowDown', 'Enter'].forEach((key) => {
     it(`should open menu when pressed ${key} key on select`, async () => {
       render(

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -633,9 +633,15 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   };
 
   const handleItemKeyDown = (child) => (event) => {
-    if (event.key === ' ') {
+    if (event.key === SPACE) {
+      // Prevent the browser from scrolling the page
       event.preventDefault();
-      handleItemClick(child)(event);
+      // Ignore auto-repeated keydowns to avoid toggling multiple times
+      if (!event.repeat) {
+        // Trigger via click so that onClick receives a click event,
+        // consistent with Enter and pointer interactions.
+        event.currentTarget.click();
+      }
     }
 
     child?.props?.onKeyDown?.(event);

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -632,6 +632,15 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     }
   };
 
+  const handleItemKeyDown = (child) => (event) => {
+    if (event.key === ' ') {
+      event.preventDefault();
+      handleItemClick(child)(event);
+    }
+
+    child?.props?.onKeyDown?.(event);
+  };
+
   delete other['aria-invalid'];
 
   let display;
@@ -714,6 +723,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
           child.props.onKeyUp(event);
         }
       },
+      onKeyDown: handleItemKeyDown(child),
       role: 'option',
       selected,
       value: undefined, // The value is most likely not a valid HTML attribute.

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -633,7 +633,9 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   };
 
   const handleItemKeyDown = (child) => (event) => {
-    if (event.key === SPACE && event.target === event.currentTarget) {
+    child?.props?.onKeyDown?.(event);
+
+    if (event.key === SPACE && event.target === event.currentTarget && !event.defaultPrevented) {
       // Prevent the browser from scrolling the page
       event.preventDefault();
       // Ignore auto-repeated keydowns to avoid toggling multiple times
@@ -643,8 +645,6 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         event.currentTarget.click();
       }
     }
-
-    child?.props?.onKeyDown?.(event);
   };
 
   delete other['aria-invalid'];

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -633,7 +633,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
   };
 
   const handleItemKeyDown = (child) => (event) => {
-    if (event.key === SPACE) {
+    if (event.key === SPACE && event.target === event.currentTarget) {
       // Prevent the browser from scrolling the page
       event.preventDefault();
       // Ignore auto-repeated keydowns to avoid toggling multiple times


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Reuse `handleItemClick` in the item key down handler for space bar.

Fixes #43874