### PR TITLE
[ButtonGroup] Respect global disableRipple / disableFocusRipple in grouped buttons

### DIFF
--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -264,21 +264,14 @@ const ButtonGroup = React.forwardRef(function ButtonGroup(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
-  // Forward the ripple flags to child buttons only when explicitly set — on the ButtonGroup
-  // or via `MuiButtonGroup.defaultProps`. When unset, each child `Button` resolves its own
-  // default, so a grouped button matches a standalone one and a global `disableRipple`
-  // (e.g. from `MuiButtonBase.defaultProps`) applies here too. See https://github.com/mui/material-ui/issues/32970.
-  const hasDisableRipple = props.disableRipple !== undefined;
-  const hasDisableFocusRipple = props.disableFocusRipple !== undefined;
-
   const context = React.useMemo(
     () => ({
       className: classes.grouped,
       color,
       disabled,
       disableElevation,
-      ...(hasDisableFocusRipple && { disableFocusRipple }),
-      ...(hasDisableRipple && { disableRipple }),
+      disableFocusRipple: props.disableFocusRipple,
+      disableRipple: props.disableRipple,
       fullWidth,
       size,
       variant,
@@ -287,10 +280,8 @@ const ButtonGroup = React.forwardRef(function ButtonGroup(inProps, ref) {
       color,
       disabled,
       disableElevation,
-      hasDisableFocusRipple,
-      disableFocusRipple,
-      hasDisableRipple,
-      disableRipple,
+      props.disableFocusRipple,
+      props.disableRipple,
       fullWidth,
       size,
       variant,

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -264,14 +264,21 @@ const ButtonGroup = React.forwardRef(function ButtonGroup(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
+  // Forward the ripple flags to child buttons only when explicitly set — on the ButtonGroup
+  // or via `MuiButtonGroup.defaultProps`. When unset, each child `Button` resolves its own
+  // default, so a grouped button matches a standalone one and a global `disableRipple`
+  // (e.g. from `MuiButtonBase.defaultProps`) applies here too. See https://github.com/mui/material-ui/issues/32970.
+  const hasDisableRipple = props.disableRipple !== undefined;
+  const hasDisableFocusRipple = props.disableFocusRipple !== undefined;
+
   const context = React.useMemo(
     () => ({
       className: classes.grouped,
       color,
       disabled,
       disableElevation,
-      disableFocusRipple,
-      disableRipple,
+      ...(hasDisableFocusRipple && { disableFocusRipple }),
+      ...(hasDisableRipple && { disableRipple }),
       fullWidth,
       size,
       variant,
@@ -280,7 +287,9 @@ const ButtonGroup = React.forwardRef(function ButtonGroup(inProps, ref) {
       color,
       disabled,
       disableElevation,
+      hasDisableFocusRipple,
       disableFocusRipple,
+      hasDisableRipple,
       disableRipple,
       fullWidth,
       size,

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
@@ -191,7 +191,7 @@ describe('<ButtonGroup />', () => {
   // JSDOM doesn't support :focus-visible
   it.skipIf(isJsdom())(
     'applies a global disableFocusRipple (MuiButton.defaultProps) to grouped buttons',
-    async () => {
+    async function test() {
       const { container } = render(
         <ThemeProvider
           theme={createTheme({
@@ -217,7 +217,7 @@ describe('<ButtonGroup />', () => {
   // JSDOM doesn't support :focus-visible
   it.skipIf(isJsdom())(
     'explicit disableFocusRipple on ButtonGroup overrides the global default',
-    async () => {
+    async function test() {
       const { container } = render(
         <ThemeProvider
           theme={createTheme({

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { createRenderer, screen } from '@mui/internal-test-utils';
+import { createRenderer, screen, simulateKeyboardDevice, isJsdom } from '@mui/internal-test-utils';
 import ButtonGroup, { buttonGroupClasses as classes } from '@mui/material/ButtonGroup';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Button, { buttonClasses } from '@mui/material/Button';
@@ -187,6 +187,58 @@ describe('<ButtonGroup />', () => {
     await ripple.startTouch(screen.getByRole('button'));
     expect(container.querySelector('.touchRipple')).not.to.equal(null);
   });
+
+  // JSDOM doesn't support :focus-visible
+  it.skipIf(isJsdom())(
+    'applies a global disableFocusRipple (MuiButton.defaultProps) to grouped buttons',
+    async () => {
+      const { container } = render(
+        <ThemeProvider
+          theme={createTheme({
+            components: { MuiButton: { defaultProps: { disableFocusRipple: true } } },
+          })}
+        >
+          <ButtonGroup>
+            <Button TouchRippleProps={{ classes: { ripplePulsate: 'pulsate-focus-visible' } }}>
+              Hello World
+            </Button>
+          </ButtonGroup>
+        </ThemeProvider>,
+      );
+      const button = screen.getByRole('button');
+
+      simulateKeyboardDevice();
+      await ripple.startFocus(button);
+
+      expect(container.querySelector('.pulsate-focus-visible')).to.equal(null);
+    },
+  );
+
+  // JSDOM doesn't support :focus-visible
+  it.skipIf(isJsdom())(
+    'explicit disableFocusRipple on ButtonGroup overrides the global default',
+    async () => {
+      const { container } = render(
+        <ThemeProvider
+          theme={createTheme({
+            components: { MuiButton: { defaultProps: { disableFocusRipple: true } } },
+          })}
+        >
+          <ButtonGroup disableFocusRipple={false}>
+            <Button TouchRippleProps={{ classes: { ripplePulsate: 'pulsate-focus-visible' } }}>
+              Hello World
+            </Button>
+          </ButtonGroup>
+        </ThemeProvider>,
+      );
+      const button = screen.getByRole('button');
+
+      simulateKeyboardDevice();
+      await ripple.startFocus(button);
+
+      expect(container.querySelector('.pulsate-focus-visible')).not.to.equal(null);
+    },
+  );
 
   it('should not be fullWidth by default', () => {
     const { container } = render(

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
@@ -156,6 +156,38 @@ describe('<ButtonGroup />', () => {
     expect(container.querySelector('.touchRipple')).to.equal(null);
   });
 
+  it('applies a global disableRipple (MuiButtonBase.defaultProps) to grouped buttons', async () => {
+    const { container } = render(
+      <ThemeProvider
+        theme={createTheme({
+          components: { MuiButtonBase: { defaultProps: { disableRipple: true } } },
+        })}
+      >
+        <ButtonGroup>
+          <Button TouchRippleProps={{ classes: { root: 'touchRipple' } }}>Hello World</Button>
+        </ButtonGroup>
+      </ThemeProvider>,
+    );
+    await ripple.startTouch(screen.getByRole('button'));
+    expect(container.querySelector('.touchRipple')).to.equal(null);
+  });
+
+  it('explicit disableRipple on ButtonGroup overrides the global default', async () => {
+    const { container } = render(
+      <ThemeProvider
+        theme={createTheme({
+          components: { MuiButtonBase: { defaultProps: { disableRipple: true } } },
+        })}
+      >
+        <ButtonGroup disableRipple={false}>
+          <Button TouchRippleProps={{ classes: { root: 'touchRipple' } }}>Hello World</Button>
+        </ButtonGroup>
+      </ThemeProvider>,
+    );
+    await ripple.startTouch(screen.getByRole('button'));
+    expect(container.querySelector('.touchRipple')).not.to.equal(null);
+  });
+
   it('should not be fullWidth by default', () => {
     const { container } = render(
       <ButtonGroup>
@@ -204,8 +236,9 @@ describe('<ButtonGroup />', () => {
     expect(context.variant).to.equal('contained');
     expect(context.size).to.equal('large');
     expect(context.fullWidth).to.equal(false);
-    expect(context.disableRipple).to.equal(false);
-    expect(context.disableFocusRipple).to.equal(false);
+    // Unset ripple flags are not forwarded, so each child resolves its own default (#32970).
+    expect(context.disableRipple).to.equal(undefined);
+    expect(context.disableFocusRipple).to.equal(undefined);
     expect(context.disableElevation).to.equal(false);
     expect(context.disabled).to.equal(false);
     expect(context.color).to.equal('primary');


### PR DESCRIPTION
closes #32970

## Reproduction

Both sandboxes set `MuiButtonBase.defaultProps.disableRipple: true` globally (the [documented FAQ recipe](https://mui.com/material-ui/getting-started/faq/#how-can-i-disable-the-ripple-effect-globally)), then render a standalone `Button` and a `ButtonGroup`. Click the buttons and watch for a ripple.

| | Sandbox | ButtonGroup ripple |
|---|---|---|
| **Before** (`@mui/material` latest) | https://stackblitz.com/edit/gl5cdvnv | still ripples 🐛 |
| **After** (this PR, via pkg.pr.new) | https://stackblitz.com/edit/mhihn5ib | no ripple ✅ |

The standalone `Button` has no ripple in both — only the grouped buttons differ.

## Problem

`ButtonGroup` seeds `disableRipple` and `disableFocusRipple` with `false` and forwards them to child buttons through context. Context outranks theme `defaultProps` (`inProps > contextProps > themeDefaultProps`), so an **unset** flag shadows the theme default. The documented "disable the ripple globally" recipe (`MuiButtonBase.defaultProps.disableRipple`) therefore does not reach grouped buttons, even though it works for standalone buttons (since #29613).

## Change

Forward `disableRipple` / `disableFocusRipple` through the ButtonGroup context **only when explicitly set** — on the `ButtonGroup` instance or via `MuiButtonGroup.defaultProps`. When unset, each child `Button` resolves its own default, so a grouped button behaves exactly like a standalone one.

- A global `disableRipple` now applies to grouped buttons.
- Explicit `<ButtonGroup disableRipple>` / `disableRipple={false}` still wins, unchanged.
- `disableElevation` is intentionally left as-is — it is visually structural (shadows) and the riskier change, deferred (see discussion on #32970).

## Semver

Behavior change only for apps that set a global ripple default **and** use `ButtonGroup` — for them it becomes the documented behavior; everyone else is unchanged. `disableRipple` / `disableFocusRipple` are interaction effects (no layout or shadow change), so this is a bugfix. Scope + versioning discussed on #32970.

Note on `disableFocusRipple`: for `Button` the resolving key is `MuiButton.defaultProps.disableFocusRipple` (Button always sends `focusRipple` to `ButtonBase`), so this aligns grouped with standalone rather than honoring `MuiButtonBase` for that flag.
