### PR TITLE
[docs] Fix redirect loop on the Design Kits page

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -514,7 +514,7 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /material-ui/experimental-api/css-theme-variables/usage/ /material-ui/customization/css-theme-variables/usage/ 301
 /material-ui/experimental-api/css-theme-variables/customization/ /material-ui/customization/css-theme-variables/configuration/ 301
 /base-ui/ https://base-ui.com/ 301
-/material-ui/discover-more/design-kits/ /material-ui/discover-more/design-kits/ 301
+/material-ui/discover-more/design-kits/ /design-kits/ 301
 /material-ui/api/loading-button/ https://v5.mui.com/material-ui/api/loading-button/ 301
 /material-ui/getting-started/templates/landing-page/ /material-ui/getting-started/templates/marketing-page/ 301
 # 2025

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -382,12 +382,11 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /joy-ui/customization/one-off-styling/ /joy-ui/customization/approaches/#one-off-customization 301
 /:lang/joy-ui/customization/theme-components/ /:lang/joy-ui/customization/themed-components/ 301
 /joy-ui/customization/theme-components/ /joy-ui/customization/themed-components/ 301
-/:lang/joy-ui/customization/theme-components/ /:lang/joy-ui/customization/themed-components/ 301
 /base/react-chip/ /material-ui/react-chip/ 301
 /system/api/ /system/properties/ 301
 /:lang/system/api/ /:lang/system/properties/ 301
 /joy-ui/core-features/global-variant/ /joy-ui/main-features/global-variants/ 301
-/:lang/joy-ui/core-features/global-variant/ /:langjoy-ui/main-features/global-variants/ 301
+/:lang/joy-ui/core-features/global-variant/ /:lang/joy-ui/main-features/global-variants/ 301
 /joy-ui/core-features/automatic-adjustment/ /joy-ui/main-features/automatic-adjustment/ 301
 /:lang/joy-ui/core-features/automatic-adjustment/ /:lang/joy-ui/main-features/automatic-adjustment/ 301
 /joy-ui/core-features/perfect-dark-mode/ /joy-ui/main-features/dark-mode-optimization/ 301
@@ -482,7 +481,6 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /base-ui/api/:component/ /base-ui/react-:component/components-api/#:component 301
 /joy-ui/customization/theme-tokens/ /joy-ui/customization/theme-colors/ 301
 /joy-ui/guides/apply-dark-mode/ /joy-ui/customization/dark-mode/ 301
-/material-ui/experimental-api/css-variables/ /material-ui/experimental-api/css-theme-variables/overview/ 301
 /material-ui/experimental-api/css-theme-variables/ /material-ui/experimental-api/css-theme-variables/overview/ 302
 /material-ui/getting-started/overview/ /material-ui/getting-started/ 301
 /joy-ui/getting-started/overview/ /joy-ui/getting-started/ 301


### PR DESCRIPTION
Spotted in Google Search Console: `/material-ui/discover-more/design-kits/` fails with `ERR_TOO_MANY_REDIRECTS`. The rule added in #48520 has its source as its own destination. Points it at `/design-kits/` instead.

While auditing the rest of the file I found the same class of bug once more: `/:langjoy-ui/` is missing a slash, so the token parses as `:langjoy` and the pt/zh Joy UI global-variant page 404s. Also drops two rules that duplicate an earlier source and therefore never fire.

I added an item in https://github.com/mui/mui-public/issues/983 to check redirects.