### PR TITLE
[docs-infra] Fix immutable cache headers for /_next/static assets

### DIFF
--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,4 +1,4 @@
-/_next/static/
+/_next/static/*
   Cache-Control: public, max-age=31536000, immutable
 
 /static/images/*


### PR DESCRIPTION
## Summary

`docs/public/_headers` already declared `immutable, max-age=31536000` for `/_next/static/`, but the rule never matched: Netlify `_headers` needs a splat (`/*`) to cover nested paths. Without it, only the exact path `/_next/static/` matched, so hashed chunks fell back to Netlify's default `max-age=0, must-revalidate`.

```
- /_next/static/
+ /_next/static/*
```

Fingerprinted filenames make these assets safe to cache forever. Confirmed broken on prod:

```
curl -sI https://mui.com/_next/static/chunks/polyfills-*.js
cache-control: public,max-age=0,must-revalidate
```

## Verify after deploy

```
curl -sI https://mui.com/_next/static/chunks/polyfills-*.js | grep -i cache-control
# expect: public, max-age=31536000, immutable
```