### PR TITLE
[Transition] Mount child in same commit when opening from unmounted

### DIFF
--- a/packages/mui-material/src/internal/Transition.test.tsx
+++ b/packages/mui-material/src/internal/Transition.test.tsx
@@ -184,6 +184,7 @@ describe('<Transition />', () => {
       // the child ref right after `in` flips must find it mounted, otherwise focus
       // management like the vertical stepper demo crashes. See issue #48637.
       let refWhenEffectRan: HTMLDivElement | null | undefined;
+      const onExited = spy();
       function Wrapper() {
         const [open, setOpen] = React.useState(false);
         const nodeRef = React.useRef<HTMLDivElement>(null);
@@ -197,7 +198,7 @@ describe('<Transition />', () => {
             <button type="button" onClick={() => setOpen(true)}>
               open
             </button>
-            <Transition in={open} unmountOnExit timeout={100} nodeRef={nodeRef}>
+            <Transition in={open} unmountOnExit timeout={100} nodeRef={nodeRef} onExited={onExited}>
               {(status) => (
                 <div ref={nodeRef} data-testid="target" data-status={status}>
                   content
@@ -212,7 +213,9 @@ describe('<Transition />', () => {
       act(() => {
         screen.getByText('open').click();
       });
-      expect(refWhenEffectRan).not.to.equal(null);
+      expect(refWhenEffectRan).to.equal(screen.getByTestId('target'));
+      // The intermediate `exited` status during open must not fire `onExited`.
+      expect(onExited.callCount).to.equal(0);
     });
   });
 

--- a/packages/mui-material/src/internal/Transition.test.tsx
+++ b/packages/mui-material/src/internal/Transition.test.tsx
@@ -178,6 +178,42 @@ describe('<Transition />', () => {
       clock.tick(100);
       expect(screen.queryByTestId('target')).to.equal(null);
     });
+
+    it('attaches the child ref in the same commit `in` turns true with unmountOnExit', () => {
+      // Regression for opening from unmounted: a parent passive effect that reads
+      // the child ref right after `in` flips must find it mounted, otherwise focus
+      // management like the vertical stepper demo crashes. See issue #48637.
+      let refWhenEffectRan: HTMLDivElement | null | undefined;
+      function Wrapper() {
+        const [open, setOpen] = React.useState(false);
+        const nodeRef = React.useRef<HTMLDivElement>(null);
+        React.useEffect(() => {
+          if (open) {
+            refWhenEffectRan = nodeRef.current;
+          }
+        }, [open]);
+        return (
+          <React.Fragment>
+            <button type="button" onClick={() => setOpen(true)}>
+              open
+            </button>
+            <Transition in={open} unmountOnExit timeout={100} nodeRef={nodeRef}>
+              {(status) => (
+                <div ref={nodeRef} data-testid="target" data-status={status}>
+                  content
+                </div>
+              )}
+            </Transition>
+          </React.Fragment>
+        );
+      }
+      render(<Wrapper />);
+      expect(screen.queryByTestId('target')).to.equal(null);
+      act(() => {
+        screen.getByText('open').click();
+      });
+      expect(refWhenEffectRan).not.to.equal(null);
+    });
   });
 
   describe('timeout semantics', () => {

--- a/packages/mui-material/src/internal/Transition.tsx
+++ b/packages/mui-material/src/internal/Transition.tsx
@@ -141,6 +141,16 @@ function Transition(props: InternalTransitionProps): React.ReactNode {
   const statusRef = React.useRef<InternalStatus>(status);
   statusRef.current = status;
 
+  // Opening from `unmounted`: mount the child in the same commit that `in` turns
+  // true so its ref is attached before effects run. react-transition-group did
+  // this by deriving the status from props during render; handling it in a
+  // layout effect instead would add a commit where the child is still null,
+  // breaking consumers that read the ref right after `in` flips.
+  if (inProp && status === 'unmounted') {
+    setStatus('exited');
+    statusRef.current = 'exited';
+  }
+
   const shouldAppearOnMountRef = React.useRef(inProp && shouldEnterOnMount);
   const mountedRef = React.useRef(false);
   const nextCallbackRef = React.useRef<CancellableCallback | null>(null);
@@ -352,7 +362,8 @@ function Transition(props: InternalTransitionProps): React.ReactNode {
   }, [cancelPendingCallback, updateStatus]);
 
   // Reconcile the rendered status after `in` or status changes:
-  // - opening from unmounted first renders the child as exited so refs exist.
+  // - opening from unmounted is handled during render (see above) so the child
+  //   is committed as exited with its ref attached before this effect runs.
   // - unmountOnExit removes the child after the exited state commits.
   // This matches react-transition-group's observable status steps without
   // running work after unrelated commits.
@@ -363,12 +374,7 @@ function Transition(props: InternalTransitionProps): React.ReactNode {
     const current = statusRef.current;
 
     if (inProp) {
-      if (current === 'unmounted') {
-        // Opening from unmounted needs one render with the child present so
-        // refs are attached before the enter animation starts.
-        statusRef.current = 'exited';
-        setStatus('exited');
-      } else if (current !== 'entering' && current !== 'entered') {
+      if (current !== 'entering' && current !== 'entered') {
         updateStatus(false, 'entering');
       }
     } else if (current === 'entering' || current === 'entered') {

--- a/packages/mui-material/src/internal/Transition.tsx
+++ b/packages/mui-material/src/internal/Transition.tsx
@@ -147,8 +147,8 @@ function Transition(props: InternalTransitionProps): React.ReactNode {
   // layout effect instead would add a commit where the child is still null,
   // breaking consumers that read the ref right after `in` flips.
   if (inProp && status === 'unmounted') {
-    setStatus('exited');
     statusRef.current = 'exited';
+    setStatus('exited');
   }
 
   const shouldAppearOnMountRef = React.useRef(inProp && shouldEnterOnMount);


### PR DESCRIPTION
closes #48637

## Summary

Fixes the `VerticalLinearStepper` demo crash introduced by the custom `Transition` component (#48325).

## Root cause

When opening from `unmounted`, the new `internal/Transition` moved the child from `unmounted → exited` inside a layout effect, adding a commit where the child is still `null`. `react-transition-group` derived that status from props **during render**, so the child existed in the same commit `in` flipped true.

The stepper demo focuses a button synchronously in a passive effect right after `activeStep` changes. With the extra commit, the previous step's button is already unmounted and the new one isn't mounted yet, so `continueButtonRef.current` is `null` and `.focus()` throws.

This is a silent behavior regression for any consumer that reads a ref (focus management, measurement, scroll-into-view) right after `in` toggles — not just this demo.

## Fix

Move the `unmounted → exited` transition to a guarded render-phase update so the child is committed (and its ref attached) in the same commit `in` turns true, matching `react-transition-group`. The redundant `unmounted` branch is removed from the reconcile effect. No demo change needed.

## Testing

Added a regression test mirroring the demo's exact pattern (a parent passive effect reads the child ref right after `in` flips). It fails (`null`) without the fix and passes with it.

Verified green: `Transition`, `Collapse`, `StepContent`, `Fade`, `Grow`, `Zoom`, `Slide`, `Accordion`, `Snackbar`, `Tooltip`, `Dialog`, `Drawer`, `Menu`, `Popover`, `SpeedDial`, `TouchRipple`, `Ripple`.
