### PR TITLE
[docs] Fix invalid UTF-8 in skill references

### DIFF
--- a/skills/material-ui-nextjs/reference.md
+++ b/skills/material-ui-nextjs/reference.md
@@ -1,4 +1,4 @@
-# Material UI + Next.js: reference
+# MaterialÂ UI + Next.js: reference
 
 ## `@mui/material-nextjs` entry points
 

--- a/skills/material-ui-styling/reference.md
+++ b/skills/material-ui-styling/reference.md
@@ -1,4 +1,4 @@
-# Material UI styling: reference tables
+# MaterialÂ UI styling: reference tables
 
 ## Global state class names
 

--- a/skills/material-ui-tailwind/reference.md
+++ b/skills/material-ui-tailwind/reference.md
@@ -1,4 +1,4 @@
-# Material UI + Tailwind CSS: reference
+# MaterialÂ UI + TailwindÂ CSS: reference
 
 ## Layer order (v4)
 
@@ -13,7 +13,7 @@ Pages Router + GlobalStyles (first child of `AppCacheProvider`):
 <GlobalStyles styles="@layer theme, base, mui, components, utilities;" />
 ```
 
-## VS Code `settings.json` (IntelliSense for `slotProps`)
+## VSÂ Code `settings.json` (IntelliSense for `slotProps`)
 
 ```json
 {
@@ -21,7 +21,7 @@ Pages Router + GlobalStyles (first child of `AppCacheProvider`):
 }
 ```
 
-From [Tailwind CSS v4 integrationâ€”Tailwind CSS IntelliSense for VS Code](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#tailwind-css-intellisense-for-vs-code).
+From [TailwindÂ CSS v4 integrationâ€”TailwindÂ CSS IntelliSense for VSÂ Code](https://mui.com/material-ui/integrations/tailwindcss/tailwindcss-v4.md#tailwind-css-intellisense-for-vs-code).
 
 ## v3 `tailwind.config.js` sketch
 
@@ -35,7 +35,7 @@ module.exports = {
 };
 ```
 
-See [Interoperabilityâ€”Tailwind CSS v3](https://mui.com/material-ui/integrations/interoperability.md#tailwind-css-v3).
+See [Interoperabilityâ€”TailwindÂ CSS v3](https://mui.com/material-ui/integrations/interoperability.md#tailwind-css-v3).
 
 ## Related skills
 

--- a/skills/material-ui-theming/reference.md
+++ b/skills/material-ui-theming/reference.md
@@ -1,4 +1,4 @@
-# Material UI theming: reference snippets
+# MaterialÂ UI theming: reference snippets
 
 ## Custom theme property (TypeScript)
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Summary

- Replace committed replacement characters in skill reference headings and links with the intended non-breaking spaces.
- Keep the existing Material UI, Tailwind CSS, and VS Code naming style intact.

## Validation

- `rg -n "�" skills/material-ui-nextjs/reference.md skills/material-ui-styling/reference.md skills/material-ui-tailwind/reference.md skills/material-ui-theming/reference.md` returned no matches.
- `git diff --check` passed.
- `pnpm code-infra vale --vale-version $(node -p "require('./package.json').config.valeVersion") --filter='.Level=="error"' skills/material-ui-nextjs/reference.md skills/material-ui-styling/reference.md skills/material-ui-tailwind/reference.md skills/material-ui-theming/reference.md` reported 0 errors, 0 warnings, and 0 suggestions.

Fixes #48677