### PR TITLE
[docs-infra] Pre-render API page descriptions

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -84,6 +84,14 @@ export default withDocsInfra({
           as: '*.js',
         },
       ],
+      // API page description JSON (imported only by generated API pages) → render
+      // the markdown to HTML at build time.
+      '**/translations/api-docs/**/*.json': [
+        {
+          loaders: [{ loader: '@mui/internal-markdown/apiPageTranslationLoader' }],
+          as: '*.js',
+        },
+      ],
     },
   },
   webpack: (
@@ -209,6 +217,13 @@ export default withDocsInfra({
                 type: 'asset/source',
               },
             ],
+          },
+          {
+            // API page description JSON (`translations/api-docs/**`, imported only by
+            // generated API pages) → render the markdown to HTML at build time.
+            test: /translations[\\/]api-docs[\\/].*\.json$/,
+            type: 'javascript/auto',
+            use: [{ loader: require.resolve('@mui/internal-markdown/apiPageTranslationLoader') }],
           },
           // required to transpile ../packages/
           {

--- a/docs/pages/material-ui/api/accordion-actions.js
+++ b/docs/pages/material-ui/api/accordion-actions.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/accordion-actions/accordion-actions.json';
+import descriptions from 'docs/translations/api-docs/accordion-actions/accordion-actions.json';
 import jsonPageContent from './accordion-actions.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/accordion-details.js
+++ b/docs/pages/material-ui/api/accordion-details.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/accordion-details/accordion-details.json';
+import descriptions from 'docs/translations/api-docs/accordion-details/accordion-details.json';
 import jsonPageContent from './accordion-details.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/accordion-summary.js
+++ b/docs/pages/material-ui/api/accordion-summary.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/accordion-summary/accordion-summary.json';
+import descriptions from 'docs/translations/api-docs/accordion-summary/accordion-summary.json';
 import jsonPageContent from './accordion-summary.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/accordion.js
+++ b/docs/pages/material-ui/api/accordion.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/accordion/accordion.json';
+import descriptions from 'docs/translations/api-docs/accordion/accordion.json';
 import jsonPageContent from './accordion.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/alert-title.js
+++ b/docs/pages/material-ui/api/alert-title.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/alert-title/alert-title.json';
+import descriptions from 'docs/translations/api-docs/alert-title/alert-title.json';
 import jsonPageContent from './alert-title.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/alert.js
+++ b/docs/pages/material-ui/api/alert.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/alert/alert.json';
+import descriptions from 'docs/translations/api-docs/alert/alert.json';
 import jsonPageContent from './alert.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/app-bar.js
+++ b/docs/pages/material-ui/api/app-bar.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/app-bar/app-bar.json';
+import descriptions from 'docs/translations/api-docs/app-bar/app-bar.json';
 import jsonPageContent from './app-bar.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/autocomplete.js
+++ b/docs/pages/material-ui/api/autocomplete.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/autocomplete/autocomplete.json';
+import descriptions from 'docs/translations/api-docs/autocomplete/autocomplete.json';
 import jsonPageContent from './autocomplete.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/avatar-group.js
+++ b/docs/pages/material-ui/api/avatar-group.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/avatar-group/avatar-group.json';
+import descriptions from 'docs/translations/api-docs/avatar-group/avatar-group.json';
 import jsonPageContent from './avatar-group.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/avatar.js
+++ b/docs/pages/material-ui/api/avatar.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/avatar/avatar.json';
+import descriptions from 'docs/translations/api-docs/avatar/avatar.json';
 import jsonPageContent from './avatar.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/backdrop.js
+++ b/docs/pages/material-ui/api/backdrop.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/backdrop/backdrop.json';
+import descriptions from 'docs/translations/api-docs/backdrop/backdrop.json';
 import jsonPageContent from './backdrop.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/badge.js
+++ b/docs/pages/material-ui/api/badge.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/badge/badge.json';
+import descriptions from 'docs/translations/api-docs/badge/badge.json';
 import jsonPageContent from './badge.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/bottom-navigation-action.js
+++ b/docs/pages/material-ui/api/bottom-navigation-action.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/bottom-navigation-action/bottom-navigation-action.json';
+import descriptions from 'docs/translations/api-docs/bottom-navigation-action/bottom-navigation-action.json';
 import jsonPageContent from './bottom-navigation-action.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/bottom-navigation.js
+++ b/docs/pages/material-ui/api/bottom-navigation.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/bottom-navigation/bottom-navigation.json';
+import descriptions from 'docs/translations/api-docs/bottom-navigation/bottom-navigation.json';
 import jsonPageContent from './bottom-navigation.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/box.js
+++ b/docs/pages/material-ui/api/box.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/box/box.json';
+import descriptions from 'docs/translations/api-docs/box/box.json';
 import jsonPageContent from './box.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/breadcrumbs.js
+++ b/docs/pages/material-ui/api/breadcrumbs.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/breadcrumbs/breadcrumbs.json';
+import descriptions from 'docs/translations/api-docs/breadcrumbs/breadcrumbs.json';
 import jsonPageContent from './breadcrumbs.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/button-base.js
+++ b/docs/pages/material-ui/api/button-base.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/button-base/button-base.json';
+import descriptions from 'docs/translations/api-docs/button-base/button-base.json';
 import jsonPageContent from './button-base.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/button-group.js
+++ b/docs/pages/material-ui/api/button-group.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/button-group/button-group.json';
+import descriptions from 'docs/translations/api-docs/button-group/button-group.json';
 import jsonPageContent from './button-group.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/button.js
+++ b/docs/pages/material-ui/api/button.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/button/button.json';
+import descriptions from 'docs/translations/api-docs/button/button.json';
 import jsonPageContent from './button.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/card-action-area.js
+++ b/docs/pages/material-ui/api/card-action-area.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/card-action-area/card-action-area.json';
+import descriptions from 'docs/translations/api-docs/card-action-area/card-action-area.json';
 import jsonPageContent from './card-action-area.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/card-actions.js
+++ b/docs/pages/material-ui/api/card-actions.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/card-actions/card-actions.json';
+import descriptions from 'docs/translations/api-docs/card-actions/card-actions.json';
 import jsonPageContent from './card-actions.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/card-content.js
+++ b/docs/pages/material-ui/api/card-content.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/card-content/card-content.json';
+import descriptions from 'docs/translations/api-docs/card-content/card-content.json';
 import jsonPageContent from './card-content.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/card-header.js
+++ b/docs/pages/material-ui/api/card-header.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/card-header/card-header.json';
+import descriptions from 'docs/translations/api-docs/card-header/card-header.json';
 import jsonPageContent from './card-header.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/card-media.js
+++ b/docs/pages/material-ui/api/card-media.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/card-media/card-media.json';
+import descriptions from 'docs/translations/api-docs/card-media/card-media.json';
 import jsonPageContent from './card-media.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/card.js
+++ b/docs/pages/material-ui/api/card.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/card/card.json';
+import descriptions from 'docs/translations/api-docs/card/card.json';
 import jsonPageContent from './card.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/checkbox.js
+++ b/docs/pages/material-ui/api/checkbox.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/checkbox/checkbox.json';
+import descriptions from 'docs/translations/api-docs/checkbox/checkbox.json';
 import jsonPageContent from './checkbox.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/chip.js
+++ b/docs/pages/material-ui/api/chip.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/chip/chip.json';
+import descriptions from 'docs/translations/api-docs/chip/chip.json';
 import jsonPageContent from './chip.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/circular-progress.js
+++ b/docs/pages/material-ui/api/circular-progress.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/circular-progress/circular-progress.json';
+import descriptions from 'docs/translations/api-docs/circular-progress/circular-progress.json';
 import jsonPageContent from './circular-progress.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/click-away-listener.js
+++ b/docs/pages/material-ui/api/click-away-listener.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/click-away-listener/click-away-listener.json';
+import descriptions from 'docs/translations/api-docs/click-away-listener/click-away-listener.json';
 import jsonPageContent from './click-away-listener.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/collapse.js
+++ b/docs/pages/material-ui/api/collapse.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/collapse/collapse.json';
+import descriptions from 'docs/translations/api-docs/collapse/collapse.json';
 import jsonPageContent from './collapse.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/container.js
+++ b/docs/pages/material-ui/api/container.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/container/container.json';
+import descriptions from 'docs/translations/api-docs/container/container.json';
 import jsonPageContent from './container.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/css-baseline.js
+++ b/docs/pages/material-ui/api/css-baseline.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/css-baseline/css-baseline.json';
+import descriptions from 'docs/translations/api-docs/css-baseline/css-baseline.json';
 import jsonPageContent from './css-baseline.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/dialog-actions.js
+++ b/docs/pages/material-ui/api/dialog-actions.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/dialog-actions/dialog-actions.json';
+import descriptions from 'docs/translations/api-docs/dialog-actions/dialog-actions.json';
 import jsonPageContent from './dialog-actions.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/dialog-content-text.js
+++ b/docs/pages/material-ui/api/dialog-content-text.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/dialog-content-text/dialog-content-text.json';
+import descriptions from 'docs/translations/api-docs/dialog-content-text/dialog-content-text.json';
 import jsonPageContent from './dialog-content-text.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/dialog-content.js
+++ b/docs/pages/material-ui/api/dialog-content.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/dialog-content/dialog-content.json';
+import descriptions from 'docs/translations/api-docs/dialog-content/dialog-content.json';
 import jsonPageContent from './dialog-content.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/dialog-title.js
+++ b/docs/pages/material-ui/api/dialog-title.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/dialog-title/dialog-title.json';
+import descriptions from 'docs/translations/api-docs/dialog-title/dialog-title.json';
 import jsonPageContent from './dialog-title.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/dialog.js
+++ b/docs/pages/material-ui/api/dialog.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/dialog/dialog.json';
+import descriptions from 'docs/translations/api-docs/dialog/dialog.json';
 import jsonPageContent from './dialog.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/divider.js
+++ b/docs/pages/material-ui/api/divider.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/divider/divider.json';
+import descriptions from 'docs/translations/api-docs/divider/divider.json';
 import jsonPageContent from './divider.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/drawer.js
+++ b/docs/pages/material-ui/api/drawer.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/drawer/drawer.json';
+import descriptions from 'docs/translations/api-docs/drawer/drawer.json';
 import jsonPageContent from './drawer.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/fab.js
+++ b/docs/pages/material-ui/api/fab.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/fab/fab.json';
+import descriptions from 'docs/translations/api-docs/fab/fab.json';
 import jsonPageContent from './fab.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/fade.js
+++ b/docs/pages/material-ui/api/fade.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/fade/fade.json';
+import descriptions from 'docs/translations/api-docs/fade/fade.json';
 import jsonPageContent from './fade.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/filled-input.js
+++ b/docs/pages/material-ui/api/filled-input.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/filled-input/filled-input.json';
+import descriptions from 'docs/translations/api-docs/filled-input/filled-input.json';
 import jsonPageContent from './filled-input.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/form-control-label.js
+++ b/docs/pages/material-ui/api/form-control-label.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/form-control-label/form-control-label.json';
+import descriptions from 'docs/translations/api-docs/form-control-label/form-control-label.json';
 import jsonPageContent from './form-control-label.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/form-control.js
+++ b/docs/pages/material-ui/api/form-control.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/form-control/form-control.json';
+import descriptions from 'docs/translations/api-docs/form-control/form-control.json';
 import jsonPageContent from './form-control.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/form-group.js
+++ b/docs/pages/material-ui/api/form-group.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/form-group/form-group.json';
+import descriptions from 'docs/translations/api-docs/form-group/form-group.json';
 import jsonPageContent from './form-group.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/form-helper-text.js
+++ b/docs/pages/material-ui/api/form-helper-text.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/form-helper-text/form-helper-text.json';
+import descriptions from 'docs/translations/api-docs/form-helper-text/form-helper-text.json';
 import jsonPageContent from './form-helper-text.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/form-label.js
+++ b/docs/pages/material-ui/api/form-label.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/form-label/form-label.json';
+import descriptions from 'docs/translations/api-docs/form-label/form-label.json';
 import jsonPageContent from './form-label.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/global-styles.js
+++ b/docs/pages/material-ui/api/global-styles.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/global-styles/global-styles.json';
+import descriptions from 'docs/translations/api-docs/global-styles/global-styles.json';
 import jsonPageContent from './global-styles.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/grid.js
+++ b/docs/pages/material-ui/api/grid.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/grid/grid.json';
+import descriptions from 'docs/translations/api-docs/grid/grid.json';
 import jsonPageContent from './grid.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/grow.js
+++ b/docs/pages/material-ui/api/grow.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/grow/grow.json';
+import descriptions from 'docs/translations/api-docs/grow/grow.json';
 import jsonPageContent from './grow.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/icon-button.js
+++ b/docs/pages/material-ui/api/icon-button.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/icon-button/icon-button.json';
+import descriptions from 'docs/translations/api-docs/icon-button/icon-button.json';
 import jsonPageContent from './icon-button.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/icon.js
+++ b/docs/pages/material-ui/api/icon.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/icon/icon.json';
+import descriptions from 'docs/translations/api-docs/icon/icon.json';
 import jsonPageContent from './icon.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/image-list-item-bar.js
+++ b/docs/pages/material-ui/api/image-list-item-bar.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/image-list-item-bar/image-list-item-bar.json';
+import descriptions from 'docs/translations/api-docs/image-list-item-bar/image-list-item-bar.json';
 import jsonPageContent from './image-list-item-bar.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/image-list-item.js
+++ b/docs/pages/material-ui/api/image-list-item.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/image-list-item/image-list-item.json';
+import descriptions from 'docs/translations/api-docs/image-list-item/image-list-item.json';
 import jsonPageContent from './image-list-item.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/image-list.js
+++ b/docs/pages/material-ui/api/image-list.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/image-list/image-list.json';
+import descriptions from 'docs/translations/api-docs/image-list/image-list.json';
 import jsonPageContent from './image-list.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/init-color-scheme-script.js
+++ b/docs/pages/material-ui/api/init-color-scheme-script.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/init-color-scheme-script/init-color-scheme-script.json';
+import descriptions from 'docs/translations/api-docs/init-color-scheme-script/init-color-scheme-script.json';
 import jsonPageContent from './init-color-scheme-script.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/input-adornment.js
+++ b/docs/pages/material-ui/api/input-adornment.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/input-adornment/input-adornment.json';
+import descriptions from 'docs/translations/api-docs/input-adornment/input-adornment.json';
 import jsonPageContent from './input-adornment.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/input-base.js
+++ b/docs/pages/material-ui/api/input-base.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/input-base/input-base.json';
+import descriptions from 'docs/translations/api-docs/input-base/input-base.json';
 import jsonPageContent from './input-base.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/input-label.js
+++ b/docs/pages/material-ui/api/input-label.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/input-label/input-label.json';
+import descriptions from 'docs/translations/api-docs/input-label/input-label.json';
 import jsonPageContent from './input-label.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/input.js
+++ b/docs/pages/material-ui/api/input.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/input/input.json';
+import descriptions from 'docs/translations/api-docs/input/input.json';
 import jsonPageContent from './input.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/linear-progress.js
+++ b/docs/pages/material-ui/api/linear-progress.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/linear-progress/linear-progress.json';
+import descriptions from 'docs/translations/api-docs/linear-progress/linear-progress.json';
 import jsonPageContent from './linear-progress.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/link.js
+++ b/docs/pages/material-ui/api/link.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/link/link.json';
+import descriptions from 'docs/translations/api-docs/link/link.json';
 import jsonPageContent from './link.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/list-item-avatar.js
+++ b/docs/pages/material-ui/api/list-item-avatar.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/list-item-avatar/list-item-avatar.json';
+import descriptions from 'docs/translations/api-docs/list-item-avatar/list-item-avatar.json';
 import jsonPageContent from './list-item-avatar.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/list-item-button.js
+++ b/docs/pages/material-ui/api/list-item-button.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/list-item-button/list-item-button.json';
+import descriptions from 'docs/translations/api-docs/list-item-button/list-item-button.json';
 import jsonPageContent from './list-item-button.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/list-item-icon.js
+++ b/docs/pages/material-ui/api/list-item-icon.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/list-item-icon/list-item-icon.json';
+import descriptions from 'docs/translations/api-docs/list-item-icon/list-item-icon.json';
 import jsonPageContent from './list-item-icon.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/list-item-secondary-action.js
+++ b/docs/pages/material-ui/api/list-item-secondary-action.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/list-item-secondary-action/list-item-secondary-action.json';
+import descriptions from 'docs/translations/api-docs/list-item-secondary-action/list-item-secondary-action.json';
 import jsonPageContent from './list-item-secondary-action.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/list-item-text.js
+++ b/docs/pages/material-ui/api/list-item-text.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/list-item-text/list-item-text.json';
+import descriptions from 'docs/translations/api-docs/list-item-text/list-item-text.json';
 import jsonPageContent from './list-item-text.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/list-item.js
+++ b/docs/pages/material-ui/api/list-item.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/list-item/list-item.json';
+import descriptions from 'docs/translations/api-docs/list-item/list-item.json';
 import jsonPageContent from './list-item.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/list-subheader.js
+++ b/docs/pages/material-ui/api/list-subheader.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/list-subheader/list-subheader.json';
+import descriptions from 'docs/translations/api-docs/list-subheader/list-subheader.json';
 import jsonPageContent from './list-subheader.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/list.js
+++ b/docs/pages/material-ui/api/list.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/list/list.json';
+import descriptions from 'docs/translations/api-docs/list/list.json';
 import jsonPageContent from './list.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/masonry.js
+++ b/docs/pages/material-ui/api/masonry.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/masonry/masonry.json';
+import descriptions from 'docs/translations/api-docs/masonry/masonry.json';
 import jsonPageContent from './masonry.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/menu-item.js
+++ b/docs/pages/material-ui/api/menu-item.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/menu-item/menu-item.json';
+import descriptions from 'docs/translations/api-docs/menu-item/menu-item.json';
 import jsonPageContent from './menu-item.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/menu-list.js
+++ b/docs/pages/material-ui/api/menu-list.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/menu-list/menu-list.json';
+import descriptions from 'docs/translations/api-docs/menu-list/menu-list.json';
 import jsonPageContent from './menu-list.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/menu.js
+++ b/docs/pages/material-ui/api/menu.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/menu/menu.json';
+import descriptions from 'docs/translations/api-docs/menu/menu.json';
 import jsonPageContent from './menu.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/mobile-stepper.js
+++ b/docs/pages/material-ui/api/mobile-stepper.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/mobile-stepper/mobile-stepper.json';
+import descriptions from 'docs/translations/api-docs/mobile-stepper/mobile-stepper.json';
 import jsonPageContent from './mobile-stepper.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/modal.js
+++ b/docs/pages/material-ui/api/modal.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/modal/modal.json';
+import descriptions from 'docs/translations/api-docs/modal/modal.json';
 import jsonPageContent from './modal.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/native-select.js
+++ b/docs/pages/material-ui/api/native-select.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/native-select/native-select.json';
+import descriptions from 'docs/translations/api-docs/native-select/native-select.json';
 import jsonPageContent from './native-select.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/no-ssr.js
+++ b/docs/pages/material-ui/api/no-ssr.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/no-ssr/no-ssr.json';
+import descriptions from 'docs/translations/api-docs/no-ssr/no-ssr.json';
 import jsonPageContent from './no-ssr.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/outlined-input.js
+++ b/docs/pages/material-ui/api/outlined-input.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/outlined-input/outlined-input.json';
+import descriptions from 'docs/translations/api-docs/outlined-input/outlined-input.json';
 import jsonPageContent from './outlined-input.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/pagination-item.js
+++ b/docs/pages/material-ui/api/pagination-item.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/pagination-item/pagination-item.json';
+import descriptions from 'docs/translations/api-docs/pagination-item/pagination-item.json';
 import jsonPageContent from './pagination-item.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/pagination.js
+++ b/docs/pages/material-ui/api/pagination.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/pagination/pagination.json';
+import descriptions from 'docs/translations/api-docs/pagination/pagination.json';
 import jsonPageContent from './pagination.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/paper.js
+++ b/docs/pages/material-ui/api/paper.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/paper/paper.json';
+import descriptions from 'docs/translations/api-docs/paper/paper.json';
 import jsonPageContent from './paper.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/pigment-container.js
+++ b/docs/pages/material-ui/api/pigment-container.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/pigment-container/pigment-container.json';
+import descriptions from 'docs/translations/api-docs/pigment-container/pigment-container.json';
 import jsonPageContent from './pigment-container.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/pigment-grid.js
+++ b/docs/pages/material-ui/api/pigment-grid.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/pigment-grid/pigment-grid.json';
+import descriptions from 'docs/translations/api-docs/pigment-grid/pigment-grid.json';
 import jsonPageContent from './pigment-grid.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/pigment-stack.js
+++ b/docs/pages/material-ui/api/pigment-stack.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/pigment-stack/pigment-stack.json';
+import descriptions from 'docs/translations/api-docs/pigment-stack/pigment-stack.json';
 import jsonPageContent from './pigment-stack.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/popover.js
+++ b/docs/pages/material-ui/api/popover.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/popover/popover.json';
+import descriptions from 'docs/translations/api-docs/popover/popover.json';
 import jsonPageContent from './popover.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/popper.js
+++ b/docs/pages/material-ui/api/popper.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/popper/popper.json';
+import descriptions from 'docs/translations/api-docs/popper/popper.json';
 import jsonPageContent from './popper.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/portal.js
+++ b/docs/pages/material-ui/api/portal.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/portal/portal.json';
+import descriptions from 'docs/translations/api-docs/portal/portal.json';
 import jsonPageContent from './portal.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/radio-group.js
+++ b/docs/pages/material-ui/api/radio-group.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/radio-group/radio-group.json';
+import descriptions from 'docs/translations/api-docs/radio-group/radio-group.json';
 import jsonPageContent from './radio-group.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/radio.js
+++ b/docs/pages/material-ui/api/radio.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/radio/radio.json';
+import descriptions from 'docs/translations/api-docs/radio/radio.json';
 import jsonPageContent from './radio.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/rating.js
+++ b/docs/pages/material-ui/api/rating.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/rating/rating.json';
+import descriptions from 'docs/translations/api-docs/rating/rating.json';
 import jsonPageContent from './rating.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/scoped-css-baseline.js
+++ b/docs/pages/material-ui/api/scoped-css-baseline.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/scoped-css-baseline/scoped-css-baseline.json';
+import descriptions from 'docs/translations/api-docs/scoped-css-baseline/scoped-css-baseline.json';
 import jsonPageContent from './scoped-css-baseline.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/select.js
+++ b/docs/pages/material-ui/api/select.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/select/select.json';
+import descriptions from 'docs/translations/api-docs/select/select.json';
 import jsonPageContent from './select.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/skeleton.js
+++ b/docs/pages/material-ui/api/skeleton.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/skeleton/skeleton.json';
+import descriptions from 'docs/translations/api-docs/skeleton/skeleton.json';
 import jsonPageContent from './skeleton.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/slide.js
+++ b/docs/pages/material-ui/api/slide.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/slide/slide.json';
+import descriptions from 'docs/translations/api-docs/slide/slide.json';
 import jsonPageContent from './slide.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/slider.js
+++ b/docs/pages/material-ui/api/slider.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/slider/slider.json';
+import descriptions from 'docs/translations/api-docs/slider/slider.json';
 import jsonPageContent from './slider.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/snackbar-content.js
+++ b/docs/pages/material-ui/api/snackbar-content.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/snackbar-content/snackbar-content.json';
+import descriptions from 'docs/translations/api-docs/snackbar-content/snackbar-content.json';
 import jsonPageContent from './snackbar-content.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/snackbar.js
+++ b/docs/pages/material-ui/api/snackbar.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/snackbar/snackbar.json';
+import descriptions from 'docs/translations/api-docs/snackbar/snackbar.json';
 import jsonPageContent from './snackbar.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/speed-dial-action.js
+++ b/docs/pages/material-ui/api/speed-dial-action.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/speed-dial-action/speed-dial-action.json';
+import descriptions from 'docs/translations/api-docs/speed-dial-action/speed-dial-action.json';
 import jsonPageContent from './speed-dial-action.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/speed-dial-icon.js
+++ b/docs/pages/material-ui/api/speed-dial-icon.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/speed-dial-icon/speed-dial-icon.json';
+import descriptions from 'docs/translations/api-docs/speed-dial-icon/speed-dial-icon.json';
 import jsonPageContent from './speed-dial-icon.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/speed-dial.js
+++ b/docs/pages/material-ui/api/speed-dial.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/speed-dial/speed-dial.json';
+import descriptions from 'docs/translations/api-docs/speed-dial/speed-dial.json';
 import jsonPageContent from './speed-dial.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/stack.js
+++ b/docs/pages/material-ui/api/stack.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/stack/stack.json';
+import descriptions from 'docs/translations/api-docs/stack/stack.json';
 import jsonPageContent from './stack.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/step-button.js
+++ b/docs/pages/material-ui/api/step-button.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/step-button/step-button.json';
+import descriptions from 'docs/translations/api-docs/step-button/step-button.json';
 import jsonPageContent from './step-button.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/step-connector.js
+++ b/docs/pages/material-ui/api/step-connector.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/step-connector/step-connector.json';
+import descriptions from 'docs/translations/api-docs/step-connector/step-connector.json';
 import jsonPageContent from './step-connector.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/step-content.js
+++ b/docs/pages/material-ui/api/step-content.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/step-content/step-content.json';
+import descriptions from 'docs/translations/api-docs/step-content/step-content.json';
 import jsonPageContent from './step-content.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/step-icon.js
+++ b/docs/pages/material-ui/api/step-icon.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/step-icon/step-icon.json';
+import descriptions from 'docs/translations/api-docs/step-icon/step-icon.json';
 import jsonPageContent from './step-icon.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/step-label.js
+++ b/docs/pages/material-ui/api/step-label.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/step-label/step-label.json';
+import descriptions from 'docs/translations/api-docs/step-label/step-label.json';
 import jsonPageContent from './step-label.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/step.js
+++ b/docs/pages/material-ui/api/step.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/step/step.json';
+import descriptions from 'docs/translations/api-docs/step/step.json';
 import jsonPageContent from './step.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/stepper.js
+++ b/docs/pages/material-ui/api/stepper.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/stepper/stepper.json';
+import descriptions from 'docs/translations/api-docs/stepper/stepper.json';
 import jsonPageContent from './stepper.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/svg-icon.js
+++ b/docs/pages/material-ui/api/svg-icon.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/svg-icon/svg-icon.json';
+import descriptions from 'docs/translations/api-docs/svg-icon/svg-icon.json';
 import jsonPageContent from './svg-icon.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/swipeable-drawer.js
+++ b/docs/pages/material-ui/api/swipeable-drawer.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/swipeable-drawer/swipeable-drawer.json';
+import descriptions from 'docs/translations/api-docs/swipeable-drawer/swipeable-drawer.json';
 import jsonPageContent from './swipeable-drawer.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/switch.js
+++ b/docs/pages/material-ui/api/switch.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/switch/switch.json';
+import descriptions from 'docs/translations/api-docs/switch/switch.json';
 import jsonPageContent from './switch.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/tab-context.js
+++ b/docs/pages/material-ui/api/tab-context.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/tab-context/tab-context.json';
+import descriptions from 'docs/translations/api-docs/tab-context/tab-context.json';
 import jsonPageContent from './tab-context.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/tab-list.js
+++ b/docs/pages/material-ui/api/tab-list.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/tab-list/tab-list.json';
+import descriptions from 'docs/translations/api-docs/tab-list/tab-list.json';
 import jsonPageContent from './tab-list.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/tab-panel.js
+++ b/docs/pages/material-ui/api/tab-panel.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/tab-panel/tab-panel.json';
+import descriptions from 'docs/translations/api-docs/tab-panel/tab-panel.json';
 import jsonPageContent from './tab-panel.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/tab-scroll-button.js
+++ b/docs/pages/material-ui/api/tab-scroll-button.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/tab-scroll-button/tab-scroll-button.json';
+import descriptions from 'docs/translations/api-docs/tab-scroll-button/tab-scroll-button.json';
 import jsonPageContent from './tab-scroll-button.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/tab.js
+++ b/docs/pages/material-ui/api/tab.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/tab/tab.json';
+import descriptions from 'docs/translations/api-docs/tab/tab.json';
 import jsonPageContent from './tab.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/table-body.js
+++ b/docs/pages/material-ui/api/table-body.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/table-body/table-body.json';
+import descriptions from 'docs/translations/api-docs/table-body/table-body.json';
 import jsonPageContent from './table-body.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/table-cell.js
+++ b/docs/pages/material-ui/api/table-cell.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/table-cell/table-cell.json';
+import descriptions from 'docs/translations/api-docs/table-cell/table-cell.json';
 import jsonPageContent from './table-cell.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/table-container.js
+++ b/docs/pages/material-ui/api/table-container.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/table-container/table-container.json';
+import descriptions from 'docs/translations/api-docs/table-container/table-container.json';
 import jsonPageContent from './table-container.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/table-footer.js
+++ b/docs/pages/material-ui/api/table-footer.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/table-footer/table-footer.json';
+import descriptions from 'docs/translations/api-docs/table-footer/table-footer.json';
 import jsonPageContent from './table-footer.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/table-head.js
+++ b/docs/pages/material-ui/api/table-head.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/table-head/table-head.json';
+import descriptions from 'docs/translations/api-docs/table-head/table-head.json';
 import jsonPageContent from './table-head.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/table-pagination-actions.js
+++ b/docs/pages/material-ui/api/table-pagination-actions.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/table-pagination-actions/table-pagination-actions.json';
+import descriptions from 'docs/translations/api-docs/table-pagination-actions/table-pagination-actions.json';
 import jsonPageContent from './table-pagination-actions.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/table-pagination.js
+++ b/docs/pages/material-ui/api/table-pagination.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/table-pagination/table-pagination.json';
+import descriptions from 'docs/translations/api-docs/table-pagination/table-pagination.json';
 import jsonPageContent from './table-pagination.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/table-row.js
+++ b/docs/pages/material-ui/api/table-row.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/table-row/table-row.json';
+import descriptions from 'docs/translations/api-docs/table-row/table-row.json';
 import jsonPageContent from './table-row.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/table-sort-label.js
+++ b/docs/pages/material-ui/api/table-sort-label.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/table-sort-label/table-sort-label.json';
+import descriptions from 'docs/translations/api-docs/table-sort-label/table-sort-label.json';
 import jsonPageContent from './table-sort-label.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/table.js
+++ b/docs/pages/material-ui/api/table.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/table/table.json';
+import descriptions from 'docs/translations/api-docs/table/table.json';
 import jsonPageContent from './table.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/tabs.js
+++ b/docs/pages/material-ui/api/tabs.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/tabs/tabs.json';
+import descriptions from 'docs/translations/api-docs/tabs/tabs.json';
 import jsonPageContent from './tabs.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/text-field.js
+++ b/docs/pages/material-ui/api/text-field.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/text-field/text-field.json';
+import descriptions from 'docs/translations/api-docs/text-field/text-field.json';
 import jsonPageContent from './text-field.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/textarea-autosize.js
+++ b/docs/pages/material-ui/api/textarea-autosize.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/textarea-autosize/textarea-autosize.json';
+import descriptions from 'docs/translations/api-docs/textarea-autosize/textarea-autosize.json';
 import jsonPageContent from './textarea-autosize.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/timeline-connector.js
+++ b/docs/pages/material-ui/api/timeline-connector.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/timeline-connector/timeline-connector.json';
+import descriptions from 'docs/translations/api-docs/timeline-connector/timeline-connector.json';
 import jsonPageContent from './timeline-connector.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/timeline-content.js
+++ b/docs/pages/material-ui/api/timeline-content.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/timeline-content/timeline-content.json';
+import descriptions from 'docs/translations/api-docs/timeline-content/timeline-content.json';
 import jsonPageContent from './timeline-content.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/timeline-dot.js
+++ b/docs/pages/material-ui/api/timeline-dot.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/timeline-dot/timeline-dot.json';
+import descriptions from 'docs/translations/api-docs/timeline-dot/timeline-dot.json';
 import jsonPageContent from './timeline-dot.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/timeline-item.js
+++ b/docs/pages/material-ui/api/timeline-item.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/timeline-item/timeline-item.json';
+import descriptions from 'docs/translations/api-docs/timeline-item/timeline-item.json';
 import jsonPageContent from './timeline-item.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/timeline-opposite-content.js
+++ b/docs/pages/material-ui/api/timeline-opposite-content.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/timeline-opposite-content/timeline-opposite-content.json';
+import descriptions from 'docs/translations/api-docs/timeline-opposite-content/timeline-opposite-content.json';
 import jsonPageContent from './timeline-opposite-content.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/timeline-separator.js
+++ b/docs/pages/material-ui/api/timeline-separator.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/timeline-separator/timeline-separator.json';
+import descriptions from 'docs/translations/api-docs/timeline-separator/timeline-separator.json';
 import jsonPageContent from './timeline-separator.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/timeline.js
+++ b/docs/pages/material-ui/api/timeline.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/timeline/timeline.json';
+import descriptions from 'docs/translations/api-docs/timeline/timeline.json';
 import jsonPageContent from './timeline.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/toggle-button-group.js
+++ b/docs/pages/material-ui/api/toggle-button-group.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/toggle-button-group/toggle-button-group.json';
+import descriptions from 'docs/translations/api-docs/toggle-button-group/toggle-button-group.json';
 import jsonPageContent from './toggle-button-group.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/toggle-button.js
+++ b/docs/pages/material-ui/api/toggle-button.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/toggle-button/toggle-button.json';
+import descriptions from 'docs/translations/api-docs/toggle-button/toggle-button.json';
 import jsonPageContent from './toggle-button.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/toolbar.js
+++ b/docs/pages/material-ui/api/toolbar.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/toolbar/toolbar.json';
+import descriptions from 'docs/translations/api-docs/toolbar/toolbar.json';
 import jsonPageContent from './toolbar.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/tooltip.js
+++ b/docs/pages/material-ui/api/tooltip.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/tooltip/tooltip.json';
+import descriptions from 'docs/translations/api-docs/tooltip/tooltip.json';
 import jsonPageContent from './tooltip.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/typography.js
+++ b/docs/pages/material-ui/api/typography.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/typography/typography.json';
+import descriptions from 'docs/translations/api-docs/typography/typography.json';
 import jsonPageContent from './typography.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/material-ui/api/zoom.js
+++ b/docs/pages/material-ui/api/zoom.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/zoom/zoom.json';
+import descriptions from 'docs/translations/api-docs/zoom/zoom.json';
 import jsonPageContent from './zoom.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/system/api/box.js
+++ b/docs/pages/system/api/box.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/box/box.json';
+import descriptions from 'docs/translations/api-docs/box/box.json';
 import jsonPageContent from './box.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/system/api/container.js
+++ b/docs/pages/system/api/container.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/container/container.json';
+import descriptions from 'docs/translations/api-docs/container/container.json';
 import jsonPageContent from './container.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/system/api/grid.js
+++ b/docs/pages/system/api/grid.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/grid/grid.json';
+import descriptions from 'docs/translations/api-docs/grid/grid.json';
 import jsonPageContent from './grid.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/docs/pages/system/api/stack.js
+++ b/docs/pages/system/api/stack.js
@@ -1,16 +1,8 @@
 import * as React from 'react';
 import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';
-import translation from 'docs/translations/api-docs/stack/stack.json';
+import descriptions from 'docs/translations/api-docs/stack/stack.json';
 import jsonPageContent from './stack.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }

--- a/packages-internal/api-docs-builder/src/ApiBuilders/ComponentApiBuilder.ts
+++ b/packages-internal/api-docs-builder/src/ApiBuilders/ComponentApiBuilder.ts
@@ -374,25 +374,17 @@ const generateApiPage = async (
     await writePrettifiedFile(
       path.resolve(apiPagesDirectory, `${kebabCase(reactApi.name)}.js`),
       `import * as React from 'react';
-import { ApiPage } from '@mui/internal-core-docs/ApiPage';
-import { mapApiPageTranslation } from '@mui/internal-core-docs/mapApiPageTranslations';${
+import { ApiPage } from '@mui/internal-core-docs/ApiPage';${
         layoutConfigPath === ''
           ? ''
           : `
 import layoutConfig from '${layoutConfigPath}';`
       }
-import translation from '${importTranslationPagesDirectory}/${kebabCase(reactApi.name)}/${kebabCase(reactApi.name)}.json';
+import descriptions from '${importTranslationPagesDirectory}/${kebabCase(reactApi.name)}/${kebabCase(reactApi.name)}.json';
 import jsonPageContent from './${kebabCase(reactApi.name)}.json';
 
-export default function Page(props) {
-  const { descriptions } = props;
+export default function Page() {
   return <ApiPage ${layoutConfigPath === '' ? '' : '{...layoutConfig} '}descriptions={descriptions} pageContent={jsonPageContent} />;
-}
-
-export async function getStaticProps() {
-  const descriptions = mapApiPageTranslation(translation);
-
-  return { props: { descriptions } };
 }
 `.replace(/\r?\n/g, reactApi.EOL),
     );

--- a/packages-internal/markdown/apiPageTranslationLoader.mjs
+++ b/packages-internal/markdown/apiPageTranslationLoader.mjs
@@ -1,0 +1,36 @@
+// @ts-check
+import { createRender } from './parseMarkdown.mjs';
+
+/**
+ * Renders the markdown `componentDescription` of an API translation JSON to HTML
+ * and computes its `componentDescriptionToc`, at bundler build time. Lets API
+ * pages import the rendered descriptions directly from the raw translation JSON
+ * without committing the rendered HTML or shipping the markdown lib to the client.
+ *
+ * Applied by path convention to `translations/api-docs/**.json` (see next.config),
+ * which only the generated API pages import.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+export default function apiPageTranslationLoader(source) {
+  const translation = JSON.parse(source);
+
+  if (translation && translation.componentDescription) {
+    /** @type {any[]} */
+    const componentDescriptionToc = [];
+    const render = createRender({
+      headingHashes: {},
+      toc: componentDescriptionToc,
+      userLanguage: 'en',
+      options: { env: { SOURCE_CODE_REPO: '' } },
+    });
+    translation.componentDescription = render(translation.componentDescription);
+    // Only attach the ToC when the description actually produced headings.
+    if (componentDescriptionToc.length > 0) {
+      translation.componentDescriptionToc = componentDescriptionToc;
+    }
+  }
+
+  return `export default ${JSON.stringify(translation)};`;
+}

--- a/packages-internal/markdown/package.json
+++ b/packages-internal/markdown/package.json
@@ -9,6 +9,7 @@
   "exports": {
     ".": "./index.mjs",
     "./loader": "./loader.mjs",
+    "./apiPageTranslationLoader": "./apiPageTranslationLoader.mjs",
     "./prism": {
       "types": "./prism.d.mts",
       "require": null,


### PR DESCRIPTION
Followup to - https://github.com/mui/material-ui/pull/48370

Render `componentDescription` markdown to HTML in the api-docs-builder and
emit it to the existing json files.

The API page html size decreases with the change with maximum reduction in autocomplete page (~7% gz / 4.5% raw).

Another approach is to use a loader that does the same transformation, but as part of the next.js build. This will avoid the need of updating json files but also increases build time.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
