### PR TITLE
[core] Bump react-router to 7.15.1

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -85,7 +85,7 @@
     "react-intersection-observer": "^10.0.3",
     "react-is": "^19.2.6",
     "react-number-format": "^5.4.5",
-    "react-router": "^7.15.0",
+    "react-router": "^7.15.1",
     "react-runner": "^1.0.5",
     "react-simple-code-editor": "^0.14.1",
     "react-swipeable-views": "^0.14.1",

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -58,7 +58,7 @@
     "fast-glob": "3.3.3",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "react-router": "7.15.0",
+    "react-router": "7.15.1",
     "sinon": "22.0.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,8 +450,8 @@ importers:
         specifier: ^5.4.5
         version: 5.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-router:
-        specifier: ^7.15.0
-        version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^7.15.1
+        version: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-runner:
         specifier: ^1.0.5
         version: 1.0.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1191,8 +1191,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
       react-router:
-        specifier: 7.15.0
-        version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 7.15.1
+        version: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       sinon:
         specifier: 22.0.0
         version: 22.0.0
@@ -1595,8 +1595,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-router:
-        specifier: 7.15.0
-        version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 7.15.1
+        version: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-window:
         specifier: 2.2.7
         version: 2.2.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -10040,8 +10040,8 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-router@7.15.0:
-    resolution: {integrity: sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==}
+  react-router@7.15.1:
+    resolution: {integrity: sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -21130,7 +21130,7 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-router@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-router@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       cookie: 1.1.1
       react: 19.2.6

--- a/test/package.json
+++ b/test/package.json
@@ -28,7 +28,7 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-is": "19.2.6",
-    "react-router": "7.15.0",
+    "react-router": "7.15.1",
     "react-window": "2.2.7",
     "sinon": "22.0.0",
     "styled-components": "6.4.1",


### PR DESCRIPTION
Bumps `react-router` to `7.15.1` in `mui-material`, `test`, and `docs` to resolve the React Router CSRF advisory (affects `>=7.12.0 <7.15.1`) flagged by Dependabot.

This is the only currently-open advisory that can be fixed with a plain direct-dependency bump. The remaining Dependabot alerts are all on transitive **dev/build/docs-only** tooling — `form-data`/`tmp` (via nx), `tar`/`js-yaml` (via lerna), `esbuild` (vite still pins `^0.27`), `@babel/runtime@7.0.0` (deprecated react-swipeable-views), `piscina`, `@babel/core`. None ship in the published `@mui/*` packages, and none can be moved without pnpm `overrides` (parents are already at their latest, and `nx@23` is blocked by `minimumReleaseAge`). Leaving those for a later natural update rather than pinning via overrides.