### PR TITLE
[autocomplete] Guard against null inputRef during unmount

### DIFF
--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -373,7 +373,7 @@ function useAutocomplete(props) {
 
   const syncHighlightedIndexToDOM = useEventCallback(
     ({ index, reason, preserveScroll = false }) => {
-      if (!inputRef.current) {
+      if (inputRef.current == null) {
         return;
       }
 

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -373,7 +373,9 @@ function useAutocomplete(props) {
 
   const syncHighlightedIndexToDOM = useEventCallback(
     ({ index, reason, preserveScroll = false }) => {
-      if (inputRef.current == null) {
+      // React can clear refs before pending passive effects run during unmount.
+      // If both refs are gone, there is no DOM left to sync.
+      if (inputRef.current == null && listboxRef.current == null) {
         return;
       }
 

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.js
@@ -373,6 +373,10 @@ function useAutocomplete(props) {
 
   const syncHighlightedIndexToDOM = useEventCallback(
     ({ index, reason, preserveScroll = false }) => {
+      if (!inputRef.current) {
+        return;
+      }
+
       // does the index exist?
       if (index === -1) {
         inputRef.current.removeAttribute('aria-activedescendant');

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
@@ -334,37 +334,45 @@ describe('useAutocomplete', () => {
     await flushEffects();
   });
 
-  it('should not crash when unmounting while highlighted', () => {
-    function Test({ options }) {
+  it('should not crash when the input ref is cleared before a pending highlighted index sync', async () => {
+    function Test() {
+      const [showAutocomplete, setShowAutocomplete] = React.useState(true);
+      const options = showAutocomplete ? ['foo', 'bar'] : [];
       const { getRootProps, getInputProps, getListboxProps, getOptionProps, groupedOptions } =
         useAutocomplete({ options, open: true });
 
       return (
-        <div {...getRootProps()}>
-          <input {...getInputProps()} />
-          {groupedOptions.length > 0 ? (
-            <ul {...getListboxProps()}>
-              {groupedOptions.map((option, index) => {
-                const { key, ...optionProps } = getOptionProps({ option, index });
-                return (
-                  <li key={key} {...optionProps}>
-                    {option}
-                  </li>
-                );
-              })}
-            </ul>
-          ) : null}
-        </div>
+        <React.Fragment>
+          <button type="button" onClick={() => setShowAutocomplete(false)}>
+            Hide
+          </button>
+          <div {...getRootProps()}>
+            {showAutocomplete ? <input {...getInputProps()} /> : null}
+            {groupedOptions.length > 0 ? (
+              <ul {...getListboxProps()}>
+                {groupedOptions.map((option, index) => {
+                  const { key, ...optionProps } = getOptionProps({ option, index });
+                  return (
+                    <li key={key} {...optionProps}>
+                      {option}
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : null}
+          </div>
+        </React.Fragment>
       );
     }
 
-    const { unmount } = render(<Test options={['foo', 'bar']} />);
-    const input = screen.getByRole('combobox');
-    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    const { user } = render(<Test />);
 
-    expect(() => {
-      unmount();
-    }).not.to.throw();
+    // This hides the input/listbox while the hook stays mounted. A full unmount
+    // doesn't run the highlighted index sync after refs are cleared; this state
+    // update does, so it exercises the problematic ordering.
+    await user.click(screen.getByRole('button', { name: 'Hide' }));
+
+    await flushEffects();
   });
 
   describe('prop: freeSolo', () => {

--- a/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-material/src/useAutocomplete/useAutocomplete.test.js
@@ -334,6 +334,39 @@ describe('useAutocomplete', () => {
     await flushEffects();
   });
 
+  it('should not crash when unmounting while highlighted', () => {
+    function Test({ options }) {
+      const { getRootProps, getInputProps, getListboxProps, getOptionProps, groupedOptions } =
+        useAutocomplete({ options, open: true });
+
+      return (
+        <div {...getRootProps()}>
+          <input {...getInputProps()} />
+          {groupedOptions.length > 0 ? (
+            <ul {...getListboxProps()}>
+              {groupedOptions.map((option, index) => {
+                const { key, ...optionProps } = getOptionProps({ option, index });
+                return (
+                  <li key={key} {...optionProps}>
+                    {option}
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+        </div>
+      );
+    }
+
+    const { unmount } = render(<Test options={['foo', 'bar']} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    expect(() => {
+      unmount();
+    }).not.to.throw();
+  });
+
   describe('prop: freeSolo', () => {
     it('should not reset if the component value does not change on blur', () => {
       function Test(props) {


### PR DESCRIPTION
Fixes a React 19 regression where `inputRef.current` is null when `syncHighlightedIndexToDOM` runs during unmount, causing `Cannot read properties of null (reading 'removeAttribute')`. React 19 cleans up refs before pending callbacks fire. Adds a null guard matching the existing `listboxRef.current` pattern. Originally fixed in #25311 but lost in the v9 rewrite.


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
