### PR TITLE
fix(Alert): add high contrast mode border via enhanceHighContrast

### DIFF
--- a/packages/mui-material/src/styles/enhanceHighContrast.ts
+++ b/packages/mui-material/src/styles/enhanceHighContrast.ts
@@ -1,3 +1,4 @@
+import alertClasses from '../Alert/alertClasses';
 import accordionSummaryClasses from '../AccordionSummary/accordionSummaryClasses';
 import autocompleteClasses from '../Autocomplete/autocompleteClasses';
 import checkboxClasses from '../Checkbox/checkboxClasses';
@@ -115,6 +116,30 @@ export default function enhanceHighContrast<
   const c = theme.components;
   theme.components = {
     ...c,
+    MuiAlert: {
+      ...c?.MuiAlert,
+      styleOverrides: {
+        ...c?.MuiAlert?.styleOverrides,
+        root: [
+          c?.MuiAlert?.styleOverrides?.root,
+          {
+            // All variants lack a visible border in HCM — add one so the
+            // alert region is distinguishable from the surrounding canvas.
+            [HCM]: {
+              outline: `1px solid ${hcTokens.buttonBorder}`,
+            },
+            // The filled variant uses background colour to convey severity;
+            // in HCM backgrounds are overridden, so restore contrast via border.
+            [`&.${alertClasses.filled}`]: {
+              [HCM]: {
+                forcedColorAdjust: 'none',
+                outline: `2px solid ${hcTokens.buttonBorder}`,
+              },
+            },
+          },
+        ],
+      },
+    },
     MuiAccordionSummary: {
       ...c?.MuiAccordionSummary,
       styleOverrides: {

--- a/packages/mui-material/src/styles/enhanceHighContrast.ts
+++ b/packages/mui-material/src/styles/enhanceHighContrast.ts
@@ -129,11 +129,14 @@ export default function enhanceHighContrast<
               outline: `1px solid ${hcTokens.buttonBorder}`,
             },
             // The filled variant uses background colour to convey severity;
-            // in HCM backgrounds are overridden, so restore contrast via border.
+            // in HCM backgrounds are overridden by the OS, so explicitly set
+            // foreground/background using system color tokens to preserve contrast.
             [`&.${alertClasses.filled}`]: {
               [HCM]: {
                 forcedColorAdjust: 'none',
                 outline: `2px solid ${hcTokens.buttonBorder}`,
+                color: hcTokens.buttonText,
+                backgroundColor: hcTokens.activeBackground,
               },
             },
           },


### PR DESCRIPTION
Part of #48681 (partial — Alert component)
What's changed
Added MuiAlert to enhanceHighContrast.ts so that Alert components get a visible border when Windows High Contrast Mode is active.

All variants (standard, outlined) get a 1px solid ButtonBorder outline
The filled variant gets a 2px solid ButtonBorder outline with forcedColorAdjust: none to preserve the extra visual weight, since filled alerts rely on background color to convey severity — which HCM overrides

Why
In HCM, background colors and box shadows are stripped by the OS, making Alert components invisible against the canvas. Adding a border restores the visual boundary so users can tell an alert region is present.
Testing
To verify, enable Windows High Contrast Mode (Settings → Accessibility → Contrast themes) and check the [MUI Alert demo](https://mui.com/material-ui/react-autocomplete/) in a browser with prefers-contrast: forced or forced-colors: active.
Notes
This only addresses Alert. Other components mentioned in #48681 (Tabs, Paper, Button) are left for follow-up PRs to keep changes reviewable.