### PR TITLE
[test] Fix react@18/next nightly workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,10 @@ jobs:
           command: xvfb-run pnpm test:regressions
       - run:
           name: A11y results committed?
-          command: git add -A && git diff --exit-code --staged
+          # The react@17/18/next jobs pin React via `package-overrides`, which rewrites
+          # package.json/pnpm-lock.yaml. Exclude those so this check still verifies the a11y
+          # results on every job without tripping over the pinned dependencies.
+          command: git add -A -- . ':(exclude)package.json' ':(exclude)pnpm-lock.yaml' && git diff --exit-code --staged
       - run:
           name: Upload screenshots to Argos CI
           command: pnpm test:argos

--- a/docs/pages/material-ui/api/list-item.json
+++ b/docs/pages/material-ui/api/list-item.json
@@ -15,7 +15,7 @@
     "slotProps": {
       "type": {
         "name": "shape",
-        "description": "{ root?: object, secondaryAction?: func<br>&#124;&nbsp;object }"
+        "description": "{ root?: func<br>&#124;&nbsp;object, secondaryAction?: func<br>&#124;&nbsp;object }"
       },
       "default": "{}"
     },

--- a/packages/mui-material/src/ListItem/ListItem.d.ts
+++ b/packages/mui-material/src/ListItem/ListItem.d.ts
@@ -5,6 +5,8 @@ import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { ListItemClasses } from './listItemClasses';
 import { SlotProps } from '../utils/types';
 
+export interface ListItemRootSlotPropsOverrides {}
+
 export interface ListItemSecondaryActionSlotPropsOverrides {}
 
 /**
@@ -66,7 +68,13 @@ export interface ListItemOwnProps extends ListItemBaseProps {
    */
   slotProps?:
     | {
-        root?: React.HTMLAttributes<HTMLDivElement> | undefined;
+        root?:
+          | SlotProps<
+              React.ElementType<React.HTMLAttributes<HTMLDivElement>>,
+              ListItemRootSlotPropsOverrides,
+              ListItemOwnerState
+            >
+          | undefined;
         secondaryAction?:
           | SlotProps<
               React.ElementType<React.HTMLAttributes<HTMLDivElement>>,

--- a/packages/mui-material/src/ListItem/ListItem.js
+++ b/packages/mui-material/src/ListItem/ListItem.js
@@ -271,7 +271,7 @@ ListItem.propTypes /* remove-proptypes */ = {
    * @default {}
    */
   slotProps: PropTypes.shape({
-    root: PropTypes.object,
+    root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     secondaryAction: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   }),
   /**

--- a/packages/mui-material/src/Tab/Tab.test.js
+++ b/packages/mui-material/src/Tab/Tab.test.js
@@ -16,9 +16,17 @@ describe('<Tab />', () => {
     classes,
     inheritComponent: ButtonBase,
     render: (node) => {
-      const value = node.props.value ?? 0;
+      // `Tab` must be a direct child of `Tabs`, which injects state into its children via
+      // `cloneElement`. Some conformance tests wrap the element(s) in a provider (e.g.
+      // `ThemeProvider`), so we slot `Tabs` *inside* the wrapper around the `Tab`s. Otherwise
+      // `Tabs` would clone the provider with `Tab`-internal props (`fullWidth`, `indicator`, …),
+      // tripping the provider's `exactProp` check under React 18.
+      // TODO: React 19 dropped runtime propType/`exactProp` validation, so once we stop testing
+      // React 18 this can revert to rendering `node` directly: `<Tabs value={0}>{node}</Tabs>`.
+      const isWrapped = node.type !== Tab;
+      const tabs = <Tabs value={0}>{isWrapped ? node.props.children : node}</Tabs>;
       const { container, ...other } = render(
-        <Tabs value={value}>{React.cloneElement(node, { value })}</Tabs>,
+        isWrapped ? React.cloneElement(node, undefined, tabs) : tabs,
       );
 
       return {

--- a/packages/mui-utils/src/useValueAsRef/useValueAsRef.test.tsx
+++ b/packages/mui-utils/src/useValueAsRef/useValueAsRef.test.tsx
@@ -33,25 +33,27 @@ describe('useValueAsRef', () => {
   });
 
   it('returns the same ref object across renders', () => {
-    let firstRef: object | undefined;
-    let nextRef: object | undefined;
+    let capturedRef: object | undefined;
 
     function Test(props: { value: number }) {
-      const valueRef = useValueAsRef(props.value);
-
-      if (firstRef === undefined) {
-        firstRef = valueRef;
-      } else {
-        nextRef = valueRef;
-      }
-
+      capturedRef = useValueAsRef(props.value);
       return null;
     }
 
+    // Collect the committed ref after each render settles. Reading inside the render body
+    // instead would capture React 18 StrictMode's discarded initial-mount object (a distinct
+    // transient `ValueRef`), which is never the one the component ends up using.
+    const refs: Array<object | undefined> = [];
     const { setProps } = render(<Test value={1} />);
-
+    refs.push(capturedRef);
     setProps({ value: 2 });
+    refs.push(capturedRef);
+    setProps({ value: 3 });
+    refs.push(capturedRef);
 
-    expect(nextRef).to.equal(firstRef);
+    expect(refs.length).to.be.at.least(2);
+    refs.forEach((ref) => {
+      expect(ref).to.equal(refs[0]);
+    });
   });
 });


### PR DESCRIPTION
Fixes the `react@18` and `react@next` nightly CI matrix, which was red across the unit, browser, and visual-regression jobs on `master`. Each failure is React-version-specific, so they don't surface on the default (React 19 stable) PR runs.

- **`test_regressions` (react@17/18/next)** — the "A11y results committed?" step ran an unscoped `git diff --exit-code`, but these jobs pin React via `package-overrides`, which rewrites `package.json`/`pnpm-lock.yaml` and tripped the check. Those two files are now excluded from the check (`:(exclude)…`), so it still verifies the a11y results on every matrix job instead of being skipped.
- **`ListItem`** — `slotProps.root` was typed as plain `HTMLAttributes`, so the generated propType was `PropTypes.object` and rejected the callback form that the conformance `slotProps.root` test passes (a warning under React 18, which still validates propTypes). Typed it as `SlotProps` like the other slots and regenerated propTypes + API docs.
- **`Tab`** — `Tab` must render as a direct child of `Tabs`, which injects state into its children via `cloneElement` (`fullWidth`, `indicator`, `selected`, …). The theme conformance tests wrap the element in a `ThemeProvider`, and the old test render made that provider a direct child of `Tabs` — so `Tabs` cloned the *provider* with `Tab`-internal props, tripping its `exactProp` check under React 18. The test render now slots `Tabs` *inside* the wrapper (`ThemeProvider > Tabs > Tab`), matching real-world usage, so the provider is never cloned. This keeps every conformance test (and the documented `themeDefaultProps` capability) intact rather than skipping them. It's a React-18-only workaround (React 19 dropped runtime `exactProp` validation) — a TODO marks it for removal once React 18 leaves the matrix.
- **`useValueAsRef`** — the ref-identity test latched its first reference during the initial render, capturing the transient object that React 18 StrictMode discards on its mount/remount. It now compares the ref captured after each render settles.

Verified locally against both React 18.3.1 and React 19.2.6 (node and chromium).

Note: the `InitColorSchemeScript` `react@next` failures from the same nightly are already handled by #48604.
