### PR TITLE
[slider] Use unrounded percent for active thumb position

### DIFF
--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -243,6 +243,44 @@ describe.skipIf(!supportsTouch())('<Slider />', () => {
     expect(handleChange.args[1][1]).to.deep.equal(22);
   });
 
+  it.skipIf(isJsdom())('should position the active thumb from the unrounded drag percent', () => {
+    const { container } = render(
+      <Slider
+        defaultValue={0}
+        step={10}
+        slotProps={{
+          thumb: {
+            'data-testid': 'thumb',
+          },
+        }}
+      />,
+    );
+    stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
+      width: 100,
+      height: 10,
+      bottom: 10,
+      left: 0,
+    }));
+    const slider = screen.getByRole('slider');
+    const thumb = screen.getByTestId('thumb');
+
+    fireEvent.pointerDown(container.firstChild, {
+      buttons: 1,
+      clientX: 42.6,
+      pointerId: 1,
+    });
+
+    expect(slider).to.have.attribute('aria-valuenow', '40');
+    expect(thumb.style.left).to.equal('42.6%');
+
+    fireEvent.pointerUp(document.body, {
+      clientX: 42.6,
+      pointerId: 1,
+    });
+
+    expect(thumb.style.left).to.equal('40%');
+  });
+
   describe('prop: classes', () => {
     it('adds custom classes to the component', () => {
       const selectedClasses = ['root', 'rail', 'track', 'mark'];

--- a/packages/mui-material/src/Slider/useSlider.ts
+++ b/packages/mui-material/src/Slider/useSlider.ts
@@ -224,6 +224,9 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
   const [active, setActive] = React.useState(-1);
   const [open, setOpen] = React.useState(-1);
   const [dragging, setDragging] = React.useState(false);
+  const [draggingThumbPercent, setDraggingThumbPercent] = React.useState<number | undefined>(
+    undefined,
+  );
   const moveCountRef = React.useRef(0);
   // Ref (not state) because setActive() always accompanies updates, providing the re-render.
   const lastUsedThumbIndexRef = React.useRef(-1);
@@ -482,6 +485,7 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
 
   if (disabled && active !== -1) {
     setActive(-1);
+    setDraggingThumbPercent(undefined);
   }
   if (disabled && focusedThumbIndex !== -1) {
     setFocusedThumbIndex(-1);
@@ -525,6 +529,7 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
 
     let newValue;
     newValue = percentToValue(percent, min, max);
+    let draggingThumbValue = clamp(newValue, min, max);
     if (step) {
       newValue = roundValueToStep(newValue, step, min);
     } else {
@@ -548,6 +553,11 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
           values[activeIndex - 1] || -Infinity,
           values[activeIndex + 1] || Infinity,
         );
+        draggingThumbValue = clamp(
+          draggingThumbValue,
+          values[activeIndex - 1] || -Infinity,
+          values[activeIndex + 1] || Infinity,
+        );
       }
 
       const previousValue = newValue;
@@ -560,7 +570,11 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
       }
     }
 
-    return { newValue, activeIndex };
+    return {
+      newValue,
+      activeIndex,
+      draggingThumbPercent: valueToPercent(draggingThumbValue, min, max),
+    };
   };
 
   const handleTouchMove = useEventCallback((nativeEvent: TouchEvent | PointerEvent) => {
@@ -592,6 +606,7 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
 
     focusThumb(sliderRef, newFingerValue.activeIndex, setActive, false);
     lastUsedThumbIndexRef.current = newFingerValue.activeIndex;
+    setDraggingThumbPercent(newFingerValue.draggingThumbPercent);
     setValueState(newFingerValue.newValue);
 
     if (!dragging && moveCountRef.current > INTENTIONAL_DRAG_COUNT_THRESHOLD) {
@@ -611,6 +626,7 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
 
     const finger = trackFinger(nativeEvent, touchIdRef);
     setDragging(false);
+    setDraggingThumbPercent(undefined);
 
     if (!finger) {
       return;
@@ -670,6 +686,7 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
       if (newFingerValue) {
         focusThumb(sliderRef, newFingerValue.activeIndex, setActive, false);
         lastUsedThumbIndexRef.current = newFingerValue.activeIndex;
+        setDraggingThumbPercent(newFingerValue.draggingThumbPercent);
 
         setValueState(newFingerValue.newValue);
 
@@ -745,6 +762,7 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
 
           setActive(newFingerValue.activeIndex);
           lastUsedThumbIndexRef.current = newFingerValue.activeIndex;
+          setDraggingThumbPercent(newFingerValue.draggingThumbPercent);
 
           if (pressedOnFocusedThumb) {
             event.preventDefault();
@@ -840,6 +858,8 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
 
   const getThumbStyle = (index: number) => {
     let zIndex: number | undefined;
+    const percent =
+      active === index && draggingThumbPercent != null ? draggingThumbPercent : undefined;
     if (range) {
       if (active === index) {
         zIndex = 2;
@@ -851,6 +871,7 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
     }
 
     return {
+      ...(percent != null && axisProps[axis as keyof typeof axisProps].offset(percent)),
       // So the non active thumb doesn't show its label on hover.
       pointerEvents: active !== -1 && active !== index ? 'none' : undefined,
       zIndex,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Problem

For stepped Sliders, the thumb position during drag is rendered from the already-rounded value. For example, dragging to `42.6%` with `step={10}` commits value `40`, so the active thumb is also rendered at `40%`. This adds visible step-quantization lag on top of any browser rendering delay.

## Change

- Track the active pointer/touch drag position as a bounded raw percent in `useSlider`.
- Apply that raw percent only through the active thumb's internal style while dragging.
- Keep committed value semantics unchanged: `value`, `aria-valuenow`, hidden input state, and `onChange` still use the rounded/clamped Slider value.
- Add a browser regression test that proves the active thumb can render at `42.6%` while `aria-valuenow` remains `40`, then falls back to `40%` after release.

## Validation

- `pnpm test:browser packages/mui-material/src/Slider/Slider.test.js`
- `pnpm test:unit packages/mui-material/src/Slider/Slider.test.js`
- `pnpm --filter @mui/material typescript`
- `pnpm prettier`
- `git diff --check`

## Risk

The change is limited to the active thumb during pointer/touch dragging. It does not change keyboard behavior, public API, rounding, hidden input values, or accessibility value semantics.

This does not eliminate all possible native/browser slider lag under heavy CPU pressure; it only removes the extra lag caused by rendering the active thumb from the rounded step value.

## Out of scope

- New Slider props or public API changes.
- Reworking Slider event handling.
- Changing marks, labels, range sorting, keyboard behavior, or value rounding.
- Generated docs, lockfiles, or dependency changes.

## Issue

Closes #44851
