### PR TITLE
[docs] update Tooltip "disabled elements" section

### DIFF
--- a/docs/data/material/components/tooltips/DisabledTooltips.js
+++ b/docs/data/material/components/tooltips/DisabledTooltips.js
@@ -4,7 +4,9 @@ import Tooltip from '@mui/material/Tooltip';
 export default function DisabledTooltips() {
   return (
     <Tooltip describeChild title="You don't have permission to do this">
-      <Button disabled style={{ pointerEvents: 'auto' }}>A Disabled Button</Button>
+      <Button disabled style={{ pointerEvents: 'auto' }}>
+        A Disabled Button
+      </Button>
     </Tooltip>
   );
 }

--- a/docs/data/material/components/tooltips/DisabledTooltips.js
+++ b/docs/data/material/components/tooltips/DisabledTooltips.js
@@ -4,9 +4,7 @@ import Tooltip from '@mui/material/Tooltip';
 export default function DisabledTooltips() {
   return (
     <Tooltip describeChild title="You don't have permission to do this">
-      <span>
-        <Button disabled>A Disabled Button</Button>
-      </span>
+      <Button disabled style={{ pointerEvents: 'auto' }}>A Disabled Button</Button>
     </Tooltip>
   );
 }

--- a/docs/data/material/components/tooltips/DisabledTooltips.tsx
+++ b/docs/data/material/components/tooltips/DisabledTooltips.tsx
@@ -4,7 +4,9 @@ import Tooltip from '@mui/material/Tooltip';
 export default function DisabledTooltips() {
   return (
     <Tooltip describeChild title="You don't have permission to do this">
-      <Button disabled style={{ pointerEvents: 'auto' }}>A Disabled Button</Button>
+      <Button disabled style={{ pointerEvents: 'auto' }}>
+        A Disabled Button
+      </Button>
     </Tooltip>
   );
 }

--- a/docs/data/material/components/tooltips/DisabledTooltips.tsx
+++ b/docs/data/material/components/tooltips/DisabledTooltips.tsx
@@ -4,9 +4,7 @@ import Tooltip from '@mui/material/Tooltip';
 export default function DisabledTooltips() {
   return (
     <Tooltip describeChild title="You don't have permission to do this">
-      <span>
-        <Button disabled>A Disabled Button</Button>
-      </span>
+      <Button disabled style={{ pointerEvents: 'auto' }}>A Disabled Button</Button>
     </Tooltip>
   );
 }

--- a/docs/data/material/components/tooltips/DisabledTooltips.tsx.preview
+++ b/docs/data/material/components/tooltips/DisabledTooltips.tsx.preview
@@ -1,3 +1,5 @@
 <Tooltip describeChild title="You don't have permission to do this">
-  <Button disabled style={{ pointerEvents: 'auto' }}>A Disabled Button</Button>
+  <Button disabled style={{ pointerEvents: 'auto' }}>
+    A Disabled Button
+  </Button>
 </Tooltip>

--- a/docs/data/material/components/tooltips/DisabledTooltips.tsx.preview
+++ b/docs/data/material/components/tooltips/DisabledTooltips.tsx.preview
@@ -1,5 +1,3 @@
 <Tooltip describeChild title="You don't have permission to do this">
-  <span>
-    <Button disabled>A Disabled Button</Button>
-  </span>
+  <Button disabled style={{ pointerEvents: 'auto' }}>A Disabled Button</Button>
 </Tooltip>

--- a/docs/data/material/components/tooltips/tooltips.md
+++ b/docs/data/material/components/tooltips/tooltips.md
@@ -152,9 +152,7 @@ When wrapping a Material UI component that inherits from `ButtonBase`, you shou
 {{"demo": "DisabledTooltips.js"}}
 
 :::warning
-
 By default, disabled elements like `<button>` are not keyboard focusable, so a `Tooltip` will only work for mouse users.
-
 :::
 
 ## Transitions

--- a/docs/data/material/components/tooltips/tooltips.md
+++ b/docs/data/material/components/tooltips/tooltips.md
@@ -147,27 +147,15 @@ You can disable this behavior (thus failing the success criterion which is requi
 
 ## Disabled elements
 
-By default disabled elements like `<button>` do not trigger user interactions so a `Tooltip` will not activate on normal events like hover. To accommodate disabled elements, add a simple wrapper element, such as a `span`.
-
-:::warning
-In order to work with Safari, you need at least one display block or flex item below the tooltip wrapper.
-:::
+When wrapping a Material UI component that inherits from `ButtonBase`, you should add the CSS property _pointer-events: auto;_ to your element when disabled:
 
 {{"demo": "DisabledTooltips.js"}}
 
 :::warning
-If you're not wrapping a Material UI component that inherits from `ButtonBase`, for instance, a native `<button>` element, you should also add the CSS property _pointer-events: none;_ to your element when disabled:
-:::
 
-```jsx
-<Tooltip describeChild title="You don't have permission to do this">
-  <span>
-    <button disabled={disabled} style={disabled ? { pointerEvents: 'none' } : {}}>
-      A disabled button
-    </button>
-  </span>
-</Tooltip>
-```
+By default, disabled elements like `<button>` are not keyboard focusable, so a `Tooltip` will only work for mouse users.
+
+:::
 
 ## Transitions
 


### PR DESCRIPTION
> [!IMPORTANT]
> The changes from this PR have been moved into #48622.

---

Original PR description:

This is a companion to https://github.com/mui/material-ui/pull/48622. The "Disabled elements" section of the Tooltip docs has been reworked to remove the wrapper `<span>` recommendation. See https://github.com/mui/material-ui/issues/33182#issuecomment-4535583425 for longer explanation.

There are two annoying parts:
- The default `pointer-events: none` needs to be undone from Buttons (see [related section](https://mui.com/material-ui/react-button/#cursor-not-allowed) in Button docs). I believe this should be addressed within ButtonBase in a separate PR.
- Keyboard accessibility (or lack thereof) is mentioned as a warning. This should be updated to recommend the `focusableWhenDisabled` prop after https://github.com/mui/material-ui/pull/48613 merges.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
