### PR TITLE
[Grid] Clarify that the demo Item component isn't a Material UI export

### DIFF
--- a/docs/data/material/components/grid/grid.md
+++ b/docs/data/material/components/grid/grid.md
@@ -48,6 +48,10 @@ For example, an item with `size={6}` occupies half of the grid container's width
 
 {{"demo": "BasicGrid.js", "bg": true}}
 
+:::info
+The `Item` component used throughout these demos isn't part of Material UI—it's a `styled(Paper)` helper that gives each grid cell a visible surface so the layout is easy to see. Replace `<Item>` with your own content.
+:::
+
 ### Multiple breakpoints
 
 Items may have multiple widths defined, causing the layout to change at the defined breakpoint.


### PR DESCRIPTION
## Summary

The Grid documentation demos render an `Item` component (e.g. `<Item>size=8</Item>`), but the page never mentions that `Item` isn't exported by Material UI—it's a local `styled(Paper)` helper defined in each demo to give grid cells a visible surface. This has confused readers who try to import `Item` (#40556).

This adds a short `:::info` callout right after the first demo, clarifying that `Item` is a demo-only helper and should be replaced with the reader's own content.

Closes #40556
