### PR TITLE
[Select] Guard display ref during mouse down

### DIFF
--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -142,11 +142,7 @@ describe('<Select />', () => {
       const handleMouseDown = spy();
 
       render(
-        <Select
-          value="one"
-          onMouseDown={handleMouseDown}
-          SelectDisplayProps={{ ref: () => {} }}
-        >
+        <Select value="one" onMouseDown={handleMouseDown} SelectDisplayProps={{ ref: () => {} }}>
           <MenuItem value="one">One</MenuItem>
           <MenuItem value="two">Two</MenuItem>
         </Select>,

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -138,6 +138,28 @@ describe('<Select />', () => {
       expect(screen.queryByRole('listbox', { hidden: false })).to.equal(null);
     });
 
+    it('does not throw when the display ref is unavailable during mouse down', () => {
+      const handleMouseDown = spy();
+
+      render(
+        <Select
+          value="one"
+          onMouseDown={handleMouseDown}
+          SelectDisplayProps={{ ref: () => {} }}
+        >
+          <MenuItem value="one">One</MenuItem>
+          <MenuItem value="two">Two</MenuItem>
+        </Select>,
+      );
+
+      expect(() => {
+        fireEvent.mouseDown(screen.getByRole('combobox'));
+      }).not.to.throw();
+
+      expect(handleMouseDown.callCount).to.equal(1);
+      expect(screen.queryByRole('listbox')).to.equal(null);
+    });
+
     it('keeps the menu open when releasing the opening mouse gesture inside the trigger bounds', async () => {
       const { user } = render(
         <Select

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -403,6 +403,11 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     }
     // Hijack the default focus behavior.
     event.preventDefault();
+
+    if (!displayRef.current) {
+      return;
+    }
+
     displayRef.current.focus();
 
     const doc = ownerDocument(event.currentTarget);


### PR DESCRIPTION
Prevents crashes when the display node is transiently detached during pointer interaction.

- Adds a `null` guard before focusing the Select display node in `handleMouseDown`.
- Add a regression test covering `mousedown` when the display ref is unavailable.

Fixes https://github.com/mui/mui-x/issues/23019