### PR TITLE
[docs][menu] Fix stale `selected` prop reference in Selected menu section

### DIFF
--- a/docs/data/material/components/menus/menus.md
+++ b/docs/data/material/components/menus/menus.md
@@ -47,7 +47,7 @@ For the menu that has long list and long text, you can use the `dense` prop to r
 ## Selected menu
 
 If used for item selection, when opened, simple menus place the initial focus on the selected menu item.
-The currently selected menu item is set using the [`selected`](/material-ui/api/menu-item/#menu-item-prop-selected) prop.
+The currently selected menu item is set using the `selected` prop available on `MenuItem`.
 To use a selected menu item without impacting the initial focus, set the `variant` prop to "menu".
 
 {{"demo": "SimpleListMenu.js"}}

--- a/docs/data/material/components/menus/menus.md
+++ b/docs/data/material/components/menus/menus.md
@@ -46,8 +46,8 @@ For the menu that has long list and long text, you can use the `dense` prop to r
 
 ## Selected menu
 
-If used for item selection, when opened, simple menus places the initial focus on the selected menu item.
-The currently selected menu item is set using the `selected` prop (from [ListItem](/material-ui/api/list-item/)).
+If used for item selection, when opened, simple menus place the initial focus on the selected menu item.
+The currently selected menu item is set using the [`selected`](/material-ui/api/menu-item/#menu-item-prop-selected) prop.
 To use a selected menu item without impacting the initial focus, set the `variant` prop to "menu".
 
 {{"demo": "SimpleListMenu.js"}}


### PR DESCRIPTION
## Summary

The "Selected menu" section of the Menu docs attributes the `selected` prop to `ListItem`:

> The currently selected menu item is set using the `selected` prop (from [ListItem](https://mui.com/material-ui/api/list-item/)).

That is v4-era text and is wrong on two counts today:

- `selected` is `MenuItem`'s own prop. `MenuItem` extends `ButtonBase`, not `ListItem`.
- `ListItem` has no `selected` prop at all -- it moved to `ListItemButton` in v5. So the link sends readers to a page where the prop they were just told about does not exist.

This PR points the link at the MenuItem API instead, and fixes a subject-verb slip on the preceding line ("simple menus places" -> "simple menus place").

```diff
-If used for item selection, when opened, simple menus places the initial focus on the selected menu item.
-The currently selected menu item is set using the `selected` prop (from [ListItem](/material-ui/api/list-item/)).
+If used for item selection, when opened, simple menus place the initial focus on the selected menu item.
+The currently selected menu item is set using the [`selected`](/material-ui/api/menu-item/#menu-item-prop-selected) prop.
```

The rest of the section is accurate and untouched: `Menu`'s default `variant` is `selectedMenu`, so it does focus the selected item on open, and `variant="menu"` opts out.

Affected page: https://mui.com/material-ui/react-menu/#selected-menu
Updated page: https://deploy-preview-48879--material-ui.netlify.app/material-ui/react-menu/#selected-menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)