### PR TITLE
Clarify docs console theme tip

### DIFF
--- a/packages-internal/core-docs/src/DocsApp/consoleBanner.ts
+++ b/packages-internal/core-docs/src/DocsApp/consoleBanner.ts
@@ -20,7 +20,7 @@ export function printConsoleBanner(): void {
 ██║ ╚═╝ ██║ ╚██████╔╝ ██████╗
 ╚═╝     ╚═╝  ╚═════╝  ╚═════╝
 
-Tip: you can access the documentation \`theme\` object directly in the console.
+Tip: you can access the documentation theme object as \`window.theme\` in the console.
 `,
       'font-family:monospace;color:#1976d2;font-size:12px;',
     );


### PR DESCRIPTION
Fixes #46580

## Summary
- Clarifies the docs console banner to reference `window.theme`, matching the global set by `printConsoleBanner`.

## Verification
- Not run; copy-only documentation change.