### PR TITLE
[docs] Fix typos in release instructions

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,7 +46,7 @@ The following steps must be proposed as a pull request.
 
 3. Click "Run workflow"
 4. Refresh the page to see the newly created workflow, and click it.
-5. The next screen will say "@username requested your review to deploy to npm-publish", click "Review deployments" and authorize your workflow run. **Never approve workflow runs you didn't initiaite.**
+5. The next screen will say "@username requested your review to deploy to npm-publish", click "Review deployments" and authorize your workflow run. **Never approve workflow runs you didn't initiate.**
 
 #### Documentation
 
@@ -106,8 +106,8 @@ The following steps must be proposed as a pull request to `release/<PATCH_VERSIO
    > - **--dry-run** Used for debugging. Or directly run `pnpm release:publish:dry-run`.
    > - **--dist-tag** Use to publish legacy or canary versions.
 
-5. This command invokes the [Publish](https://github.com/mui/base-ui/actions/workflows/publish.yml) GitHub action. It'll log the url which can be opened to see the latest workflow run.
-6. The next screen shows "@username requested your review to deploy to npm-publish", click "Review deployments" and authorize your workflow run. **Never approve workflow runs you didn't initiaite.**
+5. This command invokes the [Publish](https://github.com/mui/material-ui/actions/workflows/publish.yml) GitHub action. It'll log the URL which can be opened to see the latest workflow run.
+6. The next screen shows "@username requested your review to deploy to npm-publish", click "Review deployments" and authorize your workflow run. **Never approve workflow runs you didn't initiate.**
 
 #### Documentation
 


### PR DESCRIPTION
Ports applicable fixes from the base-ui release-instructions overhaul (mui/base-ui#5063) to this repo's `scripts/README.md`:

- Fix typo `initiaite` → `initiate` (x2)
- Fix `url` → `URL`
- Fix wrong publish-action link pointing to `mui/base-ui` → `mui/material-ui` (copy-paste bug)

The rest of that PR is base-ui-specific and does not apply here.

Reference: https://github.com/mui/base-ui/pull/5063