### PR TITLE
[skills] Fix invalid UTF-8 in skill reference files

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,4 +1,4 @@
-# Material UI agent skills
+# Material UI agent skills
 
 Packaged guidance for AI agents and humans. Each skill is a directory under `skills/` with this layout:
 

--- a/skills/material-ui-nextjs/AGENTS.md
+++ b/skills/material-ui-nextjs/AGENTS.md
@@ -1,14 +1,14 @@
-# Material UI and Next.js
+# Material UI and Next.js
 
 Version 1.0.0
 
-> Note: This document is for agents and LLMs integrating Material UI with Next.js. Source: `docs/data/material/integrations/nextjs/nextjs.md` and related integration docs in this repository.
+> Note: This document is for agents and LLMs integrating Material UI with Next.js. Source: `docs/data/material/integrations/nextjs/nextjs.md` and related integration docs in this repository.
 
 ---
 
 ## Abstract
 
-Material UI uses Emotion for styles. On Next.js you must wire an Emotion cache so SSR and streaming produce correct CSS (prefer injecting styles into `head` instead of only `body`). The `@mui/material-nextjs` package supplies `AppRouterCacheProvider` (App Router) and `AppCacheProvider` / `DocumentHeadTags` (Pages Router). Material UI components ship as client components (`"use client"`); they still SSR but are not React Server Components. Match the package import suffix (for example `v15-appRouter`) to your Next.js major version.
+Material UI uses Emotion for styles. On Next.js you must wire an Emotion cache so SSR and streaming produce correct CSS (prefer injecting styles into `head` instead of only `body`). The `@mui/material-nextjs` package supplies `AppRouterCacheProvider` (App Router) and `AppCacheProvider` / `DocumentHeadTags` (Pages Router). Material UI components ship as client components (`"use client"`); they still SSR but are not React Server Components. Match the package import suffix (for example `v15-appRouter`) to your Next.js major version.
 
 ---
 
