### PR TITLE
[docs] fix TypeScript heading capitalization

### DIFF
--- a/docs/data/material/customization/shape/shape.md
+++ b/docs/data/material/customization/shape/shape.md
@@ -23,7 +23,7 @@ const theme = createTheme({
 });
 ```
 
-### Typescript
+### TypeScript
 
 If you're using TypeScript you need to use [module augmentation](/material-ui/guides/typescript/#customization-of-theme) to extend **new** shape properties to the theme.
 


### PR DESCRIPTION
## Summary

- fix the Shape documentation heading from `Typescript` to `TypeScript`
- align the heading with the spelling used elsewhere in the Material UI customization docs

## Verification

- checked the changed file with `rg -n "Typescript" docs/data/material/customization/shape/shape.md`