### PR TITLE
fix: the application fetches ad content from a third... in AdCarbon.tsx

### DIFF
--- a/packages-internal/core-docs/src/Ad/AdCarbon.tsx
+++ b/packages-internal/core-docs/src/Ad/AdCarbon.tsx
@@ -91,9 +91,17 @@ export function AdCarbonInline() {
 
         const data = await response.json();
         // Inspired by https://github.com/Semantic-Org/Semantic-UI-React/blob/2c7134128925dd831de85011e3eb0ec382ba7f73/docs/src/components/CarbonAd/CarbonAdNative.js#L9
+        const isHttpsUrl = (url: string) => {
+          try {
+            return new URL(url).protocol === 'https:';
+          } catch {
+            return false;
+          }
+        };
         const sanitizedAd = data.ads
           .filter((item: any) => Object.keys(item).length > 0)
           .filter((item: any) => item.statlink)
+          .filter((item: any) => isHttpsUrl(item.statlink) && isHttpsUrl(item.image) && isHttpsUrl(item.statimp))
           .filter(Boolean)[0];
 
         if (!sanitizedAd) {


### PR DESCRIPTION
## Summary
Fix high severity security issue in `packages-internal/core-docs/src/Ad/AdCarbon.tsx`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `packages-internal/core-docs/src/Ad/AdCarbon.tsx:78` |
| **Assessment** | Likely exploitable |

**Description**: The application fetches ad content from a third-party service (buysellads.com) without integrity verification. The fetched JSON data is processed and rendered in the application, including URLs for images and links. If the third-party service is compromised or a MITM attack occurs, malicious content could be injected into the application.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `packages-internal/core-docs/src/Ad/AdCarbon.tsx`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
