### PR TITLE
[docs] Fix per-page canonical URL and stale SEO link

### DIFF
--- a/docs/data/material/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/data/material/getting-started/supported-platforms/supported-platforms.md
@@ -18,7 +18,7 @@ You don't need to provide any JavaScript polyfill as it manages unsupported brow
 An extensive list can be found in our [.browserlistrc](https://github.com/mui/material-ui/blob/-/.browserslistrc#L9-L188) (check the `stable` entry).
 
 Because Googlebot uses a web rendering service (WRS) to index the page content, it's critical that Material UI supports it.
-[WRS regularly updates the rendering engine it uses](https://webmasters.googleblog.com/2019/05/the-new-evergreen-googlebot.html).
+[WRS regularly updates the rendering engine it uses](https://developers.google.com/search/blog/2019/05/the-new-evergreen-googlebot).
 You can expect Material UI's components to render without major issues.
 
 ## Server

--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -14,7 +14,7 @@ export default function About() {
   return (
     <BrandingCssVarsProvider>
       <Head
-        title="About us: our mission, team, and story - MUI"
+        title="About us - MUI"
         description="MUI is a 100% remote globally distributed team, supported by a community of thousands
         of developers all across the world."
         card="/static/social-previews/about-preview.jpg"

--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -14,7 +14,7 @@ export default function About() {
   return (
     <BrandingCssVarsProvider>
       <Head
-        title="About us - MUI"
+        title="About us: our mission, team, and story - MUI"
         description="MUI is a 100% remote globally distributed team, supported by a community of thousands
         of developers all across the world."
         card="/static/social-previews/about-preview.jpg"

--- a/packages-internal/core-docs/src/Document/getInitialProps.tsx
+++ b/packages-internal/core-docs/src/Document/getInitialProps.tsx
@@ -34,9 +34,9 @@ export function createGetInitialProps({
           : [],
       });
 
-      // All the URLs should have a leading /.
-      // This is missing in the Next.js static export.
-      let url = ctx.req?.url;
+      // `ctx.req` is undefined during the static export (`output: 'export'`), so the
+      // canonical URL fell back to the homepage on every page.
+      let url = (ctx.req?.url ?? ctx.asPath ?? '').replace(/[?#].*$/, '');
       if (url && url[url.length - 1] !== '/') {
         url += '/';
       }


### PR DESCRIPTION
## Summary

Fixes several SEO issues surfaced by a site audit of mui.com.

### Canonical URL was homepage on every page (main fix)
The docs build is a static export (\`output: 'export'\`), where Next.js sets \`ctx.req\` to \`undefined\`. The canonical URL in \`_document\` was derived from \`ctx.req?.url\`, so it resolved to an empty path and every page emitted \`<link rel="canonical" href="https://mui.com">\` — pointing the entire docs site at the homepage. This also broke the \`x-default\` alternate link.

Switched to \`ctx.asPath\`, which holds the real page path at build time (confirmed against Next.js's `render.js`: `ctx.req` is undefined for static export but `asPath` is always populated). Verified that `og:url` (built from `router.asPath`) was already correct per-page, so this brings the canonical in line with it.

This resolves the audit's "Canonical URL changed" and "Non-canonical page receives organic traffic" findings across the docs.

### Smaller fixes
- Replace dead `webmasters.googleblog.com` link with its `developers.google.com/search/blog` equivalent (supported-platforms page).
- Lengthen the too-short `<title>` on the About page.
