### PR TITLE
[mui-system] replace untyped any in StorageManager interface with concrete string types

### DIFF
--- a/packages/mui-system/src/cssVars/localStorageManager.ts
+++ b/packages/mui-system/src/cssVars/localStorageManager.ts
@@ -5,13 +5,13 @@ export interface StorageManager {
      * @param defaultValue The default value to be returned if the key is not found
      * @returns The value from the storage or the default value
      */
-    get(defaultValue: any): any;
+    get(defaultValue: string): string | null;
     /**
      * Function to set the value in the storage
      * @param value The value to be set
      * @returns void
      */
-    set(value: any): void;
+    set(value: string): void;
     /**
      * Function to subscribe to the value of the specified key triggered by external events
      * @param handler The function to be called when the value changes
@@ -24,7 +24,7 @@ export interface StorageManager {
      *  return unsubscribe;
      * }, []);
      */
-    subscribe(handler: (value: any) => void): () => void;
+    subscribe(handler: (value: string | null) => void): () => void;
   };
 }
 


### PR DESCRIPTION
StorageManager interface in packages/mui-system/src/cssVars/localStorageManager.ts typed every method parameter and return value as `any`. The manager operates on localStorage / sessionStorage / cookie values, which are always strings. `get()` returns the stored value or null; `set()` takes a string. Replacing `any` with `string`, `string | null`, and `(value: string | null) => void` lets the TypeScript compiler catch incorrect callers (e.g. a caller trying to store an object via set()) instead of allowing them to silently slip through to localStorage.setItem (which would coerce the value to `[object Object]`, lose data, and produce a non-deserializable string on the next read).