@@ -43,7 +43,7 @@ In `app/layout.tsx`, wrap everything under `<body>` with `AppRouterCacheProvider
 
 (Use the `v1X-appRouter` path that matches your Next.js version if not on v15.)
 
-Why: it collects CSS from MUI System during server rendering and streaming so styles attach predictably; it is recommended so styles go to `<head>` instead of only `<body>`. See [Next.js integration—Configuration](https://mui.com/material-ui/integrations/nextjs.md#configuration).
+Why: it collects CSS from MUI System during server rendering and streaming so styles attach predictably; it is recommended so styles go to `<head>` instead of only `<body>`. See [Next.js integration—Configuration](https://mui.com/material-ui/integrations/nextjs.md#configuration).
 
 ### Optional cache `options`
 
@@ -108,7 +108,7 @@ Enable `cssVariables: true` in `createTheme` when using [CSS theme variables](ht
 
 ## Other styling stacks (CSS layers)
 
-If you combine MUI with Tailwind CSS, CSS Modules, or other global CSS, set `enableCssLayer: true` on `AppRouterCacheProvider`:
+If you combine MUI with Tailwind CSS, CSS Modules, or other global CSS, set `enableCssLayer: true` on `AppRouterCacheProvider`:
 
 `<AppRouterCacheProvider options={{ enableCssLayer: true }}>`
 

--- a/skills/material-ui-nextjs/README.md
+++ b/skills/material-ui-nextjs/README.md
@@ -1,6 +1,6 @@
-# Material UI + Next.js (agent skill)
+# Material UI + Next.js (agent skill)
 
-Integration guide for Material UI with the Next.js App Router and Pages Router: Emotion cache via `@mui/material-nextjs`, `ThemeProvider`, `next/font`, CSS layers with other tools, and `Link` usage.
+Integration guide for Material UI with the Next.js App Router and Pages Router: Emotion cache via `@mui/material-nextjs`, `ThemeProvider`, `next/font`, CSS layers with other tools, and `Link` usage.
 
 ## Files in this folder
 

--- a/skills/material-ui-nextjs/SKILL.md
+++ b/skills/material-ui-nextjs/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: material-ui-nextjs
-description: Integrates Material UI with Next.js App and Pages routers using @mui/material-nextjs, Emotion cache providers, next/font, CSS layers with Tailwind/CSS Modules, Link component prop patterns, CSS theme variables SSR notes, and App Router useSearchParams + Suspense. Use when setting up or debugging MUI in a Next.js app.
+description: Integrates Material UI with Next.js App and Pages routers using @mui/material-nextjs, Emotion cache providers, next/font, CSS layers with Tailwind/CSS Modules, Link component prop patterns, CSS theme variables SSR notes, and App Router useSearchParams + Suspense. Use when setting up or debugging MUI in a Next.js app.
 license: MIT
 metadata:
   author: mui
   version: '1.0.0'
 ---
 
-# Material UI and Next.js
+# Material UI and Next.js
 
-Agent skill for Next.js + Material UI wiring (SSR/streaming, cache providers, fonts, layers, Link, App Router URL state). SKILL.md is the entry; AGENTS.md is the full guide.
+Agent skill for Next.js + Material UI wiring (SSR/streaming, cache providers, fonts, layers, Link, App Router URL state). SKILL.md is the entry; AGENTS.md is the full guide.
 
 ## When to apply
 
 - New App Router or Pages Router app using `@mui/material`
 - Styles missing, wrong order, or in `body` instead of `head`
 - `next/font` + `ThemeProvider` / `createTheme`
-- Tailwind or CSS Modules + MUI (`enableCssLayer`)
+- Tailwind or CSS Modules + MUI (`enableCssLayer`)
 - `Button` + `component={Link}` or Next.js v16 client boundary errors
 - `useSearchParams` / URL-driven MUI views and Suspense boundaries
 

--- a/skills/material-ui-nextjs/metadata.json
+++ b/skills/material-ui-nextjs/metadata.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "organization": "Material UI",
-  "abstract": "Documents Next.js integration for Material UI: AppRouterCacheProvider and Pages Router Document/App cache wiring, Emotion options, next/font with themes, CSS theme variables and SSR flicker pointers, enableCssLayer for Tailwind/CSS Modules, and Next.js Link client-wrapper patterns.",
+  "organization": "Material UI",
+  "abstract": "Documents Next.js integration for Material UI: AppRouterCacheProvider and Pages Router Document/App cache wiring, Emotion options, next/font with themes, CSS theme variables and SSR flicker pointers, enableCssLayer for Tailwind/CSS Modules, and Next.js Link client-wrapper patterns.",
   "references": [
     "https://mui.com/material-ui/integrations/nextjs.md",
     "https://mui.com/material-ui/integrations/routing.md",

--- a/skills/material-ui-nextjs/reference.md
+++ b/skills/material-ui-nextjs/reference.md
@@ -1,4 +1,4 @@
-# Material UI + Next.js: reference
+# Material UI + Next.js: reference
 
 ## `@mui/material-nextjs` entry points
 

--- a/skills/material-ui-styling/AGENTS.md
+++ b/skills/material-ui-styling/AGENTS.md
@@ -1,14 +1,14 @@
-# Material UI styling
+# Material UI styling
 
 Version 1.0.0
 
-> Note: This document is for agents and LLMs maintaining or generating Material UI code. It follows [How to customize](https://mui.com/material-ui/customization/how-to-customize.md) and related sources in this repository (`docs/data/material/customization/`, `docs/data/system/`).
+> Note: This document is for agents and LLMs maintaining or generating Material UI code. It follows [How to customize](https://mui.com/material-ui/customization/how-to-customize.md) and related sources in this repository (`docs/data/material/customization/`, `docs/data/system/`).
 
 ---
 
 ## Abstract
 
-Material UI stacks four strategies from narrowest to broadest scope. Pick the smallest scope that solves the problem to avoid scattering global rules. The `sx` prop is the default for one-off tweaks; `styled()` is for reusable wrappers; the theme's `components` API is for app-wide consistency; `GlobalStyles` / `CssBaseline` is for baseline HTML or cross-cutting globals.
+Material UI stacks four strategies from narrowest to broadest scope. Pick the smallest scope that solves the problem to avoid scattering global rules. The `sx` prop is the default for one-off tweaks; `styled()` is for reusable wrappers; the theme's `components` API is for app-wide consistency; `GlobalStyles` / `CssBaseline` is for baseline HTML or cross-cutting globals.
 
 ---
 
@@ -40,7 +40,7 @@ Do not jump to global theme overrides for a one-off screen; do not use `sx` for 
 
 Use when: changing one instance (or a small inline case) with access to the theme.
 
-- All Material UI components support `sx`.
+- All Material UI components support `sx`.
 - Supports theme shortcuts (`palette`, `spacing`, breakpoints, etc.), pseudo-selectors, nested selectors, and responsive objects.
 - Array syntax: `sx={[base, condition && extra]}` merges styles conditionally — entries applied in order, falsy entries skipped. Prefer this over object spread for conditional `sx`.
 
@@ -74,7 +74,7 @@ Use when: the same customized component appears in multiple places and deserves 
 import { styled } from '@mui/material/styles';
 ```
 
