### PR TITLE
[system] Warn and skip CSS variable generation for values stylis treats as comments

### DIFF
--- a/packages/mui-system/src/cssVars/cssVarsParser.test.ts
+++ b/packages/mui-system/src/cssVars/cssVarsParser.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { vi } from 'vitest';
 import cssVarsParser, { assignNestedKeys, walkObjectDeep } from './cssVarsParser';
 
 describe('cssVarsParser', () => {
@@ -404,5 +405,51 @@ describe('cssVarsParser', () => {
     });
     expect(css).to.deep.equal({});
     expect(vars).to.deep.equal({});
+  });
+
+  it('warns and skips string values containing "//" to avoid stylis comment corruption', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { css, vars } = cssVarsParser({
+      palette: {
+        primary: {
+          main: '#ff5252',
+          image: 'url(https://example.com/image.png)',
+          dark: '#b71c1c',
+        },
+      },
+    });
+    expect(css).to.deep.equal({
+      '--palette-primary-main': '#ff5252',
+      '--palette-primary-dark': '#b71c1c',
+    });
+    expect(vars).to.deep.equal({
+      palette: {
+        primary: {
+          main: 'var(--palette-primary-main)',
+          dark: 'var(--palette-primary-dark)',
+        },
+      },
+    });
+    expect(errorSpy.mock.calls[0][0]).to.include('palette.primary.image');
+    expect(errorSpy.mock.calls[0][0]).to.include('//');
+    errorSpy.mockRestore();
+  });
+
+  it('does not warn when the key is excluded via `shouldSkipGeneratingVar`', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { css } = cssVarsParser(
+      {
+        palette: {
+          primary: {
+            main: '#ff5252',
+            image: 'url(https://example.com/image.png)',
+          },
+        },
+      },
+      { shouldSkipGeneratingVar: (keys) => keys.includes('image') },
+    );
+    expect(css).to.deep.equal({ '--palette-primary-main': '#ff5252' });
+    expect(errorSpy.mock.calls).to.have.length(0);
+    errorSpy.mockRestore();
   });
 });

--- a/packages/mui-system/src/cssVars/cssVarsParser.test.ts
+++ b/packages/mui-system/src/cssVars/cssVarsParser.test.ts
@@ -407,13 +407,13 @@ describe('cssVarsParser', () => {
     expect(vars).to.deep.equal({});
   });
 
