### PR TITLE
[togglebuttongroup] Add roving tabindex keyboard navigation

### DIFF
--- a/docs/data/material/components/toggle-button/toggle-button.md
+++ b/docs/data/material/components/toggle-button/toggle-button.md
@@ -101,4 +101,8 @@ The demos below show how to adjust spacing between toggle buttons in horizontal 
 
 ### Keyboard
 
-At present, toggle buttons are in DOM order. Navigate between them with the tab key. The button behavior follows standard keyboard semantics.
+The group uses a single tab stop.
+Use the left and right arrow keys to move focus in a horizontal group, or the up and down arrow keys in a vertical group.
+The <kbd>Home</kbd> and <kbd>End</kbd> keys move focus to the first and last enabled buttons.
+Focus movement wraps, skips disabled buttons, and does not change the selected value.
+Press <kbd>Space</kbd> or <kbd>Enter</kbd> to toggle the focused button.

--- a/packages-internal/api-docs-builder-core/materialUi/projectSettings.ts
+++ b/packages-internal/api-docs-builder-core/materialUi/projectSettings.ts
@@ -38,7 +38,10 @@ export const projectSettings: ProjectSettings = {
   getComponentInfo: getMaterialUiComponentInfo,
   translationLanguages: LANGUAGES,
   skipComponent(filename: string) {
-    return filename.match(/(ThemeProvider|CssVarsProvider|DefaultPropsProvider|RovingToggleButton)/) !== null;
+    return (
+      filename.match(/(ThemeProvider|CssVarsProvider|DefaultPropsProvider|RovingToggleButton)/) !==
+      null
+    );
   },
   translationPagesDirectory: 'docs/translations/api-docs',
   generateClassName,

--- a/packages-internal/api-docs-builder-core/materialUi/projectSettings.ts
+++ b/packages-internal/api-docs-builder-core/materialUi/projectSettings.ts
@@ -38,7 +38,7 @@ export const projectSettings: ProjectSettings = {
   getComponentInfo: getMaterialUiComponentInfo,
   translationLanguages: LANGUAGES,
   skipComponent(filename: string) {
-    return filename.match(/(ThemeProvider|CssVarsProvider|DefaultPropsProvider)/) !== null;
+    return filename.match(/(ThemeProvider|CssVarsProvider|DefaultPropsProvider|RovingToggleButton)/) !== null;
   },
   translationPagesDirectory: 'docs/translations/api-docs',
   generateClassName,

--- a/packages/mui-material/src/MenuList/MenuList.js
+++ b/packages/mui-material/src/MenuList/MenuList.js
@@ -218,7 +218,7 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
     [focusInitialTarget],
   );
 
-  const rovingContainerProps = getContainerProps({ onFocus: other.onFocus });
+  const rovingContainerProps = getContainerProps(undefined, other.onFocus);
   const handleRef = useForkRef(listRef, rovingContainerProps.ref, ref);
   const menuListContextValue = React.useMemo(
     () => ({

--- a/packages/mui-material/src/MenuList/MenuList.js
+++ b/packages/mui-material/src/MenuList/MenuList.js
@@ -339,6 +339,10 @@ MenuList.propTypes /* remove-proptypes */ = {
   /**
    * @ignore
    */
+  onFocus: PropTypes.func,
+  /**
+   * @ignore
+   */
   onKeyDown: PropTypes.func,
   /**
    * The variant to use. Use `menu` to prevent selected items from impacting the initial focus

--- a/packages/mui-material/src/MenuList/MenuList.js
+++ b/packages/mui-material/src/MenuList/MenuList.js
@@ -218,7 +218,7 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
     [focusInitialTarget],
   );
 
-  const rovingContainerProps = getContainerProps();
+  const rovingContainerProps = getContainerProps({ onFocus: other.onFocus });
   const handleRef = useForkRef(listRef, rovingContainerProps.ref, ref);
   const menuListContextValue = React.useMemo(
     () => ({
@@ -289,9 +289,9 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
       ref={handleRef}
       className={className}
       onKeyDown={handleKeyDown}
-      onFocus={rovingContainerProps.onFocus}
       tabIndex={-1}
       {...other}
+      onFocus={rovingContainerProps.onFocus}
     >
       <MenuListContext.Provider value={menuListContextValue}>
         <RovingTabIndexContext.Provider value={rovingContainer}>

--- a/packages/mui-material/src/MenuList/MenuList.test.js
+++ b/packages/mui-material/src/MenuList/MenuList.test.js
@@ -266,5 +266,32 @@ describe('<MenuList />', () => {
       expect(tabElements[0]).to.have.attribute('tabIndex', '0');
       expect(tabElements[1]).to.have.attribute('tabIndex', '-1');
     });
+
+    it('should compose the onFocus and onKeyDown props', async () => {
+      const onFocusSpy = spy();
+      const onKeyDownSpy = spy();
+      const { user } = render(
+        <MenuList onFocus={onFocusSpy} onKeyDown={onKeyDownSpy}>
+          <MenuItem>one</MenuItem>
+          <Divider />
+          <MenuItem>two</MenuItem>
+        </MenuList>,
+      );
+
+      await user.tab();
+      expect(screen.getByRole('menuitem', { name: 'one' })).toHaveFocus();
+
+      expect(onFocusSpy.callCount).to.equal(1);
+
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('menuitem', { name: 'two' })).toHaveFocus();
+
+      expect(onKeyDownSpy.callCount).to.equal(1);
+
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('menuitem', { name: 'one' })).toHaveFocus();
+
+      expect(onKeyDownSpy.callCount).to.equal(2);
+    });
   });
 });

--- a/packages/mui-material/src/Stepper/Stepper.js
+++ b/packages/mui-material/src/Stepper/Stepper.js
@@ -85,7 +85,11 @@ function RovingStepper(props) {
     orientation,
     isRtl,
   });
-  const rovingContainerProps = rovingContainer.getContainerProps(forwardedRef);
+  const rovingContainerProps = rovingContainer.getContainerProps({
+    ref: forwardedRef,
+    onKeyDown: other.onKeyDown,
+    onFocus: other.onFocus,
+  });
 
   return (
     <RovingTabIndexContext.Provider value={rovingContainer}>
@@ -95,8 +99,8 @@ function RovingStepper(props) {
         className={className}
         role="tablist"
         aria-orientation={orientation}
-        {...rovingContainerProps}
         {...other}
+        {...rovingContainerProps}
       >
         {children}
       </StepperRoot>

--- a/packages/mui-material/src/Stepper/Stepper.js
+++ b/packages/mui-material/src/Stepper/Stepper.js
@@ -85,11 +85,11 @@ function RovingStepper(props) {
     orientation,
     isRtl,
   });
-  const rovingContainerProps = rovingContainer.getContainerProps({
-    ref: forwardedRef,
-    onKeyDown: other.onKeyDown,
-    onFocus: other.onFocus,
-  });
+  const rovingContainerProps = rovingContainer.getContainerProps(
+    forwardedRef,
+    other.onFocus,
+    other.onKeyDown,
+  );
 
   return (
     <RovingTabIndexContext.Provider value={rovingContainer}>

--- a/packages/mui-material/src/Stepper/Stepper.test.tsx
+++ b/packages/mui-material/src/Stepper/Stepper.test.tsx
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Step, { StepProps, stepClasses } from '@mui/material/Step';
@@ -469,6 +470,32 @@ describe('<Stepper />', () => {
       await user.click(tabElements[0]);
       expect(tabElements[0]).to.have.attribute('tabIndex', '0');
       expect(tabElements[1]).to.have.attribute('tabIndex', '-1');
+    });
+
+    it('should compose the onFocus and onKeyDown handlers', async () => {
+      const onFocusSpy = spy();
+      const onKeyDownSpy = spy();
+
+      const { user } = render(
+        <Stepper nonLinear>
+          <Step>
+            <StepButton onFocus={onFocusSpy} onKeyDown={onKeyDownSpy}>
+              one
+            </StepButton>
+          </Step>
+          <Step>
+            <StepButton>two</StepButton>
+          </Step>
+        </Stepper>,
+      );
+
+      const tabElements = screen.getAllByRole('tab');
+
+      await user.click(tabElements[0]);
+      expect(onFocusSpy.callCount).to.equal(1);
+
+      await user.keyboard('{ArrowRight}');
+      expect(onKeyDownSpy.callCount).to.equal(1);
     });
   });
 });

--- a/packages/mui-material/src/ToggleButton/RovingToggleButton.tsx
+++ b/packages/mui-material/src/ToggleButton/RovingToggleButton.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
-import useId from '../utils/useId';
-import { useRovingTabIndexItem } from '../utils/useRovingTabIndex';
+import { useRovingTabIndexContext, useRovingTabIndexItem } from '../utils/useRovingTabIndex';
 
 interface RovingToggleButtonChildProps {
   ref?: React.Ref<HTMLElement> | undefined;
@@ -12,21 +11,29 @@ interface RovingToggleButtonProps {
   children: React.ReactElement<RovingToggleButtonChildProps>;
   disabled?: boolean | undefined;
   selected?: boolean | undefined;
+  value: unknown;
 }
 
 function RovingToggleButton(props: RovingToggleButtonProps, ref: React.ForwardedRef<HTMLElement>) {
-  const { children, disabled = false, selected = false } = props;
-  const id = useId();
+  const { children, disabled = false, selected = false, value } = props;
+  const rovingContext = useRovingTabIndexContext();
   const rovingItemProps = useRovingTabIndexItem({
-    id,
+    id: value,
     ref,
     disabled,
     selected,
   });
 
+  // On the server, and on the first client render before registration effects run,
+  // the roving item map is still empty. In that window, fall back to `tabIndex={0}`
+  // for the selected toggle button so the rendered markup is immediately keyboard-accessible
+  // and hydration stays consistent until item registration takes over.
+  const shouldUseSelectedTabStopFallback = rovingContext.getItemMap().size === 0 && selected;
+  const tabIndex = shouldUseSelectedTabStopFallback ? 0 : rovingItemProps.tabIndex;
+
   return React.cloneElement(React.Children.only(children), {
     ...rovingItemProps,
-    tabIndex: children.props.tabIndex ?? rovingItemProps.tabIndex,
+    tabIndex: children.props.tabIndex ?? tabIndex,
   });
 }
 

--- a/packages/mui-material/src/ToggleButton/RovingToggleButton.tsx
+++ b/packages/mui-material/src/ToggleButton/RovingToggleButton.tsx
@@ -1,0 +1,33 @@
+'use client';
+import * as React from 'react';
+import useId from '../utils/useId';
+import { useRovingTabIndexItem } from '../utils/useRovingTabIndex';
+
+interface RovingToggleButtonChildProps {
+  ref?: React.Ref<HTMLElement> | undefined;
+  tabIndex?: number | undefined;
+}
+
+interface RovingToggleButtonProps {
+  children: React.ReactElement<RovingToggleButtonChildProps>;
+  disabled?: boolean | undefined;
+  selected?: boolean | undefined;
+}
+
+function RovingToggleButton(props: RovingToggleButtonProps, ref: React.ForwardedRef<HTMLElement>) {
+  const { children, disabled = false, selected = false } = props;
+  const id = useId();
+  const rovingItemProps = useRovingTabIndexItem({
+    id,
+    ref,
+    disabled,
+    selected,
+  });
+
+  return React.cloneElement(React.Children.only(children), {
+    ...rovingItemProps,
+    tabIndex: children.props.tabIndex ?? rovingItemProps.tabIndex,
+  });
+}
+
+export default React.forwardRef(RovingToggleButton);

--- a/packages/mui-material/src/ToggleButton/ToggleButton.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.js
@@ -15,6 +15,7 @@ import toggleButtonClasses, { getToggleButtonUtilityClass } from './toggleButton
 import ToggleButtonGroupContext from '../ToggleButtonGroup/ToggleButtonGroupContext';
 import ToggleButtonGroupButtonContext from '../ToggleButtonGroup/ToggleButtonGroupButtonContext';
 import isValueSelected from '../ToggleButtonGroup/isValueSelected';
+import RovingToggleButton from './RovingToggleButton';
 
 const useUtilityClasses = (ownerState) => {
   const { classes, fullWidth, selected, disabled, size, color } = ownerState;
@@ -142,7 +143,11 @@ const ToggleButtonRoot = styled(ButtonBase, {
 
 const ToggleButton = React.forwardRef(function ToggleButton(inProps, ref) {
   // props priority: `inProps` > `contextProps` > `themeDefaultProps`
-  const { value: contextValue, ...contextProps } = React.useContext(ToggleButtonGroupContext);
+  const {
+    value: contextValue,
+    isRovingTabIndex,
+    ...contextProps
+  } = React.useContext(ToggleButtonGroupContext);
   const toggleButtonGroupButtonContextPositionClassName = React.useContext(
     ToggleButtonGroupButtonContext,
   );
@@ -191,14 +196,13 @@ const ToggleButton = React.forwardRef(function ToggleButton(inProps, ref) {
   };
 
   const positionClassName = toggleButtonGroupButtonContextPositionClassName || '';
-
-  return (
+  const button = (
     <ToggleButtonRoot
       className={clsx(contextProps.className, classes.root, className, positionClassName)}
       internalNativeButton
       disabled={disabled}
       focusRipple={!disableFocusRipple}
-      ref={ref}
+      ref={isRovingTabIndex ? undefined : ref}
       onClick={handleChange}
       onChange={onChange}
       value={value}
@@ -209,6 +213,16 @@ const ToggleButton = React.forwardRef(function ToggleButton(inProps, ref) {
       {children}
     </ToggleButtonRoot>
   );
+
+  if (isRovingTabIndex) {
+    return (
+      <RovingToggleButton disabled={disabled} selected={selected} ref={ref}>
+        {button}
+      </RovingToggleButton>
+    );
+  }
+
+  return button;
 });
 
 ToggleButton.propTypes /* remove-proptypes */ = {

--- a/packages/mui-material/src/ToggleButton/ToggleButton.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.js
@@ -216,7 +216,7 @@ const ToggleButton = React.forwardRef(function ToggleButton(inProps, ref) {
 
   if (isRovingTabIndex) {
     return (
-      <RovingToggleButton disabled={disabled} selected={selected} ref={ref}>
+      <RovingToggleButton disabled={disabled} selected={selected} ref={ref} value={value}>
         {button}
       </RovingToggleButton>
     );

--- a/packages/mui-material/src/ToggleButton/ToggleButton.test.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.test.js
@@ -53,6 +53,12 @@ describe('<ToggleButton />', () => {
     expect(screen.getByRole('button')).to.have.property('disabled', true);
   });
 
+  it('should remain in the tab order when rendered standalone', () => {
+    render(<ToggleButton value="hello">Hello World</ToggleButton>);
+
+    expect(screen.getByRole('button')).to.have.property('tabIndex', 0);
+  });
+
   it('can render a small button', () => {
     render(
       <ToggleButton data-testid="root" size="small" value="hello">

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -319,6 +319,14 @@ ToggleButtonGroup.propTypes /* remove-proptypes */ = {
    */
   onChange: PropTypes.func,
   /**
+   * @ignore
+   */
+  onFocus: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onKeyDown: PropTypes.func,
+  /**
    * The component orientation (layout flow direction).
    * @default 'horizontal'
    */

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -5,9 +5,11 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import getValidReactChildren from '@mui/utils/getValidReactChildren';
+import { useRtl } from '@mui/system/RtlProvider';
 import { styled } from '../zero-styled';
 import memoTheme from '../utils/memoTheme';
 import { useDefaultProps } from '../DefaultPropsProvider';
+import { useRovingTabIndexRoot, RovingTabIndexContext } from '../utils/useRovingTabIndex';
 import toggleButtonGroupClasses, {
   getToggleButtonGroupUtilityClass,
 } from './toggleButtonGroupClasses';
@@ -140,6 +142,7 @@ const ToggleButtonGroup = React.forwardRef(function ToggleButtonGroup(inProps, r
   } = props;
   const ownerState = { ...props, disabled, fullWidth, orientation, size };
   const classes = useUtilityClasses(ownerState);
+  const isRtl = useRtl();
 
   const handleChange = React.useCallback(
     (event, buttonValue) => {
@@ -182,6 +185,7 @@ const ToggleButtonGroup = React.forwardRef(function ToggleButtonGroup(inProps, r
       fullWidth,
       color,
       disabled,
+      isRovingTabIndex: true,
     }),
     [
       classes.grouped,
@@ -215,37 +219,50 @@ const ToggleButtonGroup = React.forwardRef(function ToggleButtonGroup(inProps, r
     return classes.middleButton;
   };
 
+  const rovingTabIndexRoot = useRovingTabIndexRoot({
+    orientation,
+    isRtl,
+  });
+
+  const rovingContainerProps = rovingTabIndexRoot.getContainerProps({
+    ref,
+    onFocus: other.onFocus,
+    onKeyDown: other.onKeyDown,
+  });
+
   return (
     <ToggleButtonGroupRoot
       role="group"
       className={clsx(classes.root, className)}
-      ref={ref}
       ownerState={ownerState}
       {...other}
+      {...rovingContainerProps}
     >
-      <ToggleButtonGroupContext.Provider value={context}>
-        {validChildren.map((child, index) => {
-          if (process.env.NODE_ENV !== 'production') {
-            if (isFragment(child)) {
-              console.error(
-                [
-                  "MUI: The ToggleButtonGroup component doesn't accept a Fragment as a child.",
-                  'Consider providing an array instead.',
-                ].join('\n'),
-              );
+      <RovingTabIndexContext.Provider value={rovingTabIndexRoot}>
+        <ToggleButtonGroupContext.Provider value={context}>
+          {validChildren.map((child, index) => {
+            if (process.env.NODE_ENV !== 'production') {
+              if (isFragment(child)) {
+                console.error(
+                  [
+                    "MUI: The ToggleButtonGroup component doesn't accept a Fragment as a child.",
+                    'Consider providing an array instead.',
+                  ].join('\n'),
+                );
+              }
             }
-          }
 
-          return (
-            <ToggleButtonGroupButtonContext.Provider
-              key={index}
-              value={getButtonPositionClassName(index)}
-            >
-              {child}
-            </ToggleButtonGroupButtonContext.Provider>
-          );
-        })}
-      </ToggleButtonGroupContext.Provider>
+            return (
+              <ToggleButtonGroupButtonContext.Provider
+                key={index}
+                value={getButtonPositionClassName(index)}
+              >
+                {child}
+              </ToggleButtonGroupButtonContext.Provider>
+            );
+          })}
+        </ToggleButtonGroupContext.Provider>
+      </RovingTabIndexContext.Provider>
     </ToggleButtonGroupRoot>
   );
 });

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -224,11 +224,11 @@ const ToggleButtonGroup = React.forwardRef(function ToggleButtonGroup(inProps, r
     isRtl,
   });
 
-  const rovingContainerProps = rovingTabIndexRoot.getContainerProps({
+  const rovingContainerProps = rovingTabIndexRoot.getContainerProps(
     ref,
-    onFocus: other.onFocus,
-    onKeyDown: other.onKeyDown,
-  });
+    other.onFocus,
+    other.onKeyDown,
+  );
 
   return (
     <ToggleButtonGroupRoot

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -61,6 +61,129 @@ describe('<ToggleButtonGroup />', () => {
     expect(secondButton).to.have.property('disabled', true);
   });
 
+  describe('keyboard navigation', () => {
+    it('should have one tab stop and skip disabled buttons', () => {
+      render(
+        <ToggleButtonGroup>
+          <ToggleButton value="one" disabled>
+            One
+          </ToggleButton>
+          <ToggleButton value="two">Two</ToggleButton>
+          <ToggleButton value="three">Three</ToggleButton>
+        </ToggleButtonGroup>,
+      );
+
+      expect(screen.getAllByRole('button').map((button) => button.tabIndex)).to.deep.equal([
+        -1, 0, -1,
+      ]);
+    });
+
+    it('should navigate horizontally and wrap focus', async () => {
+      const { user } = render(
+        <ToggleButtonGroup>
+          <ToggleButton value="one">One</ToggleButton>
+          <ToggleButton value="two" disabled>
+            Two
+          </ToggleButton>
+          <ToggleButton value="three">Three</ToggleButton>
+        </ToggleButtonGroup>,
+      );
+      const [firstButton, , thirdButton] = screen.getAllByRole('button');
+
+      await user.tab();
+      expect(firstButton).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(thirdButton).toHaveFocus();
+      expect(thirdButton).to.have.property('tabIndex', 0);
+      expect(firstButton).to.have.property('tabIndex', -1);
+
+      await user.keyboard('{ArrowRight}');
+      expect(firstButton).toHaveFocus();
+
+      await user.keyboard('{ArrowLeft}');
+      expect(thirdButton).toHaveFocus();
+    });
+
+    it('should navigate vertically and support Home and End', async () => {
+      const { user } = render(
+        <ToggleButtonGroup orientation="vertical">
+          <ToggleButton value="one">One</ToggleButton>
+          <ToggleButton value="two">Two</ToggleButton>
+          <ToggleButton value="three">Three</ToggleButton>
+        </ToggleButtonGroup>,
+      );
+      const [firstButton, secondButton, thirdButton] = screen.getAllByRole('button');
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(secondButton).toHaveFocus();
+
+      await user.keyboard('{End}');
+      expect(thirdButton).toHaveFocus();
+
+      await user.keyboard('{Home}');
+      expect(firstButton).toHaveFocus();
+
+      await user.keyboard('{ArrowUp}');
+      expect(thirdButton).toHaveFocus();
+    });
+
+    it('should move focus without changing the selected value', async () => {
+      const handleChange = spy();
+      const { user } = render(
+        <ToggleButtonGroup exclusive value="one" onChange={handleChange}>
+          <ToggleButton value="one">One</ToggleButton>
+          <ToggleButton value="two">Two</ToggleButton>
+        </ToggleButtonGroup>,
+      );
+
+      await user.tab();
+      await user.keyboard('{ArrowRight}');
+
+      expect(screen.getAllByRole('button')[1]).toHaveFocus();
+      expect(handleChange.callCount).to.equal(0);
+    });
+
+    it('should support wrapped ToggleButton children', async () => {
+      const { user } = render(
+        <ToggleButtonGroup>
+          <Tooltip title="One">
+            <ToggleButton value="one">One</ToggleButton>
+          </Tooltip>
+          <Tooltip title="Two">
+            <ToggleButton value="two">Two</ToggleButton>
+          </Tooltip>
+        </ToggleButtonGroup>,
+      );
+      const [firstButton, secondButton] = screen.getAllByRole('button');
+
+      await user.tab();
+      expect(firstButton).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(secondButton).toHaveFocus();
+    });
+
+    it('should call root event handlers without disabling roving focus', async () => {
+      const handleFocus = spy();
+      const handleKeyDown = spy();
+      const { user } = render(
+        <ToggleButtonGroup onFocus={handleFocus} onKeyDown={handleKeyDown}>
+          <ToggleButton value="one">One</ToggleButton>
+          <ToggleButton value="two">Two</ToggleButton>
+        </ToggleButtonGroup>,
+      );
+
+      await user.tab();
+      await user.keyboard('{ArrowRight}');
+
+      expect(screen.getAllByRole('button')[1]).toHaveFocus();
+      expect(handleFocus.callCount).to.be.greaterThan(0);
+      expect(handleKeyDown.callCount).to.equal(1);
+    });
+  });
+
   describe('exclusive', () => {
     it('should render a selected ToggleButton if value is selected', () => {
       render(

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -1,3 +1,4 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createRenderer, screen } from '@mui/internal-test-utils';
@@ -103,6 +104,32 @@ describe('<ToggleButtonGroup />', () => {
 
       await user.keyboard('{ArrowLeft}');
       expect(thirdButton).toHaveFocus();
+    });
+
+    it('should swap direction when RTL is applied', async () => {
+      const rtlTheme = createTheme({ direction: 'rtl' });
+      const { user } = render(
+        <ThemeProvider theme={rtlTheme}>
+          <ToggleButtonGroup>
+            <ToggleButton value="one">One</ToggleButton>
+            <ToggleButton value="two">Two</ToggleButton>
+            <ToggleButton value="three">Three</ToggleButton>
+          </ToggleButtonGroup>
+        </ThemeProvider>,
+      );
+      const [firstButton, secondButton, thirdButton] = screen.getAllByRole('button');
+
+      await user.tab();
+      expect(firstButton).toHaveFocus();
+
+      await user.keyboard('{ArrowLeft}');
+      expect(secondButton).toHaveFocus();
+
+      await user.keyboard('{ArrowLeft}');
+      expect(thirdButton).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(secondButton).toHaveFocus();
     });
 
     it('should navigate vertically and support Home and End', async () => {

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroupContext.ts
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroupContext.ts
@@ -10,6 +10,7 @@ interface ToggleButtonGroupContextType {
   fullWidth?: ToggleButtonGroupProps['fullWidth'] | undefined;
   color?: ToggleButtonGroupProps['color'] | undefined;
   disabled?: ToggleButtonGroupProps['disabled'] | undefined;
+  isRovingTabIndex?: boolean | undefined;
 }
 
 /**

--- a/packages/mui-utils/src/useRovingTabIndex/useRovingTabIndex.test.tsx
+++ b/packages/mui-utils/src/useRovingTabIndex/useRovingTabIndex.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import {
   type UseRovingTabIndexParams,
@@ -58,9 +59,18 @@ function TestComponent(
   props: Partial<UseRovingTabIndexParams<string>> & {
     items?: TestItem[];
     buttonRef?: React.Ref<HTMLButtonElement>;
+    onKeyDown?: React.KeyboardEventHandler;
+    onFocus?: React.FocusEventHandler;
   },
 ) {
-  const { items = defaultItems, buttonRef, orientation = 'horizontal', ...options } = props;
+  const {
+    items = defaultItems,
+    buttonRef,
+    orientation = 'horizontal',
+    onKeyDown,
+    onFocus,
+    ...options
+  } = props;
   const rootParams: UseRovingTabIndexParams<string> = {
     ...(options as Omit<UseRovingTabIndexParams<string>, 'orientation'>),
     orientation,
@@ -73,7 +83,11 @@ function TestComponent(
 
   return (
     <RovingTabIndexContext.Provider value={root as UseRovingTabIndexReturnValue<unknown>}>
-      <div data-testid="container" tabIndex={-1} {...root.getContainerProps()}>
+      <div
+        data-testid="container"
+        tabIndex={-1}
+        {...root.getContainerProps({ onFocus, onKeyDown })}
+      >
         {items
           .filter((item) => item.render !== false)
           .map((item) => (
@@ -468,5 +482,66 @@ describe('useRovingTabIndexRoot + useRovingTabIndexItem', () => {
 
     await user.keyboard('{ArrowRight}');
     expect(screen.getByTestId('button-3')).toHaveFocus();
+  });
+
+  test("composes with a user's onFocus and onKeyDown handlers", async () => {
+    const onFocusSpy = spy();
+    const onKeyDownSpy = spy();
+
+    const { user } = render(<TestComponent onFocus={onFocusSpy} onKeyDown={onKeyDownSpy} />);
+
+    await user.click(screen.getByTestId('button-1'));
+
+    expect(onFocusSpy.callCount).to.equal(1);
+
+    await user.keyboard('{ArrowRight}');
+    expect(screen.getByTestId('button-2')).toHaveFocus();
+
+    expect(onKeyDownSpy.callCount).to.equal(1);
+  });
+
+  test('runs the onFocus and onKeyDown handlers even when the event is prevented', async () => {
+    const onFocusSpy = spy();
+    const onKeyDownSpy = spy();
+
+    const { user } = render(
+      <TestComponent
+        onFocus={(event) => {
+          event.preventDefault();
+          onFocusSpy();
+        }}
+        onKeyDown={(event) => {
+          event.preventDefault();
+          onKeyDownSpy();
+        }}
+      />,
+    );
+
+    await user.click(screen.getByTestId('button-1'));
+
+    expect(onFocusSpy.callCount).to.equal(1);
+
+    await user.keyboard('{ArrowRight}');
+    expect(screen.getByTestId('button-1')).toHaveFocus();
+
+    expect(onKeyDownSpy.callCount).to.equal(1);
+  });
+
+  test('runs consumer onKeyDown even without arrow key navigation', async () => {
+    const onKeyDownSpy = spy();
+
+    const { user } = render(
+      <TestComponent
+        onKeyDown={(event) => {
+          event.preventDefault();
+          onKeyDownSpy();
+        }}
+      />,
+    );
+
+    await user.click(screen.getByTestId('button-1'));
+
+    await user.keyboard('{Enter}');
+    expect(onKeyDownSpy.callCount).to.equal(1);
   });
 });

--- a/packages/mui-utils/src/useRovingTabIndex/useRovingTabIndex.test.tsx
+++ b/packages/mui-utils/src/useRovingTabIndex/useRovingTabIndex.test.tsx
@@ -86,7 +86,7 @@ function TestComponent(
       <div
         data-testid="container"
         tabIndex={-1}
-        {...root.getContainerProps({ onFocus, onKeyDown })}
+        {...root.getContainerProps(undefined, onFocus, onKeyDown)}
       >
         {items
           .filter((item) => item.render !== false)

--- a/packages/mui-utils/src/useRovingTabIndex/useRovingTabIndex.ts
+++ b/packages/mui-utils/src/useRovingTabIndex/useRovingTabIndex.ts
@@ -9,12 +9,6 @@ import useEventCallback from '../useEventCallback';
 import useForkRef from '../useForkRef';
 import { useRovingTabIndexContext } from './RovingTabIndexContext';
 
-type GetContainerPropsParams = {
-  ref?: React.Ref<HTMLElement> | undefined;
-  onFocus?: ((event: React.FocusEvent<HTMLElement>) => void) | undefined;
-  onKeyDown?: ((event: React.KeyboardEvent<HTMLElement>) => void) | undefined;
-};
-
 export interface Item<Key = unknown> {
   /**
    * The logical id used to track the item across reorders and re-renders.
@@ -109,7 +103,11 @@ export interface UseRovingTabIndexReturnValue<Key = unknown> {
    * Spread these props onto the list or composite root element that should listen for focus
    * and keyboard events.
    */
-  getContainerProps: (params?: GetContainerPropsParams) => {
+  getContainerProps: (
+    ref?: React.Ref<HTMLElement> | undefined,
+    onFocus?: ((event: React.FocusEvent<HTMLElement>) => void) | undefined,
+    onKeyDown?: ((event: React.KeyboardEvent<HTMLElement>) => void) | undefined,
+  ) => {
     /**
      * Keeps the active item in sync when focus moves onto one of the registered items.
      */
@@ -319,9 +317,13 @@ export function useRovingTabIndexRoot<Key = unknown>(
   );
 
   const getContainerProps = React.useCallback(
-    (params?: GetContainerPropsParams) => {
+    (
+      ref: React.Ref<HTMLElement> | undefined,
+      onFocusProp?: (event: React.FocusEvent<HTMLElement>) => void,
+      onKeyDownProp?: (event: React.KeyboardEvent<HTMLElement>) => void,
+    ) => {
       const onFocus = (event: React.FocusEvent<HTMLElement>) => {
-        params?.onFocus?.(event);
+        onFocusProp?.(event);
 
         const snapshot = getNavigableItemsSnapshot(itemMapRef.current);
         const focusedIndex = findItemIndexByElement(snapshot, event.target);
@@ -332,7 +334,7 @@ export function useRovingTabIndexRoot<Key = unknown>(
       };
 
       const onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
-        params?.onKeyDown?.(event);
+        onKeyDownProp?.(event);
 
         if (
           event.defaultPrevented ||
@@ -402,7 +404,7 @@ export function useRovingTabIndexRoot<Key = unknown>(
       return {
         onFocus,
         onKeyDown,
-        ref: handleRefs(params?.ref, (elementNode) => {
+        ref: handleRefs(ref, (elementNode) => {
           containerRef.current = elementNode;
         }),
       };

--- a/packages/mui-utils/src/useRovingTabIndex/useRovingTabIndex.ts
+++ b/packages/mui-utils/src/useRovingTabIndex/useRovingTabIndex.ts
@@ -9,6 +9,12 @@ import useEventCallback from '../useEventCallback';
 import useForkRef from '../useForkRef';
 import { useRovingTabIndexContext } from './RovingTabIndexContext';
 
+type GetContainerPropsParams = {
+  ref?: React.Ref<HTMLElement> | undefined;
+  onFocus?: ((event: React.FocusEvent<HTMLElement>) => void) | undefined;
+  onKeyDown?: ((event: React.KeyboardEvent<HTMLElement>) => void) | undefined;
+};
+
 export interface Item<Key = unknown> {
   /**
    * The logical id used to track the item across reorders and re-renders.
@@ -103,7 +109,7 @@ export interface UseRovingTabIndexReturnValue<Key = unknown> {
    * Spread these props onto the list or composite root element that should listen for focus
    * and keyboard events.
    */
-  getContainerProps: (ref?: React.Ref<HTMLElement>) => {
+  getContainerProps: (params?: GetContainerPropsParams) => {
     /**
      * Keeps the active item in sync when focus moves onto one of the registered items.
      */
@@ -313,8 +319,10 @@ export function useRovingTabIndexRoot<Key = unknown>(
   );
 
   const getContainerProps = React.useCallback(
-    (ref?: React.Ref<HTMLElement>) => {
+    (params?: GetContainerPropsParams) => {
       const onFocus = (event: React.FocusEvent<HTMLElement>) => {
+        params?.onFocus?.(event);
+
         const snapshot = getNavigableItemsSnapshot(itemMapRef.current);
         const focusedIndex = findItemIndexByElement(snapshot, event.target);
 
@@ -324,7 +332,15 @@ export function useRovingTabIndexRoot<Key = unknown>(
       };
 
       const onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
-        if (event.altKey || event.shiftKey || event.ctrlKey || event.metaKey) {
+        params?.onKeyDown?.(event);
+
+        if (
+          event.defaultPrevented ||
+          event.altKey ||
+          event.shiftKey ||
+          event.ctrlKey ||
+          event.metaKey
+        ) {
           return;
         }
 
@@ -386,7 +402,7 @@ export function useRovingTabIndexRoot<Key = unknown>(
       return {
         onFocus,
         onKeyDown,
-        ref: handleRefs(ref, (elementNode) => {
+        ref: handleRefs(params?.ref, (elementNode) => {
           containerRef.current = elementNode;
         }),
       };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/17281.

## Changes

- Add roving tabindex behavior to `ToggleButtonGroup`.
  - Arrow-key navigation respects orientation and RTL.
  - `Home`/`End` navigation, wrapping, and disabled-item skipping.
  - Focus movement does not change selection.
- Keep standalone `ToggleButton` behavior unchanged.
- Add an internal `RovingToggleButton` wrapper to register grouped buttons and forward refs/tabindex.
- Compose consumer focus and keyboard handlers with internal roving behavior; consumers can prevent internal navigation.
- Update `MenuList` and `Stepper` for the revised container-props API.
- Add keyboard-navigation regression tests and update the Toggle Button keyboard documentation.

## Validation

- Focused `ToggleButton`, `ToggleButtonGroup`, `MenuList`, `Stepper`, and roving-tabindex tests.
- Check ToggleButton docs examples, click / tab to any of them, use Arrow Keys and Home / End for navigation, also check disabled items are skipped.