### PR TITLE
[material-ui][FormControlLabel] Add missing `labelPlacementEnd` class

### DIFF
--- a/docs/pages/material-ui/api/form-control-label.json
+++ b/docs/pages/material-ui/api/form-control-label.json
@@ -84,6 +84,12 @@
       "isGlobal": false
     },
     {
+      "key": "labelPlacementEnd",
+      "className": "MuiFormControlLabel-labelPlacementEnd",
+      "description": "Styles applied to the root element if `labelPlacement=\"end\"`.",
+      "isGlobal": false
+    },
+    {
       "key": "labelPlacementStart",
       "className": "MuiFormControlLabel-labelPlacementStart",
       "description": "Styles applied to the root element if `labelPlacement=\"start\"`.",

--- a/docs/translations/api-docs/form-control-label/form-control-label.json
+++ b/docs/translations/api-docs/form-control-label/form-control-label.json
@@ -56,6 +56,11 @@
       "nodeName": "the root element",
       "conditions": "<code>labelPlacement=\"bottom\"</code>"
     },
+    "labelPlacementEnd": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>labelPlacement=\"end\"</code>"
+    },
     "labelPlacementStart": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.test.js
@@ -130,6 +130,20 @@ describe('<FormControlLabel />', () => {
       expect(container.firstChild).to.have.class(classes.labelPlacementStart);
     });
 
+    it('should have the `end` class', () => {
+      const { container } = render(
+        <FormControlLabel label="Pizza" labelPlacement="end" control={<div />} />,
+      );
+
+      expect(container.firstChild).to.have.class(classes.labelPlacementEnd);
+    });
+
+    it('should have the `end` class by default', () => {
+      const { container } = render(<FormControlLabel label="Pizza" control={<div />} />);
+
+      expect(container.firstChild).to.have.class(classes.labelPlacementEnd);
+    });
+
     it('should have the `top` class', () => {
       const { container } = render(
         <FormControlLabel label="Pizza" labelPlacement="top" control={<div />} />,

--- a/packages/mui-material/src/FormControlLabel/formControlLabelClasses.ts
+++ b/packages/mui-material/src/FormControlLabel/formControlLabelClasses.ts
@@ -6,6 +6,8 @@ export interface FormControlLabelClasses {
   root: string;
   /** Styles applied to the root element if `labelPlacement="start"`. */
   labelPlacementStart: string;
+  /** Styles applied to the root element if `labelPlacement="end"`. */
+  labelPlacementEnd: string;
   /** Styles applied to the root element if `labelPlacement="top"`. */
   labelPlacementTop: string;
   /** Styles applied to the root element if `labelPlacement="bottom"`. */
@@ -33,6 +35,7 @@ const formControlLabelClasses: FormControlLabelClasses = generateUtilityClasses(
   [
     'root',
     'labelPlacementStart',
+    'labelPlacementEnd',
     'labelPlacementTop',
     'labelPlacementBottom',
     'disabled',


### PR DESCRIPTION
## Summary

`FormControlLabel` composes a `labelPlacement${capitalize(labelPlacement)}` class key for every placement, but `labelPlacementEnd` was missing from `formControlLabelClasses` — so while `start`/`top`/`bottom` render their `MuiFormControlLabel-labelPlacement*` utility class on the root element, the default `end` placement renders none, and `formControlLabelClasses.labelPlacementEnd` doesn't exist as a constant for targeting.

This adds the missing `labelPlacementEnd` entry, so:

- the root element renders `MuiFormControlLabel-labelPlacementEnd` when `labelPlacement="end"` (including the default, when the prop is omitted) — consistent with the other three placements;
- `formControlLabelClasses.labelPlacementEnd` is available for styling and tests:

```tsx
import { formControlLabelClasses } from '@mui/material/FormControlLabel';

const Styled = styled('div')({
  [`& .${formControlLabelClasses.labelPlacementEnd}`]: {
    marginRight: 8,
  },
});
```

No behavior or style change — the component already passed the key through `composeClasses`; it was silently dropped because no utility class was registered for it.

## For Reviewers

- The class key composition in `FormControlLabel.js` is untouched — it already emits `labelPlacementEnd` for the default placement. The gap was only in the classes definition, so the fix is limited to [registering the key](https://github.com/mui/material-ui/pull/48843/files#diff-230d366bf4eb83525d38b62ba7249f91ab22aab414551d8131d65b326c762f2e) in the interface + `generateUtilityClasses` list.
- [Tests](https://github.com/mui/material-ui/pull/48843/files#diff-5dec4e3c59b26569f781df80564446172c3bd68f4a487d10cc61bd89f89760f6) cover both the explicit `labelPlacement="end"` and the default (prop omitted) case, mirroring the existing `start`/`top`/`bottom` tests.
- API docs (`form-control-label.json` + translations) regenerated via `docs:api:build`.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