-- Prefer `@mui/material/styles` when using Material UI so the default theme matches the rest of the app.
+- Prefer `@mui/material/styles` when using Material UI so the default theme matches the rest of the app.
 - `styled()` adds theme integration, optional `name` / `slot` for theme overrides, and `sx` on the result (unless disabled).
 - For custom props, use `shouldForwardProp` so DOM/React does not receive invalid attributes. Extend the component's prop types in TypeScript.
 

--- a/skills/material-ui-styling/README.md
+++ b/skills/material-ui-styling/README.md
@@ -1,6 +1,6 @@
-# Material UI styling (agent skill)
+# Material UI styling (agent skill)
 
-Material UI-specific guidance for which styling mechanism to use (`sx`, `styled()`, theme overrides, global CSS), aligned with the official docs in this monorepo.
+Material UI-specific guidance for which styling mechanism to use (`sx`, `styled()`, theme overrides, global CSS), aligned with the official docs in this monorepo.
 
 ## Files in this folder
 

--- a/skills/material-ui-styling/SKILL.md
+++ b/skills/material-ui-styling/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: material-ui-styling
-description: Chooses the right Material UI styling approach (sx, styled, theme overrides, global CSS) from official MUI guidance. Use when styling @mui/material components, customizing themes, overriding slots, or comparing sx vs styled.
+description: Chooses the right Material UI styling approach (sx, styled, theme overrides, global CSS) from official MUI guidance. Use when styling @mui/material components, customizing themes, overriding slots, or comparing sx vs styled.
 license: MIT
 metadata:
   author: mui
   version: '1.0.0'
 ---
 
-# Material UI styling
+# Material UI styling
 
-Agent skill for picking the correct styling layer in Material UI (narrowest scope first). SKILL.md is the entry and index; AGENTS.md is the full guide.
+Agent skill for picking the correct styling layer in Material UI (narrowest scope first). SKILL.md is the entry and index; AGENTS.md is the full guide.
 
 ## When to apply
 

