### PR TITLE
[legal] Update EULA links on website

### DIFF
--- a/docs/src/components/pricing/PricingFAQ.tsx
+++ b/docs/src/components/pricing/PricingFAQ.tsx
@@ -50,7 +50,7 @@ const faqData = [
         <br />
         <Link
           target="_blank"
-          href="https://mui.com/legal/mui-x-eula/#required-quantity-of-licenses"
+          href="https://mui.com/legal/mui-x-eula/#authorized-developer-count-rule"
         >
           The clause in the EULA.
         </Link>
@@ -103,7 +103,7 @@ const faqData = [
           <li>Commercial solutions deployed for end-users</li>
         </ul>
         Based on the{' '}
-        <Link target="_blank" href="https://mui.com/legal/mui-x-eula/#deployment">
+        <Link target="_blank" href="https://mui.com/legal/mui-x-eula/#sublicense-conditions">
           'Deployment' section of the EULA
         </Link>
         , you can sublicense the software if it's made part of a larger work. The new licenses must
@@ -171,7 +171,7 @@ const faqData = [
         license.{' '}
         <Link
           target="_blank"
-          href="https://mui.com/legal/mui-x-eula/#required-quantity-of-licenses"
+          href="https://mui.com/legal/mui-x-eula/#authorized-developer-count-rule"
         >
           The relevant EULA clause.
         </Link>

--- a/docs/src/components/pricing/PricingWhatToExpect.tsx
+++ b/docs/src/components/pricing/PricingWhatToExpect.tsx
@@ -55,7 +55,7 @@ export default function PricingWhatToExpect() {
             You can learn more about this in{' '}
             <Link
               target="_blank"
-              href="https://mui.com/legal/mui-x-eula/#required-quantity-of-licenses"
+              href="https://mui.com/legal/mui-x-eula/#authorized-developer-count-rule"
             >
               the EULA
             </Link>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

-- 

From PR #1564, addressing the following:

- [x] All the anchor links seem broken now after those changes: https://github.com/search?q=org%3Amui+https%3A%2F%2Fmui.com%2Flegal%2Fmui-x-eula%2F%23&type=code.
👉 pricing page fixed in commit https://github.com/mui/material-ui/commit/a9d0109d10d06f64db39e271e41f2b3e591e7f89
👉 mui-x docs fixed in PR [#22717](https://github.com/mui/mui-x/pull/22717)

Preview: https://deploy-preview-