### PR TITLE
[docs-infra] Infinitely cache all static assets

### DIFF
--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,4 +1,4 @@
-/_next/*.js
+/_next/static/
   Cache-Control: public, max-age=31536000, immutable
 
 /static/images/*


### PR DESCRIPTION
## Summary

- Cache-Control rule in `docs/public/_headers` now targets `/_next/static/` instead of `/_next/*.js`.
- All static assets under `/_next/static/` (JS, CSS, fonts, media) get `public, max-age=31536000, immutable` instead of only `.js` files.

## Why

Next.js content-hashes every file under `/_next/static/`, so the contents are immutable and safe to cache forever. The previous glob only matched `.js`, leaving CSS and other hashed assets uncached.

