### PR TITLE
[docs] Improve TransferList examples

### DIFF
--- a/docs/data/material/components/transfer-list/SelectAllTransferList.js
+++ b/docs/data/material/components/transfer-list/SelectAllTransferList.js
@@ -97,7 +97,7 @@ CustomList.propTypes = {
   handleToggleAll: PropTypes.func.isRequired,
   items: PropTypes.arrayOf(PropTypes.number).isRequired,
   numberOfChecked: PropTypes.func.isRequired,
-  title: PropTypes.node.isRequired,
+  title: PropTypes.node,
 };
 
 export default function SelectAllTransferList() {

--- a/docs/data/material/components/transfer-list/SelectAllTransferList.js
+++ b/docs/data/material/components/transfer-list/SelectAllTransferList.js
@@ -1,15 +1,16 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import Grid from '@mui/material/Grid';
-import List from '@mui/material/List';
 import Card from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
-import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Checkbox from '@mui/material/Checkbox';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
+import MenuItem from '@mui/material/MenuItem';
+import MenuList from '@mui/material/MenuList';
 
 function not(a, b) {
   return a.filter((value) => !b.includes(value));
@@ -23,6 +24,82 @@ function union(a, b) {
   return [...a, ...not(b, a)];
 }
 
+const CustomList = React.forwardRef(function CustomList(props, ref) {
+  const { title, items, checked, handleToggle, handleToggleAll, numberOfChecked } =
+    props;
+
+  return (
+    <Card>
+      <CardHeader
+        sx={{ px: 2, py: 0.5 }}
+        avatar={
+          <Checkbox
+            size="small"
+            onClick={handleToggleAll(items)}
+            checked={numberOfChecked(items) === items.length && items.length !== 0}
+            indeterminate={
+              numberOfChecked(items) !== items.length && numberOfChecked(items) !== 0
+            }
+            disabled={items.length === 0}
+            slotProps={{
+              input: { 'aria-label': 'all items selected' },
+            }}
+          />
+        }
+        title={title}
+        subheader={`${numberOfChecked(items)}/${items.length} selected`}
+      />
+      <Divider />
+      <MenuList
+        sx={{
+          width: 200,
+          height: 230,
+          bgcolor: 'background.paper',
+          overflow: 'auto',
+        }}
+        dense
+        component="div"
+        role="list"
+        ref={ref}
+      >
+        {items.map((value) => {
+          const labelId = `transfer-list-all-item-${value}-label`;
+
+          return (
+            <MenuItem
+              component="div"
+              key={value}
+              role="listitem"
+              onClick={handleToggle(value)}
+            >
+              <ListItemIcon>
+                <Checkbox
+                  checked={checked.includes(value)}
+                  tabIndex={-1}
+                  disableRipple
+                  slotProps={{
+                    input: { 'aria-labelledby': labelId },
+                  }}
+                />
+              </ListItemIcon>
+              <ListItemText id={labelId} primary={`List item ${value + 1}`} />
+            </MenuItem>
+          );
+        })}
+      </MenuList>
+    </Card>
+  );
+});
+
+CustomList.propTypes = {
+  checked: PropTypes.arrayOf(PropTypes.number).isRequired,
+  handleToggle: PropTypes.func.isRequired,
+  handleToggleAll: PropTypes.func.isRequired,
+  items: PropTypes.arrayOf(PropTypes.number).isRequired,
+  numberOfChecked: PropTypes.func.isRequired,
+  title: PropTypes.node,
+};
+
 export default function SelectAllTransferList() {
   const [checked, setChecked] = React.useState([]);
   const [left, setLeft] = React.useState([0, 1, 2, 3]);
@@ -30,6 +107,9 @@ export default function SelectAllTransferList() {
 
   const leftChecked = intersection(checked, left);
   const rightChecked = intersection(checked, right);
+
+  const leftListRef = React.useRef(null);
+  const rightListRef = React.useRef(null);
 
   const handleToggle = (value) => () => {
     const currentIndex = checked.indexOf(value);
@@ -58,72 +138,15 @@ export default function SelectAllTransferList() {
     setRight(right.concat(leftChecked));
     setLeft(not(left, leftChecked));
     setChecked(not(checked, leftChecked));
+    rightListRef.current?.focus();
   };
 
   const handleCheckedLeft = () => {
     setLeft(left.concat(rightChecked));
     setRight(not(right, rightChecked));
     setChecked(not(checked, rightChecked));
+    leftListRef.current?.focus();
   };
-
-  const customList = (title, items) => (
-    <Card>
-      <CardHeader
-        sx={{ px: 2, py: 1 }}
-        avatar={
-          <Checkbox
-            onClick={handleToggleAll(items)}
-            checked={numberOfChecked(items) === items.length && items.length !== 0}
-            indeterminate={
-              numberOfChecked(items) !== items.length && numberOfChecked(items) !== 0
-            }
-            disabled={items.length === 0}
-            slotProps={{
-              input: { 'aria-label': 'all items selected' },
-            }}
-          />
-        }
-        title={title}
-        subheader={`${numberOfChecked(items)}/${items.length} selected`}
-      />
-      <Divider />
-      <List
-        sx={{
-          width: 200,
-          height: 230,
-          bgcolor: 'background.paper',
-          overflow: 'auto',
-        }}
-        dense
-        component="div"
-        role="list"
-      >
-        {items.map((value) => {
-          const labelId = `transfer-list-all-item-${value}-label`;
-
-          return (
-            <ListItemButton
-              key={value}
-              role="listitem"
-              onClick={handleToggle(value)}
-            >
-              <ListItemIcon>
-                <Checkbox
-                  checked={checked.includes(value)}
-                  tabIndex={-1}
-                  disableRipple
-                  slotProps={{
-                    input: { 'aria-labelledby': labelId },
-                  }}
-                />
-              </ListItemIcon>
-              <ListItemText id={labelId} primary={`List item ${value + 1}`} />
-            </ListItemButton>
-          );
-        })}
-      </List>
-    </Card>
-  );
 
   return (
     <Grid
@@ -131,7 +154,15 @@ export default function SelectAllTransferList() {
       spacing={2}
       sx={{ justifyContent: 'center', alignItems: 'center' }}
     >
-      <Grid>{customList('Choices', left)}</Grid>
+      <CustomList
+        ref={leftListRef}
+        title="Choices"
+        items={left}
+        checked={checked}
+        handleToggle={handleToggle}
+        handleToggleAll={handleToggleAll}
+        numberOfChecked={numberOfChecked}
+      />
       <Stack>
         <Button
           sx={{ my: 0.5 }}
@@ -154,7 +185,15 @@ export default function SelectAllTransferList() {
           &lt;
         </Button>
       </Stack>
-      <Grid>{customList('Chosen', right)}</Grid>
+      <CustomList
+        ref={rightListRef}
+        title="Chosen"
+        items={right}
+        checked={checked}
+        handleToggle={handleToggle}
+        handleToggleAll={handleToggleAll}
+        numberOfChecked={numberOfChecked}
+      />
     </Grid>
   );
 }

--- a/docs/data/material/components/transfer-list/SelectAllTransferList.js
+++ b/docs/data/material/components/transfer-list/SelectAllTransferList.js
@@ -97,7 +97,7 @@ CustomList.propTypes = {
   handleToggleAll: PropTypes.func.isRequired,
   items: PropTypes.arrayOf(PropTypes.number).isRequired,
   numberOfChecked: PropTypes.func.isRequired,
-  title: PropTypes.node,
+  title: PropTypes.node.isRequired,
 };
 
 export default function SelectAllTransferList() {

--- a/docs/data/material/components/transfer-list/SelectAllTransferList.tsx
+++ b/docs/data/material/components/transfer-list/SelectAllTransferList.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import Grid from '@mui/material/Grid';
-import List from '@mui/material/List';
 import Card from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
-import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Checkbox from '@mui/material/Checkbox';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
+import MenuItem from '@mui/material/MenuItem';
+import MenuList from '@mui/material/MenuList';
 
 function not(a: readonly number[], b: readonly number[]) {
   return a.filter((value) => !b.includes(value));
@@ -23,6 +23,85 @@ function union(a: readonly number[], b: readonly number[]) {
   return [...a, ...not(b, a)];
 }
 
+type CustomListProps = {
+  title: React.ReactNode;
+  items: readonly number[];
+  checked: readonly number[];
+  handleToggle: (value: number) => () => void;
+  handleToggleAll: (items: readonly number[]) => () => void;
+  numberOfChecked: (items: readonly number[]) => number;
+};
+
+const CustomList = React.forwardRef(function CustomList(
+  props: CustomListProps,
+  ref: React.Ref<HTMLDivElement & { focus: () => void }>,
+) {
+  const { title, items, checked, handleToggle, handleToggleAll, numberOfChecked } =
+    props;
+
+  return (
+    <Card>
+      <CardHeader
+        sx={{ px: 2, py: 0.5 }}
+        avatar={
+          <Checkbox
+            size="small"
+            onClick={handleToggleAll(items)}
+            checked={numberOfChecked(items) === items.length && items.length !== 0}
+            indeterminate={
+              numberOfChecked(items) !== items.length && numberOfChecked(items) !== 0
+            }
+            disabled={items.length === 0}
+            slotProps={{
+              input: { 'aria-label': 'all items selected' },
+            }}
+          />
+        }
+        title={title}
+        subheader={`${numberOfChecked(items)}/${items.length} selected`}
+      />
+      <Divider />
+      <MenuList
+        sx={{
+          width: 200,
+          height: 230,
+          bgcolor: 'background.paper',
+          overflow: 'auto',
+        }}
+        dense
+        component="div"
+        role="list"
+        ref={ref}
+      >
+        {items.map((value: number) => {
+          const labelId = `transfer-list-all-item-${value}-label`;
+
+          return (
+            <MenuItem
+              component="div"
+              key={value}
+              role="listitem"
+              onClick={handleToggle(value)}
+            >
+              <ListItemIcon>
+                <Checkbox
+                  checked={checked.includes(value)}
+                  tabIndex={-1}
+                  disableRipple
+                  slotProps={{
+                    input: { 'aria-labelledby': labelId },
+                  }}
+                />
+              </ListItemIcon>
+              <ListItemText id={labelId} primary={`List item ${value + 1}`} />
+            </MenuItem>
+          );
+        })}
+      </MenuList>
+    </Card>
+  );
+});
+
 export default function SelectAllTransferList() {
   const [checked, setChecked] = React.useState<readonly number[]>([]);
   const [left, setLeft] = React.useState<readonly number[]>([0, 1, 2, 3]);
@@ -30,6 +109,9 @@ export default function SelectAllTransferList() {
 
   const leftChecked = intersection(checked, left);
   const rightChecked = intersection(checked, right);
+
+  const leftListRef = React.useRef<HTMLDivElement & { focus: () => void }>(null);
+  const rightListRef = React.useRef<HTMLDivElement & { focus: () => void }>(null);
 
   const handleToggle = (value: number) => () => {
     const currentIndex = checked.indexOf(value);
@@ -59,72 +141,15 @@ export default function SelectAllTransferList() {
     setRight(right.concat(leftChecked));
     setLeft(not(left, leftChecked));
     setChecked(not(checked, leftChecked));
+    rightListRef.current?.focus();
   };
 
   const handleCheckedLeft = () => {
     setLeft(left.concat(rightChecked));
     setRight(not(right, rightChecked));
     setChecked(not(checked, rightChecked));
+    leftListRef.current?.focus();
   };
-
-  const customList = (title: React.ReactNode, items: readonly number[]) => (
-    <Card>
-      <CardHeader
-        sx={{ px: 2, py: 1 }}
-        avatar={
-          <Checkbox
-            onClick={handleToggleAll(items)}
-            checked={numberOfChecked(items) === items.length && items.length !== 0}
-            indeterminate={
-              numberOfChecked(items) !== items.length && numberOfChecked(items) !== 0
-            }
-            disabled={items.length === 0}
-            slotProps={{
-              input: { 'aria-label': 'all items selected' },
-            }}
-          />
-        }
-        title={title}
-        subheader={`${numberOfChecked(items)}/${items.length} selected`}
-      />
-      <Divider />
-      <List
-        sx={{
-          width: 200,
-          height: 230,
-          bgcolor: 'background.paper',
-          overflow: 'auto',
-        }}
-        dense
-        component="div"
-        role="list"
-      >
-        {items.map((value: number) => {
-          const labelId = `transfer-list-all-item-${value}-label`;
-
-          return (
-            <ListItemButton
-              key={value}
-              role="listitem"
-              onClick={handleToggle(value)}
-            >
-              <ListItemIcon>
-                <Checkbox
-                  checked={checked.includes(value)}
-                  tabIndex={-1}
-                  disableRipple
-                  slotProps={{
-                    input: { 'aria-labelledby': labelId },
-                  }}
-                />
-              </ListItemIcon>
-              <ListItemText id={labelId} primary={`List item ${value + 1}`} />
-            </ListItemButton>
-          );
-        })}
-      </List>
-    </Card>
-  );
 
   return (
     <Grid
@@ -132,7 +157,15 @@ export default function SelectAllTransferList() {
       spacing={2}
       sx={{ justifyContent: 'center', alignItems: 'center' }}
     >
-      <Grid>{customList('Choices', left)}</Grid>
+      <CustomList
+        ref={leftListRef}
+        title="Choices"
+        items={left}
+        checked={checked}
+        handleToggle={handleToggle}
+        handleToggleAll={handleToggleAll}
+        numberOfChecked={numberOfChecked}
+      />
       <Stack>
         <Button
           sx={{ my: 0.5 }}
@@ -155,7 +188,15 @@ export default function SelectAllTransferList() {
           &lt;
         </Button>
       </Stack>
-      <Grid>{customList('Chosen', right)}</Grid>
+      <CustomList
+        ref={rightListRef}
+        title="Chosen"
+        items={right}
+        checked={checked}
+        handleToggle={handleToggle}
+        handleToggleAll={handleToggleAll}
+        numberOfChecked={numberOfChecked}
+      />
     </Grid>
   );
 }

--- a/docs/data/material/components/transfer-list/TransferList.js
+++ b/docs/data/material/components/transfer-list/TransferList.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import Grid from '@mui/material/Grid';
-import List from '@mui/material/List';
-import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Checkbox from '@mui/material/Checkbox';
 import Button from '@mui/material/Button';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
+import MenuItem from '@mui/material/MenuItem';
+import MenuList from '@mui/material/MenuList';
 
 function not(a, b) {
   return a.filter((value) => !b.includes(value));
@@ -17,6 +18,47 @@ function intersection(a, b) {
   return a.filter((value) => b.includes(value));
 }
 
+const CustomList = React.forwardRef(function CustomList(props, ref) {
+  const { items, checked, handleToggle } = props;
+
+  return (
+    <Paper sx={{ width: 200, height: 230, overflow: 'auto' }}>
+      <MenuList dense component="div" role="list" ref={ref}>
+        {items.map((value) => {
+          const labelId = `transfer-list-item-${value}-label`;
+
+          return (
+            <MenuItem
+              component="div"
+              key={value}
+              role="listitem"
+              onClick={handleToggle(value)}
+            >
+              <ListItemIcon>
+                <Checkbox
+                  checked={checked.includes(value)}
+                  tabIndex={-1}
+                  disableRipple
+                  slotProps={{
+                    input: { 'aria-labelledby': labelId },
+                  }}
+                />
+              </ListItemIcon>
+              <ListItemText id={labelId} primary={`List item ${value + 1}`} />
+            </MenuItem>
+          );
+        })}
+      </MenuList>
+    </Paper>
+  );
+});
+
+CustomList.propTypes = {
+  checked: PropTypes.arrayOf(PropTypes.number).isRequired,
+  handleToggle: PropTypes.func.isRequired,
+  items: PropTypes.arrayOf(PropTypes.number).isRequired,
+};
+
 export default function TransferList() {
   const [checked, setChecked] = React.useState([]);
   const [left, setLeft] = React.useState([0, 1, 2, 3]);
@@ -24,6 +66,9 @@ export default function TransferList() {
 
   const leftChecked = intersection(checked, left);
   const rightChecked = intersection(checked, right);
+
+  const leftListRef = React.useRef(null);
+  const rightListRef = React.useRef(null);
 
   const handleToggle = (value) => () => {
     const currentIndex = checked.indexOf(value);
@@ -41,54 +86,30 @@ export default function TransferList() {
   const handleAllRight = () => {
     setRight(right.concat(left));
     setLeft([]);
+    setChecked(not(checked, left));
+    rightListRef.current?.focus();
   };
 
   const handleCheckedRight = () => {
     setRight(right.concat(leftChecked));
     setLeft(not(left, leftChecked));
     setChecked(not(checked, leftChecked));
+    rightListRef.current?.focus();
   };
 
   const handleCheckedLeft = () => {
     setLeft(left.concat(rightChecked));
     setRight(not(right, rightChecked));
     setChecked(not(checked, rightChecked));
+    leftListRef.current?.focus();
   };
 
   const handleAllLeft = () => {
     setLeft(left.concat(right));
     setRight([]);
+    setChecked(not(checked, right));
+    leftListRef.current?.focus();
   };
-
-  const customList = (items) => (
-    <Paper sx={{ width: 200, height: 230, overflow: 'auto' }}>
-      <List dense component="div" role="list">
-        {items.map((value) => {
-          const labelId = `transfer-list-item-${value}-label`;
-
-          return (
-            <ListItemButton
-              key={value}
-              role="listitem"
-              onClick={handleToggle(value)}
-            >
-              <ListItemIcon>
-                <Checkbox
-                  checked={checked.includes(value)}
-                  tabIndex={-1}
-                  disableRipple
-                  slotProps={{
-                    input: { 'aria-labelledby': labelId },
-                  }}
-                />
-              </ListItemIcon>
-              <ListItemText id={labelId} primary={`List item ${value + 1}`} />
-            </ListItemButton>
-          );
-        })}
-      </List>
-    </Paper>
-  );
 
   return (
     <Grid
@@ -96,7 +117,12 @@ export default function TransferList() {
       spacing={2}
       sx={{ justifyContent: 'center', alignItems: 'center' }}
     >
-      <Grid>{customList(left)}</Grid>
+      <CustomList
+        ref={leftListRef}
+        items={left}
+        checked={checked}
+        handleToggle={handleToggle}
+      />
       <Stack>
         <Button
           sx={{ my: 0.5 }}
@@ -139,7 +165,12 @@ export default function TransferList() {
           ≪
         </Button>
       </Stack>
-      <Grid>{customList(right)}</Grid>
+      <CustomList
+        ref={rightListRef}
+        items={right}
+        checked={checked}
+        handleToggle={handleToggle}
+      />
     </Grid>
   );
 }

--- a/docs/data/material/components/transfer-list/TransferList.tsx
+++ b/docs/data/material/components/transfer-list/TransferList.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import Grid from '@mui/material/Grid';
-import List from '@mui/material/List';
-import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Checkbox from '@mui/material/Checkbox';
 import Button from '@mui/material/Button';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
+import MenuItem from '@mui/material/MenuItem';
+import MenuList from '@mui/material/MenuList';
 
 function not(a: readonly number[], b: readonly number[]) {
   return a.filter((value) => !b.includes(value));
@@ -17,6 +17,50 @@ function intersection(a: readonly number[], b: readonly number[]) {
   return a.filter((value) => b.includes(value));
 }
 
+type CustomListProps = {
+  items: readonly number[];
+  checked: readonly number[];
+  handleToggle: (value: number) => () => void;
+};
+
+const CustomList = React.forwardRef(function CustomList(
+  props: CustomListProps,
+  ref: React.Ref<HTMLDivElement & { focus: () => void }>,
+) {
+  const { items, checked, handleToggle } = props;
+
+  return (
+    <Paper sx={{ width: 200, height: 230, overflow: 'auto' }}>
+      <MenuList dense component="div" role="list" ref={ref}>
+        {items.map((value: number) => {
+          const labelId = `transfer-list-item-${value}-label`;
+
+          return (
+            <MenuItem
+              component="div"
+              key={value}
+              role="listitem"
+              onClick={handleToggle(value)}
+            >
+              <ListItemIcon>
+                <Checkbox
+                  checked={checked.includes(value)}
+                  tabIndex={-1}
+                  disableRipple
+                  slotProps={{
+                    input: { 'aria-labelledby': labelId },
+                  }}
+                />
+              </ListItemIcon>
+              <ListItemText id={labelId} primary={`List item ${value + 1}`} />
+            </MenuItem>
+          );
+        })}
+      </MenuList>
+    </Paper>
+  );
+});
+
 export default function TransferList() {
   const [checked, setChecked] = React.useState<readonly number[]>([]);
   const [left, setLeft] = React.useState<readonly number[]>([0, 1, 2, 3]);
@@ -24,6 +68,9 @@ export default function TransferList() {
 
   const leftChecked = intersection(checked, left);
   const rightChecked = intersection(checked, right);
+
+  const leftListRef = React.useRef<HTMLDivElement & { focus: () => void }>(null);
+  const rightListRef = React.useRef<HTMLDivElement & { focus: () => void }>(null);
 
   const handleToggle = (value: number) => () => {
     const currentIndex = checked.indexOf(value);
@@ -41,54 +88,30 @@ export default function TransferList() {
   const handleAllRight = () => {
     setRight(right.concat(left));
     setLeft([]);
+    setChecked(not(checked, left));
+    rightListRef.current?.focus();
   };
 
   const handleCheckedRight = () => {
     setRight(right.concat(leftChecked));
     setLeft(not(left, leftChecked));
     setChecked(not(checked, leftChecked));
+    rightListRef.current?.focus();
   };
 
   const handleCheckedLeft = () => {
     setLeft(left.concat(rightChecked));
     setRight(not(right, rightChecked));
     setChecked(not(checked, rightChecked));
+    leftListRef.current?.focus();
   };
 
   const handleAllLeft = () => {
     setLeft(left.concat(right));
     setRight([]);
+    setChecked(not(checked, right));
+    leftListRef.current?.focus();
   };
-
-  const customList = (items: readonly number[]) => (
-    <Paper sx={{ width: 200, height: 230, overflow: 'auto' }}>
-      <List dense component="div" role="list">
-        {items.map((value: number) => {
-          const labelId = `transfer-list-item-${value}-label`;
-
-          return (
-            <ListItemButton
-              key={value}
-              role="listitem"
-              onClick={handleToggle(value)}
-            >
-              <ListItemIcon>
-                <Checkbox
-                  checked={checked.includes(value)}
-                  tabIndex={-1}
-                  disableRipple
-                  slotProps={{
-                    input: { 'aria-labelledby': labelId },
-                  }}
-                />
-              </ListItemIcon>
-              <ListItemText id={labelId} primary={`List item ${value + 1}`} />
-            </ListItemButton>
-          );
-        })}
-      </List>
-    </Paper>
-  );
 
   return (
     <Grid
@@ -96,7 +119,12 @@ export default function TransferList() {
       spacing={2}
       sx={{ justifyContent: 'center', alignItems: 'center' }}
     >
-      <Grid>{customList(left)}</Grid>
+      <CustomList
+        ref={leftListRef}
+        items={left}
+        checked={checked}
+        handleToggle={handleToggle}
+      />
       <Stack>
         <Button
           sx={{ my: 0.5 }}
@@ -139,7 +167,12 @@ export default function TransferList() {
           ≪
         </Button>
       </Stack>
-      <Grid>{customList(right)}</Grid>
+      <CustomList
+        ref={rightListRef}
+        items={right}
+        checked={checked}
+        handleToggle={handleToggle}
+      />
     </Grid>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `TransferList` examples could use some refresh.

- use `MenuList` instead of `List` to make use of the roving tabindex strategy.
- fix the lost focus after clicking any of the transfer buttons, now focus is managed to the list receiving the items.
- remove the "checked" status of the items we move through "transfer all", aligning the behavior with "transfer checked"
- make the select all checkbox small to visually align with the others, also reduce the vertical padding of its card header
- extract the custom list into separate components.

Preview: https://deploy-preview-48845--material-ui.netlify.app/material-ui/react-transfer-list/
