### PR TITLE
[ButtonBase] Fix focus ripple lingering after blur

### DIFF
--- a/packages/mui-material/src/ButtonBase/TouchRipple.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.js
@@ -224,6 +224,23 @@ export const TouchRippleRipple = styled(Ripple, {
     transform: scale(1);
   }
 
+  /*
+   * Order matters: 'child', 'childLeaving' and 'childPulsate' apply to the same
+   * element with equal specificity, so the later rule wins. 'child' must come
+   * before 'childLeaving' so the leaving 'opacity: 0' takes precedence. A focus
+   * (pulsate) ripple keeps 'pulsateKeyframe' (no opacity animation) on exit, so
+   * it relies on this static 'opacity: 0' to disappear on blur instead of
+   * lingering until removal.
+   */
+  & .${touchRippleClasses.child} {
+    opacity: 1;
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background-color: currentColor;
+  }
+
   & .${touchRippleClasses.childLeaving} {
     opacity: 0;
   }
@@ -236,15 +253,6 @@ export const TouchRippleRipple = styled(Ripple, {
   }
 
   ${({ theme }) => getAnimationStyles(theme)}
-
-  & .${touchRippleClasses.child} {
-    opacity: 1;
-    display: block;
-    width: 100%;
-    height: 100%;
-    border-radius: 50%;
-    background-color: currentColor;
-  }
 `;
 
 /**

--- a/packages/mui-material/src/ButtonBase/TouchRipple.test.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { act, createRenderer } from '@mui/internal-test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
+import touchRippleClasses from './touchRippleClasses';
 import describeConformance from '../../test/describeConformance';
 
 const cb = () => {};
@@ -205,6 +206,37 @@ describe('<TouchRipple />', () => {
       });
 
       expect(queryAllRipples()).to.have.lengthOf(0);
+    });
+  });
+
+  describe('focus ripple exit', () => {
+    clock.withFakeTimers();
+
+    it('hides the leaving focus ripple immediately, then removes it', () => {
+      const ref = React.createRef();
+      const { container } = render(<TouchRipple ref={ref} />);
+
+      act(() => {
+        ref.current.start({}, { pulsate: true, fakeElement: true }, cb);
+      });
+
+      const child = container.querySelector(`.${touchRippleClasses.child}`);
+      expect(window.getComputedStyle(child).opacity).to.equal('1');
+
+      act(() => {
+        ref.current.stop({ type: 'blur' });
+      });
+
+      // `.childLeaving { opacity: 0 }` must win over `.child { opacity: 1 }`, else
+      // a focus (pulsate) ripple lingers until removal instead of hiding on blur.
+      expect(child).to.have.class(touchRippleClasses.childLeaving);
+      expect(window.getComputedStyle(child).opacity).to.equal('0');
+
+      act(() => {
+        clock.runAll();
+      });
+
+      expect(container.querySelector(`.${touchRippleClasses.child}`)).to.equal(null);
     });
   });
 


### PR DESCRIPTION
**Before**:

https://github.com/user-attachments/assets/8499b513-f185-4306-badd-f1288432bc60

**After**: https://deploy-preview-48650--material-ui.netlify.app/material-ui/react-button/

## Summary

Fixes the keyboard-focus ripple lingering for ~550ms after a button loses focus (visible when tabbing between buttons — the previous button's focus ripple stays on screen, then pops out). Reproducible in both Chrome and Safari because the cause is CSS source-order, not a browser quirk.

## Root cause

Regression from #48357. That PR extracted `getAnimationStyles` and, in the process, moved the `& .${touchRippleClasses.child} { opacity: 1 }` block to the **end** of the `TouchRippleRipple` styled template — now **after** `& .${touchRippleClasses.childLeaving} { opacity: 0 }`. (#48325 had preserved the original order.) Both selectors target the same element with **equal specificity**, so the later rule wins:

| | rule order | winner on leaving |
|---|---|---|
| before #48357 | `.child{opacity:1}` → `.childLeaving{opacity:0}` | `opacity: 0` ✅ |
| after #48357 | `.childLeaving{opacity:0}` → … → `.child{opacity:1}` | `opacity: 1` ❌ |

On exit, `animation-name` is single-valued and `.childPulsate` (pulsateKeyframe) wins over `.childLeaving` (exitKeyframe). `pulsateKeyframe` animates only `transform`, **not** opacity, so the focus ripple's opacity comes purely from the static rule:

- before: static `opacity: 0` → focus ripple vanishes the instant the button blurs.
- after: static `opacity: 1` → focus ripple stays visible (kept pulsing) until `onExited` removes it ~550ms later.

Click ripples hid this because their `exitKeyframe` animates opacity→0 and DOM removal lands at the same 550ms.

## Fix

Move the `& .${touchRippleClasses.child}` block back above `& .${touchRippleClasses.childLeaving}`, restoring the original cascade so the leaving `opacity: 0` wins again. Added a comment documenting why the order matters, to prevent the same mistake.

## Verification

Verified in a real browser (Vite dev server aliasing `@mui/material` to source), tabbing between buttons and reading the leaving ripple's computed opacity:

- **with fix**: `#btn-text` leaving child `getComputedStyle(...).opacity === "0"` (gone immediately); next button shows its pulsate ripple at `1`.
- **without fix** (reverted order): same leaving child reads `opacity === "1"` (lingers) — confirming causation.

Existing `TouchRipple`, `Ripple`, and `ButtonBase` unit tests pass (184). This is a CSS cascade-order fix that jsdom can't meaningfully assert, so it's covered by the in-browser check above rather than a new unit test.
