### PR TITLE
[useScrollTrigger] Fix flip-flopping when a layout resize shifts the scroll position

### DIFF
--- a/packages/mui-material/src/useScrollTrigger/useScrollTrigger.js
+++ b/packages/mui-material/src/useScrollTrigger/useScrollTrigger.js
@@ -4,19 +4,39 @@ import * as React from 'react';
 function defaultTrigger(store, options) {
   const { disableHysteresis = false, threshold = 100, target } = options;
   const previous = store.current;
+  const previousScrollHeight = store.scrollHeight;
 
   if (target) {
     // Get vertical scroll
     store.current = target.pageYOffset !== undefined ? target.pageYOffset : target.scrollTop;
+    store.scrollHeight =
+      target.document !== undefined
+        ? target.document.documentElement.scrollHeight
+        : target.scrollHeight;
   }
 
   if (!disableHysteresis && previous !== undefined) {
+    if (previousScrollHeight !== undefined && store.scrollHeight !== previousScrollHeight) {
+      // The scrollable area was resized since the last scroll event, for example by a
+      // Collapse transition inside a sticky AppBar. The resize itself can shift the
+      // scroll position (scroll anchoring), so the direction of this change doesn't
+      // reflect the user's scroll intent. Keep the previous value to avoid the
+      // trigger from flip-flopping. See https://github.com/mui/material-ui/issues/46589
+      return store.trigger;
+    }
     if (store.current < previous) {
+      store.trigger = false;
       return false;
+    }
+    if (store.trigger) {
+      // A resize can leave the scroll position below the threshold while triggered.
+      // With hysteresis, only scrolling up should untrigger.
+      return true;
     }
   }
 
-  return store.current > threshold;
+  store.trigger = store.current > threshold;
+  return store.trigger;
 }
 
 const defaultTarget = typeof window !== 'undefined' ? window : null;

--- a/packages/mui-material/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/mui-material/src/useScrollTrigger/useScrollTrigger.test.js
@@ -270,5 +270,62 @@ describe('useScrollTrigger', () => {
         expect(getTriggerValue()).to.equal(test.result, `Index: ${index} ${JSON.stringify(test)}`);
       });
     });
+
+    // https://github.com/mui/material-ui/issues/46589
+    describe('layout resize, e.g. Collapse inside a sticky AppBar', () => {
+      function setScrollHeight(element, value) {
+        Object.defineProperty(element, 'scrollHeight', { value, configurable: true });
+      }
+
+      // Simulates a collapsible section inside a sticky AppBar: triggering the collapse
+      // shrinks the page, and scroll anchoring shifts the scroll position along with it.
+      const scrollSequence = [
+        // establish a baseline below the threshold
+        { offset: 50, height: 1000, result: 'false' },
+        // user scrolls down past the threshold => trigger, the collapse starts
+        { offset: 150, height: 1000, result: 'true' },
+        // the collapse shrinks the page, shifting the scroll position up without
+        // any scrolling from the user
+        { offset: 130, height: 980, result: 'true' },
+        { offset: 110, height: 960, result: 'true' },
+        { offset: 94, height: 944, result: 'true' },
+        // collapse finished, user keeps scrolling down below the original threshold
+        { offset: 96, height: 944, result: 'true' },
+        { offset: 98, height: 944, result: 'true' },
+        // user scrolls up => untrigger, the collapsed section expands again
+        { offset: 95, height: 944, result: 'false' },
+        // the expand grows the page, shifting the scroll position down
+        { offset: 115, height: 964, result: 'false' },
+        { offset: 135, height: 984, result: 'false' },
+        { offset: 151, height: 1000, result: 'false' },
+        // genuine scrolling keeps behaving as usual
+        { offset: 150, height: 1000, result: 'false' },
+        { offset: 155, height: 1000, result: 'true' },
+      ];
+
+      it('should not flip-flop when a scroll container resize shifts the scroll position', () => {
+        render(<Test customContainer />);
+        scrollSequence.forEach((test, index) => {
+          setScrollHeight(getContainer(), test.height);
+          dispatchScroll(test.offset, getContainer());
+          expect(getTriggerValue()).to.equal(test.result, `Index: ${index} ${JSON.stringify(test)}`);
+        });
+      });
+
+      it('should not flip-flop when a page resize shifts the window scroll position', () => {
+        try {
+          setScrollHeight(document.documentElement, 1000);
+          render(<Test />);
+          scrollSequence.forEach((test, index) => {
+            setScrollHeight(document.documentElement, test.height);
+            dispatchScroll(test.offset);
+            expect(getTriggerValue()).to.equal(test.result, `Index: ${index} ${JSON.stringify(test)}`);
+          });
+        } finally {
+          // restore the prototype getter
+          delete document.documentElement.scrollHeight;
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes #46589

## Problem

When `useScrollTrigger` drives content inside a `position="sticky"` AppBar (for example a `Collapse` that hides a secondary toolbar), the trigger flip-flops and the AppBar visibly shakes while scrolling slowly:

1. The user scrolls down past the threshold, the trigger turns `true` and the collapse starts.
2. The collapse shrinks the page. The browser's scroll anchoring keeps the visible content in place by reducing `scrollY`, which fires scroll events with a *decreasing* position.
3. `defaultTrigger` interprets the decreasing position as the user scrolling up and flips the trigger back to `false`.
4. The content expands again, scroll anchoring increases `scrollY`, the trigger flips to `true`… and the loop repeats.

As @abriginets noted in the issue, the resize itself changes `pageYOffset`/`scrollTop`, so the previous-vs-current comparison in `defaultTrigger` no longer reflects the user's scroll intent during the transition.

## Fix

`defaultTrigger` now also records the scroll target's `scrollHeight` between scroll events (entirely internal state, no API change):

- If the scrollable area's height changed since the last scroll event, the position change is (at least partly) caused by the layout resize, so the event's direction is not trusted and the previous trigger value is kept.
- With hysteresis, once triggered, scrolling down no longer re-checks the threshold. A resize can legitimately leave the scroll position below the threshold while triggered (previously unreachable state); only a genuine upward scroll should untrigger. This keeps the trigger stable after the collapse settles.

Genuine scrolling behaves exactly as before: all existing tests pass unchanged, and the threshold/hysteresis semantics for a stable layout are untouched.

## Tests

Added two regression tests (element target and window target) that replay the reported scenario: scroll down past the threshold, shrink the scrollable area while shifting the position up (collapse + scroll anchoring), keep scrolling, scroll up, grow the area back. Both fail on `master` with the exact oscillation from the issue (trigger flips on every resize frame) and pass with this change.

Ran: `pnpm test:unit run useScrollTrigger` (node: 16 passed; browser: 3 passed, 13 jsdom-only skipped), eslint, prettier and `tsgo -p tsconfig.json` for `packages/mui-material`.

## Relation to #46751

The earlier attempt #46751 added a user-facing opt-in (`enableReentrantLock` + a duration that had to match the transition timing) and was closed after reviewers asked for the edge case to be fixed internally without new public API ([review comment](https://github.com/mui/material-ui/pull/46751#discussion_r3080745136)). This PR fixes it inside `defaultTrigger` with no new options, no timers, and no behavior change for stable layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
