### PR TITLE
[docs-infra] Run link checker during docs build instead of as separate CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,6 @@ jobs:
       # - run: pnpm release:changelog
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check docs links
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: pnpm docs:link-check
       - name: Debug export-detail.json on when pnpm docs:build fails with EMFILE error
         if: failure()
         run: cat ./docs/.next/export-detail.json || true

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build --webpack && pnpm build-sw",
+    "build": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build --webpack && pnpm build-sw && pnpm link-check",
     "build:turbopack": "rimraf ./export && cross-env NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 next build --turbopack && pnpm build-sw",
     "build:clean": "rimraf .next && pnpm build",
     "build-sw": "node ./scripts/buildServiceWorker.js",


### PR DESCRIPTION
Reverts the CI-orchestration part of #48088, which moved the broken-links checker out of the docs build into a standalone GitHub Actions step (`pnpm docs:link-check`).

The checker doesn't just validate links — it also writes `export/material-ui/link-structure.json`, which gets deployed to https://mui.com/material-ui/link-structure.json and is consumed by other products' link checkers (e.g. mui-x). Running it in a separate CI step meant the file was no longer produced inside the Netlify build's `export/` output, so that URL started returning 404. Downstream checkers fetch it and throw on the non-OK response, breaking their docs builds — see mui/mui-x#22707.

This restores the prior behavior: `pnpm link-check` runs at the end of `docs build` (during the Netlify build), so `link-structure.json` is generated and deployed again. The separate CI step is removed.

The HTML-validation work from #48088 (the `htmlValidate` config and `errorCount` exit handling in `reportBrokenLinks.mts`) is intentionally kept — only the run-location change is reverted.