### PR TITLE
[InitColorSchemeScript] Fix script tag warning in Next.js 16 dev mode

### DIFF
--- a/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.test.js
+++ b/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.test.js
@@ -12,7 +12,7 @@ describe('InitColorSchemeScript', () => {
   // `InitColorSchemeScript` is only ever rendered on the server (Next.js `_document` or the App
   // Router root layout), so render it to a string here. A client mount of a `<script>` triggers a
   // React warning (and is a non-executing no-op) starting with React 19.3.
-  const { renderToString } = createRenderer();
+  const { render, renderToString } = createRenderer();
   let originalMatchmedia;
   let storage = {};
   const createMatchMedia = (matches) => () => ({
@@ -185,5 +185,12 @@ describe('InitColorSchemeScript', () => {
       eval(container.firstChild.textContent);
       expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('yellow');
     });
+  });
+
+  // The inline script never executes when created during a client render, and React 19.3+ warns
+  // about it. Emitting it only on the server pass keeps client renders script-free (see #48595).
+  it('should not render the script on the client', () => {
+    const { container } = render(<InitColorSchemeScript />);
+    expect(container.querySelector('script')).to.equal(null);
   });
 });

--- a/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.test.js
+++ b/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.test.js
@@ -10,8 +10,7 @@ import {
 
 describe('InitColorSchemeScript', () => {
   // `InitColorSchemeScript` is only ever rendered on the server (Next.js `_document` or the App
-  // Router root layout), so render it to a string here. A client mount of a `<script>` triggers a
-  // React warning and is a non-executing no-op.
+  // Router root layout), so render it to a string here.
   const { render, renderToString } = createRenderer();
   let originalMatchmedia;
   let storage = {};
@@ -187,8 +186,7 @@ describe('InitColorSchemeScript', () => {
     });
   });
 
-  // Pure client mount: the script never executes when created during a client render and React
-  // warns about it, so it must not be emitted (see #48595).
+  // Client renders must stay script-free (#48595).
   it('should not render the script on the client', () => {
     const { container } = render(<InitColorSchemeScript />);
     expect(container.querySelector('script')).to.equal(null);

--- a/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.test.js
+++ b/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.test.js
@@ -11,7 +11,7 @@ import {
 describe('InitColorSchemeScript', () => {
   // `InitColorSchemeScript` is only ever rendered on the server (Next.js `_document` or the App
   // Router root layout), so render it to a string here. A client mount of a `<script>` triggers a
-  // React warning (and is a non-executing no-op) starting with React 19.3.
+  // React warning and is a non-executing no-op.
   const { render, renderToString } = createRenderer();
   let originalMatchmedia;
   let storage = {};
@@ -187,10 +187,24 @@ describe('InitColorSchemeScript', () => {
     });
   });
 
-  // The inline script never executes when created during a client render, and React 19.3+ warns
-  // about it. Emitting it only on the server pass keeps client renders script-free (see #48595).
+  // Pure client mount: the script never executes when created during a client render and React
+  // warns about it, so it must not be emitted (see #48595).
   it('should not render the script on the client', () => {
     const { container } = render(<InitColorSchemeScript />);
+    expect(container.querySelector('script')).to.equal(null);
+  });
+
+  // Hydration path (the bug in #48595): the script is server-rendered, hydrated without a mismatch
+  // warning (vitest-fail-on-console turns the warning into a failure), then dropped on the
+  // post-hydration commit when the client snapshot takes over.
+  it('should emit the script on server render and drop it after hydration', () => {
+    storage[DEFAULT_MODE_STORAGE_KEY] = 'light';
+    storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-light`] = 'foo';
+
+    const view = renderToString(<InitColorSchemeScript />);
+    expect(view.container.querySelector('script')).not.to.equal(null);
+
+    const { container } = view.hydrate();
     expect(container.querySelector('script')).to.equal(null);
   });
 });

--- a/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.tsx
+++ b/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.tsx
@@ -1,3 +1,6 @@
+'use client';
+import * as React from 'react';
+
 export const DEFAULT_MODE_STORAGE_KEY = 'mode';
 export const DEFAULT_COLOR_SCHEME_STORAGE_KEY = 'color-scheme';
 export const DEFAULT_ATTRIBUTE = 'data-color-scheme';
@@ -46,7 +49,32 @@ export interface InitColorSchemeScriptProps {
   nonce?: string | undefined;
 }
 
-export default function InitColorSchemeScript(options?: InitColorSchemeScriptProps) {
+// See https://github.com/mui/material-ui/issues/41190#issuecomment-2040873379 for why
+const safeReact = { ...React };
+const maybeReactUseSyncExternalStore: undefined | any = safeReact.useSyncExternalStore;
+
+const subscribe = () => () => {};
+
+/**
+ * `true` during the server render and the matching hydration render, `false`
+ * on every client render afterwards. React 19.3+ warns when a `<script>` is
+ * created during a client render (such scripts never execute), so the inline
+ * script is only emitted on the server pass and dropped after hydration — the
+ * attribute it already set on the document persists. React <18 has no
+ * `useSyncExternalStore` and no such warning, so the script is always emitted.
+ */
+function useIsServerRender() {
+  if (maybeReactUseSyncExternalStore === undefined) {
+    return true;
+  }
+  return maybeReactUseSyncExternalStore(
+    subscribe,
+    () => false,
+    () => true,
+  );
+}
+
+export function buildInitColorSchemeScript(options?: InitColorSchemeScriptProps) {
   const {
     defaultMode = 'system',
     defaultLightColorScheme = 'light',
@@ -118,4 +146,14 @@ try {
       }}
     />
   );
+}
+
+export default function InitColorSchemeScript(options?: InitColorSchemeScriptProps) {
+  // Inline scripts never execute when created during a client render, so only
+  // emit on the server pass to avoid React's client-script warning (#48595).
+  const isServerRender = useIsServerRender();
+  if (!isServerRender) {
+    return null;
+  }
+  return buildInitColorSchemeScript(options);
 }

--- a/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.tsx
+++ b/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.tsx
@@ -49,7 +49,8 @@ export interface InitColorSchemeScriptProps {
   nonce?: string | undefined;
 }
 
-// See https://github.com/mui/material-ui/issues/41190#issuecomment-2040873379 for why
+// React 17 has no `useSyncExternalStore`; spread into a plain object so reading the
+// missing property returns `undefined` instead of throwing under strict ESM. See #41190 (comment).
 const safeReact = { ...React };
 const maybeReactUseSyncExternalStore: undefined | any = safeReact.useSyncExternalStore;
 
@@ -149,8 +150,6 @@ try {
 }
 
 export default function InitColorSchemeScript(options?: InitColorSchemeScriptProps) {
-  // Inline scripts never execute when created during a client render, so only
-  // emit on the server pass to avoid React's client-script warning (#48595).
   const isServerRender = useIsServerRender();
   if (!isServerRender) {
     return null;

--- a/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.tsx
+++ b/packages/mui-system/src/InitColorSchemeScript/InitColorSchemeScript.tsx
@@ -57,7 +57,7 @@ const subscribe = () => () => {};
 
 /**
  * `true` during the server render and the matching hydration render, `false`
- * on every client render afterwards. React 19.3+ warns when a `<script>` is
+ * on every client render afterwards. React warns when a `<script>` is
  * created during a client render (such scripts never execute), so the inline
  * script is only emitted on the server pass and dropped after hydration — the
  * attribute it already set on the document persists. React <18 has no

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -5,7 +5,8 @@ import { GlobalStyles } from '@mui/styled-engine';
 import { useTheme as muiUseTheme } from '@mui/private-theming';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import ThemeProvider from '../ThemeProvider';
-import InitColorSchemeScript, {
+import {
+  buildInitColorSchemeScript,
   DEFAULT_COLOR_SCHEME_STORAGE_KEY,
   DEFAULT_MODE_STORAGE_KEY,
 } from '../InitColorSchemeScript/InitColorSchemeScript';
@@ -401,7 +402,7 @@ export default function createCssVarsProvider(options) {
     typeof defaultColorScheme === 'string' ? defaultColorScheme : defaultColorScheme.dark;
 
   const getInitColorSchemeScript = (params) =>
-    InitColorSchemeScript({
+    buildInitColorSchemeScript({
       colorSchemeStorageKey: defaultColorSchemeStorageKey,
       defaultLightColorScheme,
       defaultDarkColorScheme,


### PR DESCRIPTION
closes #48595

✅ tested locally with the pr build. no more warning.

## Problem

`InitColorSchemeScript` renders a raw inline `<script>` as part of the React tree. React 19.3+ (shipped with Next.js 16) emits a dev-only console error when an inline `<script>` is **created during a client render**, because such scripts never execute:

> Encountered a script tag while rendering React component. Scripts inside React components are never executed when rendering on the client.

Production and SSR work fine (no FOUC) — it is purely a dev-mode warning, but a noisy one on every render.

## Fix

Emit the inline script **only on the server render and the matching hydration render**, and render `null` on every client render afterwards. Server/client are distinguished with `useSyncExternalStore` (server snapshot `true`, client snapshot `false`), which stays stable across the hydration boundary so there is no hydration mismatch. By the time React drops the tag on the first post-hydration commit, the IIFE has already run and set the color-scheme attribute on the document, so the applied scheme persists — no FOUC and no behavior change.

React <18 (still in the peer-dependency range) has neither `useSyncExternalStore` nor the warning, so it falls back to always emitting the script — same as today. This reuses the existing `safeReact` pattern from `useMediaQuery`.

The pure script-element builder is split into `buildInitColorSchemeScript` (no hooks) so the deprecated `getInitColorSchemeScript` function — which calls the component directly as a plain function rather than as JSX — does not invoke a hook.

No public API change: existing `<InitColorSchemeScript />` placements keep working and simply stop warning, across all SSR frameworks (Next App/Pages Router, Remix, Vite SSR).

## Testing

- Added a unit test asserting no `<script>` is rendered on a client render.
- Existing `renderToString` tests, `createCssVarsProvider` tests, ESLint, and TypeScript all pass.
