### PR TITLE
[link][docs] Remove outdated security section

### DIFF
--- a/docs/data/material/components/links/links.md
+++ b/docs/data/material/components/links/links.md
@@ -29,15 +29,6 @@ The `underline` prop can be used to set the underline behavior. The default is `
 
 {{"demo": "UnderlineLink.js"}}
 
-## Security
-
-When you use `target="_blank"` with Links, it is [recommended](https://developers.google.com/web/tools/lighthouse/audits/noopener) to always set `rel="noopener"` or `rel="noreferrer"` when linking to third party content.
-
-- `rel="noopener"` prevents the new page from being able to access the `window.opener` property and ensures it runs in a separate process.
-  Without this, the target page can potentially redirect your page to a malicious URL.
-- `rel="noreferrer"` has the same effect, but also prevents the _Referer_ header from being sent to the new page.
-  ⚠️ Removing the referrer header will affect analytics.
-
 ## Third-party routing library
 
 One frequent use case is to perform navigation on the client only, without an HTTP round-trip to the server.


### PR DESCRIPTION
This section is not true anymore, see #40447. We want to remove it so we don't signal to the people who know about this that the docs are outdated. Right now, people could see that, as there is some need for very old browser support, they need it, but it's already a borderline argument, since we are 5+ years in this change of how `rel` behaves.