### PR TITLE
[tooltip] Fix onOpen/onClose callback skipping due to stale state in batched updates

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -280,6 +280,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   });
 
   let open = openState;
+  const openRef = React.useRef(open);
 
   if (process.env.NODE_ENV !== 'production') {
     // TODO: uncomment once we enable eslint-plugin-react-compiler // eslint-disable-next-line react-compiler/react-compiler
@@ -329,9 +330,11 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     // The mouseover event will trigger for every nested element in the tooltip.
     // We can skip rerendering when the tooltip is already open.
     // We are using the mouseover event instead of the mouseenter event to fix a hide/show issue.
+    const wasOpen = openRef.current;
+    openRef.current = true;
     setOpenState(true);
 
-    if (onOpen && !open) {
+    if (onOpen && !wasOpen) {
       onOpen(event);
     }
   };
@@ -344,9 +347,11 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
       hystersisTimer.start(800 + leaveDelay, () => {
         hystersisOpen = false;
       });
+      const wasOpen = openRef.current;
+      openRef.current = false;
       setOpenState(false);
 
-      if (onClose && open) {
+      if (onClose && wasOpen) {
         onClose(event);
       }
 
@@ -498,6 +503,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   if (!title && title !== 0) {
     open = false;
   }
+  openRef.current = open;
 
   const popperRef = React.useRef();
 

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -451,6 +451,38 @@ describe('<Tooltip />', () => {
     expect(eventLog).to.deep.equal(['mouseover', 'open', 'mouseleave', 'close']);
   });
 
+  it('should call onClose when controlled close follows a delayed open before rerender', () => {
+    const eventLog = [];
+    render(
+      <Tooltip
+        enterDelay={100}
+        title="Hello World"
+        onOpen={() => eventLog.push('open')}
+        onClose={() => eventLog.push('close')}
+        open={false}
+      >
+        <button
+          id="testChild"
+          onMouseLeave={() => eventLog.push('mouseleave')}
+          onMouseOver={() => eventLog.push('mouseover')}
+          type="submit"
+        >
+          Hello World
+        </button>
+      </Tooltip>,
+    );
+
+    fireEvent.mouseOver(screen.getByRole('button'));
+    clock.tick(100);
+
+    expect(eventLog).to.deep.equal(['mouseover', 'open']);
+
+    fireEvent.mouseLeave(screen.getByRole('button'));
+    clock.tick(0);
+
+    expect(eventLog).to.deep.equal(['mouseover', 'open', 'mouseleave', 'close']);
+  });
+
   it('should not call onOpen again if already open', () => {
     const eventLog = [];
     render(


### PR DESCRIPTION
## Problem

In React 18+ automatic batching, `setOpenState` does not trigger an immediate re-render. When `onOpen`/`onClose` callbacks check the `open` variable right after `setOpenState`, they read a stale value, which can cause callbacks to be incorrectly skipped in certain scenarios (e.g. controlled mode with delayed open followed by immediate close).

## Fix

Use a `useRef` to track the last known open state. Capture `wasOpen` before `setOpenState` and use it for the `onOpen`/`onClose` guard condition, ensuring callbacks fire correctly regardless of React's batching behavior.

## Test

Added a test case that verifies `onClose` is called when a controlled tooltip (`open={false}`) is internally opened via mouseOver with `enterDelay` and then immediately closed via mouseLeave.