### PR TITLE
[docs-infra] Revert "Pin StackBlitz demo vite to v7 and plugin-react to v5"

### DIFF
--- a/packages-internal/core-docs/src/Demo/sandbox/StackBlitz.test.js
+++ b/packages-internal/core-docs/src/Demo/sandbox/StackBlitz.test.js
@@ -72,8 +72,8 @@ describe('StackBlitz', () => {
     "@emotion/styled": "latest"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^5",
-    "vite": "^7"
+    "@vitejs/plugin-react": "latest",
+    "vite": "latest"
   }
 }`,
         'src/Demo.jsx': `import * as React from 'react';
@@ -121,8 +121,8 @@ export default defineConfig({
         '@emotion/styled': 'latest',
       },
       devDependencies: {
-        '@vitejs/plugin-react': '^5',
-        vite: '^7',
+        '@vitejs/plugin-react': 'latest',
+        vite: 'latest',
       },
     });
   });
@@ -183,8 +183,8 @@ export default defineConfig({
     "typescript": "latest"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^5",
-    "vite": "^7",
+    "@vitejs/plugin-react": "latest",
+    "vite": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest"
   }
@@ -269,8 +269,8 @@ export default defineConfig({
       devDependencies: {
         '@types/react': 'latest',
         '@types/react-dom': 'latest',
-        '@vitejs/plugin-react': '^5',
-        vite: '^7',
+        '@vitejs/plugin-react': 'latest',
+        vite: 'latest',
       },
     });
   });

--- a/packages-internal/core-docs/src/Demo/sandbox/StackBlitz.ts
+++ b/packages-internal/core-docs/src/Demo/sandbox/StackBlitz.ts
@@ -20,10 +20,8 @@ function ensureExtension(file: string, extension: string): string {
 }
 
 const VITE_DEV_DEPENDENCIES = {
-  // Pinned to major versions instead of `latest` to work around
-  // https://github.com/stackblitz/webcontainer-core/issues/2104
-  '@vitejs/plugin-react': '^5',
-  vite: '^7',
+  '@vitejs/plugin-react': 'latest',
+  vite: 'latest',
 };
 
 function openStackBlitz({


### PR DESCRIPTION
Reverts mui/material-ui#48643

See https://github.com/stackblitz/webcontainer-core/issues/2104#issuecomment-4766334034