--- a/skills/material-ui-styling/metadata.json
+++ b/skills/material-ui-styling/metadata.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "organization": "Material UI",
-  "abstract": "Guides selection of Material UI styling strategies from narrowest to broadest scope (sx, styled, theme.components, GlobalStyles/CssBaseline), including slot/state overrides and sx vs styled foot-guns.",
+  "organization": "Material UI",
+  "abstract": "Guides selection of Material UI styling strategies from narrowest to broadest scope (sx, styled, theme.components, GlobalStyles/CssBaseline), including slot/state overrides and sx vs styled foot-guns.",
   "references": [
     "https://mui.com/material-ui/customization/how-to-customize.md",
     "https://mui.com/system/getting-started/the-sx-prop.md",

--- a/skills/material-ui-styling/reference.md
+++ b/skills/material-ui-styling/reference.md
@@ -1,4 +1,4 @@
-# Material UI styling: reference tables
+# Material UI styling: reference tables
 
 ## Global state class names
 

--- a/skills/material-ui-tailwind/AGENTS.md
+++ b/skills/material-ui-tailwind/AGENTS.md
@@ -1,39 +1,39 @@
-# Material UI and Tailwind CSS
+# Material UI and Tailwind CSS
 
 Version 1.0.0
 
-> Note: For agents and LLMs combining Material UI with Tailwind CSS. Primary source for v4: `docs/data/material/integrations/tailwindcss/tailwindcss-v4.md`. v3: `docs/data/material/integrations/interoperability/interoperability.md` (Tailwind CSS v3).
+> Note: For agents and LLMs combining Material UI with Tailwind CSS. Primary source for v4: `docs/data/material/integrations/tailwindcss/tailwindcss-v4.md`. v3: `docs/data/material/integrations/interoperability/interoperability.md` (Tailwind CSS v3).
 
 ---
 
 ## Abstract
 
-Tailwind CSS v4 integration with Material UI is built on CSS cascade layers: MUI emits styles inside `@layer mui`, and Tailwind's `utilities` layer must come after so utilities can override without `!important`. Enable MUI's layer mode with `enableCssLayer: true` (Next.js via `AppRouterCacheProvider` / shared `createEmotionCache`) or `StyledEngineProvider` with `enableCssLayer` (Vite and other SPAs). Declare layer order (for example `@layer theme, base, mui, components, utilities`) before `@import 'tailwindcss'` (or inject the same string with `GlobalStyles` where the docs show). Tailwind CSS v3 uses a different recipe (preflight off, `important`, `StyledEngineProvider` with `injectFirst`, portal `container`). Prefer v4 for new work when possible.
+Tailwind CSS v4 integration with Material UI is built on CSS cascade layers: MUI emits styles inside `@layer mui`, and Tailwind's `utilities` layer must come after so utilities can override without `!important`. Enable MUI's layer mode with `enableCssLayer: true` (Next.js via `AppRouterCacheProvider` / shared `createEmotionCache`) or `StyledEngineProvider` with `enableCssLayer` (Vite and other SPAs). Declare layer order (for example `@layer theme, base, mui, components, utilities`) before `@import 'tailwindcss'` (or inject the same string with `GlobalStyles` where the docs show). Tailwind CSS v3 uses a different recipe (preflight off, `important`, `StyledEngineProvider` with `injectFirst`, portal `container`). Prefer v4 for new work when possible.
 
 ---
 
 ## Table of contents
 
-1. [Tailwind CSS v4 (preferred)](#tailwind-css-v4-preferred)
+1. [Tailwind CSS v4 (preferred)](#tailwind-css-v4-preferred)
 2. [Next.js specifics](#nextjs-specifics)
 3. [Vite and other SPAs](#vite-and-other-spas)
 4. [Applying utilities to MUI components](#applying-utilities-to-mui-components)
 5. [Theme tokens in Tailwind (`@theme`)](#theme-tokens-in-tailwind-theme)
-6. [VS Code IntelliSense](#vs-code-intellisense)
-7. [Tailwind CSS v3 (legacy)](#tailwind-css-v3-legacy)
+6. [VS Code IntelliSense](#vs-code-intellisense)
+7. [Tailwind CSS v3 (legacy)](#tailwind-css-v3-legacy)
 8. [Troubleshooting](#troubleshooting)
 9. [Further reading](#further-reading)
 
 ---
 
-## Tailwind CSS v4 (preferred)
+## Tailwind CSS v4 (preferred)
 
 ### Goals
 
 1. Generate Tailwind with the `@layer` directive.
 2. Order layers so `mui` comes before `utilities`, so Tailwind utilities override MUI predictably.
 
-See [Tailwind CSS v4 integration—Overview](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#overview).
+See [Tailwind CSS v4 integration—Overview](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#overview).
 
 ### Layer stack (typical)
 
@@ -52,7 +52,7 @@ Adjust file paths to your app (`src/app/global.css`, `styles/global.css`, etc.).
 
 1. Complete the [Next.js integration—App Router](https://mui.com/material-ui/integrations/nextjs.md#app-router) or [Next.js integration—Pages Router](https://mui.com/material-ui/integrations/nextjs.md#pages-router) setup first.
 2. App Router: `<AppRouterCacheProvider options={{ enableCssLayer: true }}>` in the root layout. `suppressHydrationWarning` on `<html>` appears in the doc example when relevant.
-3. Pages Router: shared `createEmotionCache({ enableCssLayer: true })` from `@mui/material-nextjs`, passed through `documentGetInitialProps`; `AppCacheProvider` uses the same cache; layer order via `GlobalStyles` as the first child inside `AppCacheProvider`. See [Tailwind CSS v4 integration—Next.js Pages Router](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#nextjs-pages-router).
+3. Pages Router: shared `createEmotionCache({ enableCssLayer: true })` from `@mui/material-nextjs`, passed through `documentGetInitialProps`; `AppCacheProvider` uses the same cache; layer order via `GlobalStyles` as the first child inside `AppCacheProvider`. See [Tailwind CSS v4 integration—Next.js Pages Router](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#nextjs-pages-router).
 
 For a concise provider checklist, see the material-ui-nextjs skill and [Next.js integration—Using other styling solutions](https://mui.com/material-ui/integrations/nextjs.md#using-other-styling-solutions).
 
@@ -63,7 +63,7 @@ For a concise provider checklist, see the material-ui-nextjs skill and [Next.js 
 1. `StyledEngineProvider` with `enableCssLayer`.
 2. `GlobalStyles` injecting `@layer theme, base, mui, components, utilities;` before the app tree.
 
-See [Tailwind CSS v4 integration—Vite.js or any other SPA](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#vitejs-or-any-other-spa).
+See [Tailwind CSS v4 integration—Vite.js or any other SPA](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#vitejs-or-any-other-spa).
 
 Example repo: [material-ui-vite-tailwind-ts](https://github.com/mui/material-ui/tree/master/examples/material-ui-vite-tailwind-ts).
 
@@ -74,7 +74,7 @@ Example repo: [material-ui-vite-tailwind-ts](https://github.com/mui/material-ui/
 - `className`: root element of the component.
 - `slotProps.{slot}.className`: interior [slots](https://mui.com/material-ui/customization/overriding-component-structure.md#interior-slots).
 
-See [Tailwind CSS v4 integration—Usage](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#usage).
+See [Tailwind CSS v4 integration—Usage](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#usage).
 
 ---
 
@@ -92,23 +92,23 @@ To reuse MUI theme variables as Tailwind tokens, map `--mui-*` CSS variables int
 }
 ```
 
-The full token list (palette, typography, breakpoints, shadows, …) is long and maintained on the doc page. Copy the complete `@theme inline { ... }` block from [Extend Material UI classes](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#extend-material-ui-classes) when you need it all.
+The full token list (palette, typography, breakpoints, shadows, …) is long and maintained on the doc page. Copy the complete `@theme inline { ... }` block from [Extend Material UI classes](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#extend-material-ui-classes) when you need it all.
 
-See [Tailwind CSS v4 integration—Extend Material UI classes](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#extend-material-ui-classes) and the linked [playground](https://play.tailwindcss.com/mh7Ym0mGff).
+See [Tailwind CSS v4 integration—Extend Material UI classes](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#extend-material-ui-classes) and the linked [playground](https://play.tailwindcss.com/mh7Ym0mGff).
 
 Requirement: MUI CSS theme variables (`cssVariables: true` in `createTheme`) so the `--mui-*` variables exist. Align with the material-ui-theming skill.
 
 ---
 
-## VS Code IntelliSense
+## VS Code IntelliSense
 
-For `slotProps` and similar, add `tailwindCSS.experimental.classRegex` in VS Code `settings.json` as in [Tailwind CSS v4 integration—Tailwind CSS IntelliSense for VS Code](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#tailwind-css-intellisense-for-vs-code).
+For `slotProps` and similar, add `tailwindCSS.experimental.classRegex` in VS Code `settings.json` as in [Tailwind CSS v4 integration—Tailwind CSS IntelliSense for VS Code](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#tailwind-css-intellisense-for-vs-code).
 
 Snippet also lives in [reference.md](reference.md).
 
 ---
 
-## Tailwind CSS v3 (legacy)
+## Tailwind CSS v3 (legacy)
 
 Use the interoperability guide, not the v4 page:
 
@@ -118,13 +118,13 @@ Use the interoperability guide, not the v4 page:
 4. `StyledEngineProvider` with `injectFirst` (or Emotion `prepend: true` cache) for injection order.
 5. Theme `defaultProps` `container` on `Modal`, `Dialog`, `Popover`, `Popper` to the same root as `important`.
 
-See [Interoperability—Tailwind CSS v3](https://mui.com/material-ui/integrations/interoperability.md#tailwind-css-v3) and [Interoperability—Troubleshooting](https://mui.com/material-ui/integrations/interoperability.md#troubleshooting) (table of root IDs).
+See [Interoperability—Tailwind CSS v3](https://mui.com/material-ui/integrations/interoperability.md#tailwind-css-v3) and [Interoperability—Troubleshooting](https://mui.com/material-ui/integrations/interoperability.md#troubleshooting) (table of root IDs).
 
 ---
 
 ## Troubleshooting
 
-v4: confirm Tailwind >= v4, layer order, and DevTools cascade layers (`mui` before `utilities`). See [Tailwind CSS v4 integration—Troubleshooting](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#troubleshooting).
+v4: confirm Tailwind >= v4, layer order, and DevTools cascade layers (`mui` before `utilities`). See [Tailwind CSS v4 integration—Troubleshooting](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#troubleshooting).
 
 v3: verify `important` selector matches root `id`, `preflight: false`, and `injectFirst`. See the interoperability Troubleshooting subsection linked above.
 
@@ -134,7 +134,7 @@ v3: verify `important` selector matches root `id`, `preflight: false`, and `inje
 
 | Topic                     | Link                                                                                                                                        |
 | :------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------ |
-| Tailwind CSS v4 + MUI     | [Tailwind CSS v4 integration](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md)                                       |
+| Tailwind CSS v4 + MUI     | [Tailwind CSS v4 integration](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md)                                       |
 | CSS layers (MUI concepts) | [CSS Layers](https://mui.com/material-ui/customization/css-layers.md)                                                                       |
 | Interior slots            | [Overriding component structure—Interior slots](https://mui.com/material-ui/customization/overriding-component-structure.md#interior-slots) |
-| Tailwind v3 + MUI         | [Interoperability—Tailwind CSS v3](https://mui.com/material-ui/integrations/interoperability.md#tailwind-css-v3)                            |
+| Tailwind v3 + MUI         | [Interoperability—Tailwind CSS v3](https://mui.com/material-ui/integrations/interoperability.md#tailwind-css-v3)                            |

--- a/skills/material-ui-tailwind/README.md
+++ b/skills/material-ui-tailwind/README.md
@@ -1,6 +1,6 @@
-# Material UI + Tailwind CSS (agent skill)
+# Material UI + Tailwind CSS (agent skill)
 
-Covers Tailwind CSS v4 with Material UI (cascade layers, `enableCssLayer`) and summarizes v3 patterns from the interoperability guide (preflight, `important`, `injectFirst`).
+Covers Tailwind CSS v4 with Material UI (cascade layers, `enableCssLayer`) and summarizes v3 patterns from the interoperability guide (preflight, `important`, `injectFirst`).
 
 ## Files in this folder
 

--- a/skills/material-ui-tailwind/SKILL.md
+++ b/skills/material-ui-tailwind/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: material-ui-tailwind
-description: Integrates Material UI with Tailwind CSS v4 using cascade layers (enableCssLayer, @layer order) and documents Tailwind v3 interoperability (preflight, important, injectFirst, portals). Use when combining MUI with Tailwind utilities, slotProps className, or theme token bridges.
+description: Integrates Material UI with Tailwind CSS v4 using cascade layers (enableCssLayer, @layer order) and documents Tailwind v3 interoperability (preflight, important, injectFirst, portals). Use when combining MUI with Tailwind utilities, slotProps className, or theme token bridges.
 license: MIT
 metadata:
   author: mui
   version: '1.0.0'
 ---
 
-# Material UI and Tailwind CSS
+# Material UI and Tailwind CSS
 
 Agent skill for MUI + Tailwind. SKILL.md is the entry; AGENTS.md is the full guide.
 
@@ -28,7 +28,7 @@ Agent skill for MUI + Tailwind. SKILL.md is the entry; AGENTS.md is the full gui
 | SPA          | `StyledEngineProvider` + `enableCssLayer`             |
 | Usage        | Root vs slot `className`                              |
 | `@theme`     | Full snippet on docs site; needs `cssVariables`       |
-| IntelliSense | VS Code `classRegex`                                  |
+| IntelliSense | VS Code `classRegex`                                  |
 | v3           | preflight, `important`, `injectFirst`, portals        |
 
 ## Full guide

--- a/skills/material-ui-tailwind/metadata.json
+++ b/skills/material-ui-tailwind/metadata.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "organization": "Material UI",
-  "abstract": "Tailwind CSS v4 with Material UI via @layer ordering and enableCssLayer; Next.js App/Pages and Vite setup; className and slotProps; @theme token bridge from --mui-* variables; VS Code IntelliSense; Tailwind v3 legacy path via interoperability guide.",
+  "organization": "Material UI",
+  "abstract": "Tailwind CSS v4 with Material UI via @layer ordering and enableCssLayer; Next.js App/Pages and Vite setup; className and slotProps; @theme token bridge from --mui-* variables; VS Code IntelliSense; Tailwind v3 legacy path via interoperability guide.",
   "references": [
     "https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md",
     "https://mui.com/material-ui/integrations/interoperability.md#tailwind-css-v3",

--- a/skills/material-ui-tailwind/reference.md
+++ b/skills/material-ui-tailwind/reference.md
@@ -1,4 +1,4 @@
-# Material UI + Tailwind CSS: reference
+# Material UI + Tailwind CSS: reference
 
 ## Layer order (v4)
 
@@ -13,7 +13,7 @@ Pages Router + GlobalStyles (first child of `AppCacheProvider`):
 <GlobalStyles styles="@layer theme, base, mui, components, utilities;" />
 ```
 
-## VS Code `settings.json` (IntelliSense for `slotProps`)
+## VS Code `settings.json` (IntelliSense for `slotProps`)
 
 ```json
 {
@@ -21,7 +21,7 @@ Pages Router + GlobalStyles (first child of `AppCacheProvider`):
 }
 ```
 
-From [Tailwind CSS v4 integrationâ€”Tailwind CSS IntelliSense for VS Code](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#tailwind-css-intellisense-for-vs-code).
+From [Tailwind CSS v4 integrationâ€”Tailwind CSS IntelliSense for VS Code](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#tailwind-css-intellisense-for-vs-code).
 
 ## v3 `tailwind.config.js` sketch
 
@@ -35,7 +35,7 @@ module.exports = {
 };
 ```
 
-See [Interoperabilityâ€”Tailwind CSS v3](https://mui.com/material-ui/integrations/interoperability.md#tailwind-css-v3).
+See [Interoperabilityâ€”Tailwind CSS v3](https://mui.com/material-ui/integrations/interoperability.md#tailwind-css-v3).
 
 ## Related skills
 

--- a/skills/material-ui-theming/AGENTS.md
+++ b/skills/material-ui-theming/AGENTS.md
@@ -1,14 +1,14 @@
-# Material UI theming and design tokens
+# Material UI theming and design tokens
 
 Version 1.0.0
 
-> Note: This document is for agents and LLMs implementing themes and design tokens with Material UI. Grounded in `docs/data/material/customization/` (theming, palette, dark-mode, css-theme-variables, typography, spacing, shape).
+> Note: This document is for agents and LLMs implementing themes and design tokens with Material UI. Grounded in `docs/data/material/customization/` (theming, palette, dark-mode, css-theme-variables, typography, spacing, shape).
 
 ---
 
 ## Abstract
 
-A Material UI theme is a single object of design tokens (palette, typography, spacing, shape, breakpoints, etc.) plus optional per-component defaults (`theme.components`). Apps typically call `createTheme` once (or in composed steps), pass the result to `ThemeProvider` near the root, and read values with `useTheme`, `sx`, or `styled`. For system-driven light/dark, prefer `colorSchemes` and related APIs over a static `palette.mode`-only setup when you need toggling, tab sync, and SSR-friendly behavior; enable `cssVariables` when you want `theme.vars`, fewer theme nests for dark regions, and clearer debugging via `--mui-*` CSS variables.
+A Material UI theme is a single object of design tokens (palette, typography, spacing, shape, breakpoints, etc.) plus optional per-component defaults (`theme.components`). Apps typically call `createTheme` once (or in composed steps), pass the result to `ThemeProvider` near the root, and read values with `useTheme`, `sx`, or `styled`. For system-driven light/dark, prefer `colorSchemes` and related APIs over a static `palette.mode`-only setup when you need toggling, tab sync, and SSR-friendly behavior; enable `cssVariables` when you want `theme.vars`, fewer theme nests for dark regions, and clearer debugging via `--mui-*` CSS variables.
 
 ---
 
@@ -29,7 +29,7 @@ A Material UI theme is a single object of design tokens (palette, typography, s
 
 ## Core setup
 
-1. `import { createTheme, ThemeProvider } from '@mui/material/styles'` (Material UI default theme).
+1. `import { createTheme, ThemeProvider } from '@mui/material/styles'` (Material UI default theme).
 2. Build a theme with `createTheme({ ... })`; wrap the app in `<ThemeProvider theme={theme}>` so descendants receive context.
 3. Use `<CssBaseline />` inside the provider when you want baseline element styles and correct dark background behavior (see [Dark mode](https://mui.com/material-ui/customization/dark-mode.md)).
 

--- a/skills/material-ui-theming/README.md
+++ b/skills/material-ui-theming/README.md
@@ -1,6 +1,6 @@
-# Material UI theming (agent skill)
+# Material UI theming (agent skill)
 
-Theming and design tokens for Material UI: `createTheme`, `ThemeProvider`, palette, typography, spacing, `colorSchemes`, `cssVariables` / `theme.vars`, and TypeScript customization.
+Theming and design tokens for Material UI: `createTheme`, `ThemeProvider`, palette, typography, spacing, `colorSchemes`, `cssVariables` / `theme.vars`, and TypeScript customization.
 
 ## Files in this folder
 

--- a/skills/material-ui-theming/SKILL.md
+++ b/skills/material-ui-theming/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: material-ui-theming
-description: Guides Material UI theming and design tokens (createTheme, ThemeProvider, palette, colorSchemes, cssVariables, theme.vars, dark mode, TypeScript augmentation). Use when building or extending a theme, toggling light/dark, or aligning tokens across an app.
+description: Guides Material UI theming and design tokens (createTheme, ThemeProvider, palette, colorSchemes, cssVariables, theme.vars, dark mode, TypeScript augmentation). Use when building or extending a theme, toggling light/dark, or aligning tokens across an app.
 license: MIT
 metadata:
   author: mui
   version: '1.0.0'
 ---
 
-# Material UI theming and design tokens
+# Material UI theming and design tokens
 
 Agent skill for theme creation, design tokens, light/dark, and CSS theme variables. SKILL.md is the entry; AGENTS.md is the full guide.
 

--- a/skills/material-ui-theming/metadata.json
+++ b/skills/material-ui-theming/metadata.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "organization": "Material UI",
-  "abstract": "Covers Material UI theme objects and design tokens: createTheme, ThemeProvider, palette and colorSchemes, cssVariables and theme.vars, dark mode toggling and SSR, typography/spacing, theme composition, and TypeScript augmentation.",
+  "organization": "Material UI",
+  "abstract": "Covers Material UI theme objects and design tokens: createTheme, ThemeProvider, palette and colorSchemes, cssVariables and theme.vars, dark mode toggling and SSR, typography/spacing, theme composition, and TypeScript augmentation.",
   "references": [
     "https://mui.com/material-ui/customization/theming.md",
     "https://mui.com/material-ui/customization/palette.md",

--- a/skills/material-ui-theming/reference.md
+++ b/skills/material-ui-theming/reference.md
@@ -1,4 +1,4 @@
-# Material UI theming: reference snippets
+# Material UI theming: reference snippets
 
 ## Custom theme property (TypeScript)
 


### PR DESCRIPTION
closes #48677

## Problem

The skill files under `skills/` contained **non-breaking spaces** inside brand names ("Material UI", "Tailwind CSS", "VS Code", "CSS Modules", "MUI System"), in two forms:

- **Lone `0xA0` bytes** (Latin-1 NBSP) in the four `reference.md` files — genuinely **invalid UTF-8** (decoded to `U+FFFD`). These are the errors reported by skills.sh.
- **Valid `0xC2 0xA0` UTF-8 NBSP** scattered through every other skill file (`AGENTS.md`, `SKILL.md`, `README.md`, `metadata.json`) — valid encoding but still hidden characters that a prompt-injection scanner flags.

## Fix

Replaced **all** non-breaking spaces with regular ASCII spaces across the `skills/` tree (21 files). Every occurrence was a plain word-separator, so no meaning is lost.

## Verification

- All skill files now decode as valid UTF-8 with zero `0xA0` bytes.
- `metadata.json` files still parse as valid JSON.
- Diff is purely NBSP→space; no content changes.