### PR TITLE
[codemod] Don't leak state between files in v5.0.0/path-imports

### DIFF
--- a/packages/mui-codemod/src/v5.0.0/path-imports.js
+++ b/packages/mui-codemod/src/v5.0.0/path-imports.js
@@ -1,9 +1,5 @@
 import addImports from 'jscodeshift-add-imports';
 
-const barrelImportsToTransform = {
-  material: {},
-  'icons-material': {},
-};
 const muiImportRegExp = /^@mui\/([^/]+)$/;
 
 export default function transformer(fileInfo, api, options) {
@@ -11,6 +7,11 @@ export default function transformer(fileInfo, api, options) {
   const printOptions = options.printOptions || {
     quote: 'single',
     trailingComma: true,
+  };
+
+  const barrelImportsToTransform = {
+    material: {},
+    'icons-material': {},
   };
 
   const root = j(fileInfo.source);

--- a/packages/mui-codemod/src/v5.0.0/path-imports.test.js
+++ b/packages/mui-codemod/src/v5.0.0/path-imports.test.js
@@ -44,6 +44,22 @@ describe('@mui/codemod', () => {
           'The transformed version should be correct',
         );
       });
+
+      it('should not leak imports between file transformations', () => {
+        transform(
+          {
+            source: read('./path-imports.test/actual.js'),
+            path: require.resolve('./path-imports.test/actual.js'),
+          },
+          { jscodeshift },
+          {},
+        );
+
+        const source = "import { createContext } from 'react';\n";
+        const actual = transform({ source, path: 'other.js' }, { jscodeshift }, {});
+
+        expect(actual).to.equal(source);
+      });
     });
   });
 });


### PR DESCRIPTION
The `v5.0.0/path-imports` transform stores imports to transform in an object defined at the module scope. `jscodeshift` reuses the module, so that state is shared between files, which makes imports collected while transforming one file get added into every following file, including files that never reference `@mui/material`. This means on a large codebase, there are a ton of unused imports added to each file that potentially conflict with existing unrelated imports.