### PR TITLE
[code-infra] Pin node version in publish CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ default-job: &default-job
   working_directory: /tmp/material-ui
   executor:
     name: code-infra/mui-node
-    node-version: '22.18'
+    node-version: '22.22.3'
   resource_class: medium.gen2
 
 default-context: &default-context
@@ -185,7 +185,7 @@ jobs:
       - run:
           name: Upgrade Node.js for pnpm 11
           command: |
-            curl -fsSL https://nodejs.org/dist/v22.18.0/node-v22.18.0-linux-x64.tar.gz | tar -xz -C /usr/local --strip-components=1
+            curl -fsSL https://nodejs.org/dist/v22.22.3/node-v22.22.3-linux-x64.tar.gz | tar -xz -C /usr/local --strip-components=1
             node --version
       - code-infra/install-pnpm
       - run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22.18.0'
+          node-version: '22.22.3'
           cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: pnpm install
       - name: Cache Next.js build
@@ -49,11 +49,9 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-nextjs-
       - run: pnpm release:build
-      - name: Publish packages to pkg.pr.new and npm dry-run
+      - name: Publish packages to pkg.pr.new
         uses: mui/mui-public/.github/actions/ci-publish@9033c846aecf0e1454f13486af685d93269456e9 # master
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        with:
-          npm-dry-run: true
       - name: Build docs
         run: pnpm docs:build
         env:
@@ -86,3 +84,22 @@ jobs:
           # Required, set by GitHub actions automatically:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           token: ${{secrets.GITHUB_TOKEN}}
+
+  # Mirrors the real publish workflow environment (`publish.yml`) so an env
+  # mismatch — e.g. the Node version pinned by `publish-prepare` violating our
+  # engineStrict `engines` range — is caught here instead of during publishing.
+  publish-dry-run:
+    name: Publish Dry Run
+
+    if: ${{ github.repository_owner == 'mui' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Prepare for publishing
+        uses: mui/mui-public/.github/actions/publish-prepare@5a12855e473909291f8782c324f2c48983054337 # master
+        with:
+          node-version: '22.22.3'
+      - name: Dry run npm publishing
+        env:
+          IS_PUBLISH_TEST: 'true'
+        run: pnpm code-infra publish --ci --dry-run

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22.18.0'
+          node-version: '22.22.3'
           cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: pnpm install
       - run: pnpm canary:release --ignore @mui/icons-material --yes --skip-last-commit-comparison

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,9 @@ jobs:
           ref: ${{ github.event_name == 'push' && github.sha || inputs.sha }}
           fetch-depth: 0 # Fetch full history for proper git operations
       - name: Prepare for publishing
-        uses: mui/mui-public/.github/actions/publish-prepare@9033c846aecf0e1454f13486af685d93269456e9 # master
+        uses: mui/mui-public/.github/actions/publish-prepare@5a12855e473909291f8782c324f2c48983054337 # master
+        with:
+          node-version: '22.22.3'
       - name: Publish packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +70,9 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0 # Fetch full history for proper git operations
       - name: Prepare for publishing
-        uses: mui/mui-public/.github/actions/publish-prepare@9033c846aecf0e1454f13486af685d93269456e9 # master
+        uses: mui/mui-public/.github/actions/publish-prepare@5a12855e473909291f8782c324f2c48983054337 # master
+        with:
+          node-version: '22.22.3'
       - name: Publish packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   command = "pnpm docs:build"
 
 [build.environment]
-  NODE_VERSION = "22.18"
+  NODE_VERSION = "22.22.3"
   PNPM_FLAGS = "--frozen-lockfile"
 
 # [[plugins]]

--- a/package.json
+++ b/package.json
@@ -152,6 +152,6 @@
   "packageManager": "pnpm@11.5.0",
   "engines": {
     "pnpm": "11.5.0",
-    "node": ">=22.18.0"
+    "node": ">=22.22.3"
   }
 }


### PR DESCRIPTION
Pins and bumps the Node version used across CI and the publish workflow to `22.22.3`, fixing the `EBADENGINE` publish failure (npm@12 requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, so publishing on Node 22.18 fails).

- Pin `node-version: '22.22.3'` on `publish-prepare` in `.github/workflows/publish.yml`, bumping `publish-prepare` to the mui-public commit that exposes the `node-version` input.
- Add a standalone `publish-dry-run` job in `.github/workflows/ci.yml` mirroring the real publish environment (`pnpm code-infra publish --ci --dry-run`).
- Move the npm dry-run out of the `ci-publish` step into the dedicated `publish-dry-run` job.
- Bump `node-version` in `ci.yml` setup-node and `engines.node` to `>=22.22.3`.
- Pass `node-version: '22.22.3'` explicitly to the `code-infra/mui-node` CircleCI executor.
- Bump the CircleCI executor override and the manual Node install URL in the browser jobs.

## Changelog

Pin and bump Node version to 22.22.3 in CI and the publish workflow.