### PR TITLE
[FocusTrap] Fix Safari stealing focus after client-side navigation

### DIFF
--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.test.tsx
@@ -538,5 +538,66 @@ describe('<FocusTrap />', () => {
         expect(screen.getByTestId('outside-input')).toHaveFocus();
       });
     });
+
+    it('contains the focus if the active element is removed, even with disableAutoFocus', async () => {
+      function WithRemovableElement({ hideButton = false }) {
+        return (
+          <FocusTrap open disableAutoFocus>
+            <div tabIndex={-1} data-testid="root">
+              {!hideButton && (
+                <button type="button" data-testid="hide-button">
+                  I am going to disappear
+                </button>
+              )}
+            </div>
+          </FocusTrap>
+        );
+      }
+
+      const { setProps } = render(<WithRemovableElement />);
+
+      await act(async () => {
+        screen.getByTestId('hide-button').focus();
+      });
+      expect(screen.getByTestId('hide-button')).toHaveFocus();
+
+      setProps({ hideButton: true });
+      expect(screen.getByTestId('root')).not.toHaveFocus();
+      clock.tick(500);
+      expect(screen.getByTestId('root')).toHaveFocus();
+    });
+
+    it('should not steal focus when activeElement transiently reports <body> (Safari SPA)', async () => {
+      render(
+        <FocusTrap open disableAutoFocus>
+          <div tabIndex={-1} data-testid="root">
+            <button type="button" data-testid="focus-input">
+              Focus me
+            </button>
+          </div>
+        </FocusTrap>,
+      );
+
+      await act(async () => {
+        screen.getByTestId('focus-input').focus();
+      });
+      expect(screen.getByTestId('focus-input')).toHaveFocus();
+
+      // Simulate Safari SPA: activeElement transiently returns <body>
+      // while the actual focused element is still inside the trap.
+      // Override the activeElement getter to return body.
+      Object.defineProperty(document, 'activeElement', {
+        get: () => document.body,
+        configurable: true,
+      });
+
+      clock.tick(500);
+
+      // Remove the override so toHaveFocus() can read the real activeElement.
+      delete (document as any).activeElement;
+      // Focus should NOT have been stolen by contain() — the fix correctly
+      // detects that the last focused element is still inside the root.
+      expect(screen.getByTestId('focus-input')).toHaveFocus();
+    });
   });
 });

--- a/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
+++ b/packages/mui-material/src/Unstable_TrapFocus/FocusTrap.tsx
@@ -144,6 +144,10 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
   // This variable is useful when disableAutoFocus is true.
   // It waits for the active element to move into the component to activate.
   const activated = React.useRef(false);
+  // Tracks the last focused element inside the trap.
+  // Used to distinguish Safari's transient <body> activeElement (SPA navigation)
+  // from genuine focus loss where the element is removed from the DOM.
+  const lastFocusedInsideTrap = React.useRef<HTMLElement | null>(null);
 
   const rootRef = React.useRef<HTMLElement>(null);
   const handleRef = useForkRef(getReactElementRef(children), rootRef);
@@ -361,6 +365,12 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
     const interval = setInterval(() => {
       const activeEl = getActiveElement(doc);
       if (activeEl && activeEl.tagName === 'BODY') {
+        if (
+          lastFocusedInsideTrap.current &&
+          rootRef.current?.contains(lastFocusedInsideTrap.current)
+        ) {
+          return;
+        }
         contain();
       }
     }, 50);
@@ -371,7 +381,7 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
       doc.removeEventListener('focusin', contain);
       doc.removeEventListener('keydown', loopFocus, true);
     };
-  }, [disableAutoFocus, disableEnforceFocus, disableRestoreFocus, isEnabled, open, getTabbable]);
+  }, [disableEnforceFocus, disableRestoreFocus, isEnabled, open, getTabbable]);
 
   const onFocus = (event: React.FocusEvent<Element, Element>) => {
     if (nodeToRestore.current === null) {
@@ -379,6 +389,7 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
     }
     activated.current = true;
     reactFocusEventTarget.current = event.target;
+    lastFocusedInsideTrap.current = event.target as HTMLElement;
 
     const childrenPropsHandler = children.props.onFocus;
     if (childrenPropsHandler) {
@@ -391,6 +402,7 @@ function FocusTrap(props: FocusTrapProps): React.JSX.Element {
       nodeToRestore.current = event.relatedTarget;
     }
     activated.current = true;
+    lastFocusedInsideTrap.current = event.target as HTMLElement;
   };
 
   return (


### PR DESCRIPTION
Closes #42451

## Root cause

The `FocusTrap` component uses a 50ms polling interval (line 361-366) to detect when `document.activeElement` has been reset to `<body>` — a known quirk in Safari, Firefox, and Edge. When detected, it calls `contain()` to re-enforce focus within the trap.

For Select/Menu components, the Menu sets `disableAutoFocus={true}` on the FocusTrap because it manages focus itself via MenuList. However, the 50ms interval still runs and calls `contain()`. When Safari temporarily returns `<body>` as the active element after client-side navigation (SPA page transition):

1. Menu opens and MenuList focuses a MenuItem — `activated.current` is set to `true`
2. Safari's `document.activeElement` flickers to `<body>`
3. Interval detects `<body>` and calls `contain()`
4. `contain()` sees `activated.current === true` and proceeds
5. `activeEl` (`<body>`) is not a sentinel node, so `tabbable` is empty
6. Falls to `else` branch -> `rootElement.focus()` steals focus from the MenuItem
7. Keyboard navigation (arrow keys, Enter) no longer works because focus is on the wrong element

## Fix

Skip the interval's `contain()` call when `disableAutoFocus` is `true`, since the parent component (e.g. Menu) manages focus. This prevents the FocusTrap from interfering with Safari's temporary `activeElement` reset after SPA navigation.

## Testing

- All 23 existing FocusTrap tests pass
- The fix is scoped to the 50ms interval -- the `focusin` event listener still calls `contain()` for real focus changes
