### PR TITLE
[docs-infra] Enable webpackBuildWorker in shared Next.js config

### DIFF
--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -76,6 +76,12 @@ function withDocsInfra(nextConfig) {
     experimental: {
       scrollRestoration: true,
       workerThreads: false,
+      // Run each webpack compilation in a separate, disposable worker process so
+      // its memory is released before static generation instead of accumulating
+      // in the long-lived build process. This is off by default whenever a custom
+      // `webpack` config is present (Next resolves the `undefined` default to
+      // `false` when `config.webpack` is set), so it must be enabled explicitly.
+      webpackBuildWorker: true,
       ...(process.env.CI
         ? {
             cpus: process.env.NEXT_PARALLELISM


### PR DESCRIPTION
Enables Next.js's `experimental.webpackBuildWorker` in the shared `withDocsInfra` factory so every docs consumer runs each webpack compilation in a separate, disposable worker process. Its memory is released before static generation instead of accumulating in the long-lived build process, lowering peak docs-build memory.

The flag is off by default whenever a custom `webpack` config is present (Next resolves the `undefined` default to `false` when `config.webpack` is set), and the docs config defines one — so it has to be enabled explicitly. It's placed before the `...nextConfig.experimental` spread so individual projects can still override it.

Applies review feedback from mui/mui-x#23100, which asked that this setting live in the shared docs infrastructure rather than only in mui-x's per-project config.