### PR TITLE
[docs] Fix stepper width alignment on Material UI product page

### DIFF
--- a/docs/src/components/productMaterial/MaterialHero.tsx
+++ b/docs/src/components/productMaterial/MaterialHero.tsx
@@ -274,7 +274,7 @@ export default function MaterialHero() {
       }}
       right={
         <CssVarsProvider theme={customTheme}>
-          <Paper sx={{ maxWidth: 780, p: 2, mb: 4 }}>
+          <Paper sx={{ maxWidth: 772, p: 2, mb: 4 }}>
             <Stepper activeStep={1}>
               <Step>
                 <StepLabel>Search for React UI libraries</StepLabel>


### PR DESCRIPTION

On the `/material-ui` page, the stepper's `Paper` wrapper used `maxWidth: 780`, but the two columns of demo elements below it total 772px (two 370px `Stack`s plus a 32px gap), so the stepper stuck out slightly wider than the content beneath it. This reduces the stepper's `maxWidth` to `772` so it aligns with the elements below.

Before:

<img width="2439" height="2550" alt="image" src="https://github.com/user-attachments/assets/1611016e-be26-4a6f-9466-467d836e536b" />


After:

<img width="1611" height="1697" alt="image" src="https://github.com/user-attachments/assets/12b020ee-0241-43d0-8b1c-7b8382e3b34f" />
