### PR TITLE
[codemod] Transform all style exports in `v5.0.0/path-imports` codemod

### DIFF
--- a/packages/mui-codemod/src/v5.0.0/path-imports.js
+++ b/packages/mui-codemod/src/v5.0.0/path-imports.js
@@ -1,4 +1,6 @@
+import { dirname } from 'path';
 import addImports from 'jscodeshift-add-imports';
+import getJSExports from '../util/getJSExports';
 
 const muiImportRegExp = /^@mui\/([^/]+)$/;
 
@@ -8,6 +10,12 @@ export default function transformer(fileInfo, api, options) {
     quote: 'single',
     trailingComma: true,
   };
+
+  const styleExports = getJSExports(
+    require.resolve('@mui/material-v5/modern/styles', {
+      paths: [dirname(fileInfo.path)],
+    }),
+  );
 
   const barrelImportsToTransform = {
     material: {},
@@ -52,7 +60,7 @@ export default function transformer(fileInfo, api, options) {
       if (specifier.type === 'ImportSpecifier') {
         const name = specifier.imported.name;
         if (moduleName === 'material') {
-          if (name === 'ThemeProvider' || name === 'createTheme') {
+          if (styleExports.has(name)) {
             importsToAdd.styles ??= [];
             importsToAdd.styles.push(specifier);
             indexesToPrune.push(index);

--- a/packages/mui-codemod/src/v5.0.0/path-imports.test/actual.js
+++ b/packages/mui-codemod/src/v5.0.0/path-imports.test/actual.js
@@ -1,4 +1,3 @@
-
 import { withStyles } from '@mui/styles';
 
 import { grey, blue } from '@mui/material/colors';
@@ -8,6 +7,12 @@ import { blue as blue2 } from '@mui/material/colors';
 import {
   ThemeProvider,
   createTheme,
+  alpha,
+  darken as darken2,
+  useTheme,
+  styled,
+  responsiveFontSizes,
+  withStyles as MuiWithStyles,
   MenuItem,
   Tab,
   Tabs as MuiTabs,

--- a/packages/mui-codemod/src/v5.0.0/path-imports.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/path-imports.test/expected.js
@@ -1,11 +1,20 @@
-
 import { withStyles } from '@mui/styles';
 
 import { grey, blue } from '@mui/material/colors';
 import { grey as grey2 } from '@mui/material/colors';
 import { blue as blue2 } from '@mui/material/colors';
 
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import {
+  ThemeProvider,
+  createTheme,
+  alpha,
+  darken as darken2,
+  useTheme,
+  styled,
+  responsiveFontSizes,
+  withStyles as MuiWithStyles,
+} from '@mui/material/styles';
+
 import MenuItem from '@mui/material/MenuItem';
 import Tab from '@mui/material/Tab';
 import MuiTabs from '@mui/material/Tabs';


### PR DESCRIPTION
`v5.0.0/path-imports` rewrites barrel imports into path imports, but only `ThemeProvider` and `createTheme` were routed to `@mui/material/styles`. Every other name that `@mui/material` re-exports from `./styles` (`alpha`, `useTheme`, etc.) was incorrectly rewritten to a non-existent sub-path like `@mui/material/alpha`. This fixes this by checking imported name against the complete list of exports from `@mui/material/styles`.