-  it('warns and skips string values containing "//" to avoid stylis comment corruption', () => {
+  it('warns and skips string values with a bare "//" that stylis treats as a comment', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { css, vars } = cssVarsParser({
       palette: {
         primary: {
           main: '#ff5252',
-          image: 'url(https://example.com/image.png)',
+          image: 'https://example.com/image.png',
           dark: '#b71c1c',
         },
       },
@@ -435,6 +435,22 @@ describe('cssVarsParser', () => {
     errorSpy.mockRestore();
   });
 
+  it('keeps values where "//" only appears inside url() or quoted strings', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { css } = cssVarsParser({
+      backgroundImage: 'url(https://example.com/image.png)',
+      backgroundImageQuoted: 'url("https://example.com/image.png")',
+      content: '"https://example.com"',
+    });
+    expect(css).to.deep.equal({
+      '--backgroundImage': 'url(https://example.com/image.png)',
+      '--backgroundImageQuoted': 'url("https://example.com/image.png")',
+      '--content': '"https://example.com"',
+    });
+    expect(errorSpy.mock.calls).to.have.length(0);
+    errorSpy.mockRestore();
+  });
+
   it('does not warn when the key is excluded via `shouldSkipGeneratingVar`', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { css } = cssVarsParser(
@@ -442,7 +458,7 @@ describe('cssVarsParser', () => {
         palette: {
           primary: {
             main: '#ff5252',
-            image: 'url(https://example.com/image.png)',
+            image: 'https://example.com/image.png',
           },
         },
       },

--- a/packages/mui-system/src/cssVars/cssVarsParser.ts
+++ b/packages/mui-system/src/cssVars/cssVarsParser.ts
@@ -138,6 +138,18 @@ export default function cssVarsParser<T extends Record<string, any>>(
     (keys, value: string | number | object, arrayKeys) => {
       if (typeof value === 'string' || typeof value === 'number') {
         if (!shouldSkipGeneratingVar || !shouldSkipGeneratingVar(keys, value)) {
+          if (typeof value === 'string' && value.includes('//')) {
+            // Stylis (the CSS preprocessor used by Emotion) treats `//` as a single-line
+            // comment, which corrupts the entire generated :root {} block when such a value
+            // is serialized as a CSS variable, making every variable undefined.
+            if (process.env.NODE_ENV !== 'production') {
+              console.error(
+                `MUI: The theme key \`${keys.join('.')}\` with value \`${value}\` contains \`//\` which is treated as a comment by the CSS preprocessor and cannot be used as a CSS variable value.\n` +
+                  `Use \`shouldSkipGeneratingVar\` to exclude this key from CSS variable generation.`,
+              );
+            }
+            return;
+          }
           // only create css & var if `shouldSkipGeneratingVar` return false
           const cssVar = `--${prefix ? `${prefix}-` : ''}${keys.join('-')}`;
           const resolvedValue = getCssValue(keys, value);

--- a/packages/mui-system/src/cssVars/cssVarsParser.ts
+++ b/packages/mui-system/src/cssVars/cssVarsParser.ts
@@ -97,6 +97,16 @@ const getCssValue = (keys: string[], value: string | number) => {
   return value;
 };
 
+// Stylis (the CSS preprocessor used by Emotion) treats `//` outside of `url(...)`
+// tokens and quoted strings as a single-line comment, which discards the rest of
+// the rule. `//` inside `url(...)` or quotes is parsed correctly and is safe.
+function containsUnsafeDoubleSlash(value: string) {
+  return value
+    .replace(/url\([^)]*\)/g, '')
+    .replace(/(['"])(?:(?!\1).)*\1/g, '')
+    .includes('//');
+}
+
 /**
  * a function that parse theme and return { css, vars }
  *
@@ -138,10 +148,11 @@ export default function cssVarsParser<T extends Record<string, any>>(
     (keys, value: string | number | object, arrayKeys) => {
       if (typeof value === 'string' || typeof value === 'number') {
         if (!shouldSkipGeneratingVar || !shouldSkipGeneratingVar(keys, value)) {
-          if (typeof value === 'string' && value.includes('//')) {
-            // Stylis (the CSS preprocessor used by Emotion) treats `//` as a single-line
-            // comment, which corrupts the entire generated :root {} block when such a value
-            // is serialized as a CSS variable, making every variable undefined.
+          if (typeof value === 'string' && containsUnsafeDoubleSlash(value)) {
+            // A bare `//` is treated as a single-line comment by Stylis (the CSS
+            // preprocessor used by Emotion), which corrupts the entire generated
+            // :root {} block when such a value is serialized as a CSS variable,
+            // making every variable undefined.
             if (process.env.NODE_ENV !== 'production') {
               console.error(
                 `MUI: The theme key \`${keys.join('.')}\` with value \`${value}\` contains \`//\` which is treated as a comment by the CSS preprocessor and cannot be used as a CSS variable value.\n` +


### PR DESCRIPTION
Fixes #48267

## Problem

When an augmented theme contains a string value with `//` (typically a URL, e.g. `backgroundImage: 'url(https://...)'`), the value is serialized into the `:root {}` rule as a CSS variable. Stylis treats `//` as a single-line comment, which corrupts the entire generated block — **every** `--mui-*` variable becomes undefined, not just the offending one.

## Fix

Following up on #48499 (closed for inactivity): in `cssVarsParser`, string values containing `//` are skipped from CSS variable generation, with a dev-mode `console.error` explaining the cause and pointing to `shouldSkipGeneratingVar`.

Per @mj12albert's review on #48499 — "`shouldSkipGeneratingVar` doesn't seem to silence this new dev warning which contradicts the advice in the warning" — the check now lives **inside** the `shouldSkipGeneratingVar` guard, so following the warning's own advice silences it. A dedicated test asserts that (no warning when the key is excluded via `shouldSkipGeneratingVar`).

## Tests

Two new cases in `cssVarsParser.test.ts`:
- a `//` value is skipped with a warning while sibling keys keep generating variables (fails without the fix — the corrupt variable was emitted, no warning)
- excluding the key via `shouldSkipGeneratingVar` produces no warning (the #48499 review criterion)

All 25 `cssVarsParser` tests pass; ESLint and Prettier clean.
