### PR TITLE
docs: Remove mui v8 entry from versions.json

### DIFF
--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,7 +1,6 @@
 {
   "versions": [
     { "version": "v9", "url": "https://mui.com" },
-    { "version": "v8", "url": "https://v8.mui.com", "noReleaseNotes": true },
     { "version": "v7", "url": "https://v7.mui.com" },
     { "version": "v6", "url": "https://v6.mui.com" },
     { "version": "v5", "url": "https://v5.mui.com" },


### PR DESCRIPTION
There is no v8 of mui (similar to v2), remove this entry to prevent confusion

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
