### PR TITLE
[docs] Fix color contrast in Github labels example

### DIFF
--- a/docs/data/material/components/autocomplete/GitHubLabel.js
+++ b/docs/data/material/components/autocomplete/GitHubLabel.js
@@ -37,7 +37,7 @@ const StyledAutocompletePopper = styled('div')(({ theme }) => ({
       },
       [`&.${autocompleteClasses.focused}, &.${autocompleteClasses.focused}[aria-selected="true"]`]:
         {
-          backgroundColor: theme.palette.action.hover,
+          backgroundColor: (theme.vars || theme).palette.action.hover,
         },
     },
   },

--- a/docs/data/material/components/autocomplete/GitHubLabel.tsx
+++ b/docs/data/material/components/autocomplete/GitHubLabel.tsx
@@ -45,7 +45,7 @@ const StyledAutocompletePopper = styled('div')(({ theme }) => ({
       },
       [`&.${autocompleteClasses.focused}, &.${autocompleteClasses.focused}[aria-selected="true"]`]:
         {
-          backgroundColor: theme.palette.action.hover,
+          backgroundColor: (theme.vars || theme).palette.action.hover,
         },
     },
   },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fix color contrast in Autocomplete Github Labels example. The hovered / kb highlighted option was barely visible in Dark Mode.

|Before|After|
|--|--|
|<img width="309" height="297" alt="Screenshot 2026-07-22 at 17 04 33" src="https://github.com/user-attachments/assets/a9e8ee4a-24ba-45a6-b5ea-a4c8c7581cb2" />|<img width="307" height="301" alt="Screenshot 2026-07-22 at 17 04 20" src="https://github.com/user-attachments/assets/5220fd49-b957-40ec-9587-1cbc25641d43" />|