### PR TITLE
[l10n] Add missing MuiPagination localization to zh-CN locale

### DIFF
--- a/packages/mui-material/src/locale/zhCN.ts
+++ b/packages/mui-material/src/locale/zhCN.ts
@@ -49,5 +49,26 @@ export const zhCN: Localization = {
         closeText: '关闭',
       },
     },
+    MuiPagination: {
+      defaultProps: {
+        'aria-label': '分页导航',
+        getItemAriaLabel: (type, page, selected) => {
+          if (type === 'page') {
+            return `${selected ? '' : '转到'}第 ${page} 页`;
+          }
+          if (type === 'first') {
+            return '转到第一页';
+          }
+          if (type === 'last') {
+            return '转到最后一页';
+          }
+          if (type === 'next') {
+            return '转到下一页';
+          }
+          // if (type === 'previous')
+          return '转到上一页';
+        },
+      },
+    },
   },
 };


### PR DESCRIPTION
The `zh-CN` locale is missing the `MuiPagination` block, so its pagination `aria-label` and the `getItemAriaLabel` text fall back to English even though every other component in the file is localized.

`MuiPagination` (`aria-label` plus `getItemAriaLabel`) is part of the canonical localizable set documented in `enUS.ts`, and almost every locale file already provides it. The only ones that don't are the three Chinese locales (`zh-CN`, `zh-HK`, `zh-TW`); for comparison `ja-JP` and `ko-KR` both localize this block already. So this looks like a copy-paste gap rather than an intentional omission.

This PR fills it in for `zh-CN`. For the first/last/next/previous and page wording I reused the noun phrases already present in this file's `MuiTablePagination.getItemAriaLabel` (第一页 / 最后一页 / 下一页 / 上一页) and added 转到 ("Go to") so it matches the English source, which marks every navigable item with "Go to" and leaves the current page unmarked.

Note: the same block is also absent from `zh-HK` and `zh-TW`. I left those out here since the Traditional Chinese wording differs and I would rather not guess at it. Happy to follow up if you want them covered too.
