### PR TITLE
[docs] Document Grid direction column removal in v9 upgrade guide

### DIFF
--- a/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
+++ b/docs/data/material/migration/upgrade-to-v9/upgrade-to-v9.md
@@ -174,6 +174,33 @@ See the [Grid v2 migration guide](/material-ui/migration/upgrade-to-grid-v2/) fo
 
 `MuiGridLegacy` has also been removed from the theme `components` types (`ComponentsProps`, `ComponentsOverrides`, and `ComponentsVariants`).
 
+### Grid
+
+#### `direction="column"` and `direction="column-reverse"` removed
+
+The `Grid` component no longer accepts `direction="column"` or `direction="column-reverse"`.
+These values were unsupported in practice in earlier versions and are now removed from the TypeScript types and prop validation.
+
+`Grid` is designed to subdivide a layout into **columns**, not rows.
+For vertical stacking, use the [`Stack`](/material-ui/react-stack/) component instead (including inside a `Grid` item when needed).
+See the [Grid column direction limitation](/material-ui/react-grid/#column-direction) for details.
+
+```diff
+-import Grid from '@mui/material/Grid';
++import Stack from '@mui/material/Stack';
+
+-<Grid container direction="column" spacing={2}>
+-  <Grid size={12}>First item</Grid>
+-  <Grid size={12}>Second item</Grid>
+-</Grid>
++<Stack spacing={2}>
++  <div>First item</div>
++  <div>Second item</div>
++</Stack>
+```
+
+If you still need horizontal column subdivision, keep using `Grid` with `direction="row"` (the default) or `direction="row-reverse"`.
+
 ### List
 
 The `ListItemIcon` default min-width has changed to `36px` (previously `56px`) to be consistent with the menu item, and now uses `theme.spacing` instead of a hardcoded number.


### PR DESCRIPTION
## Summary

- Documents that `Grid` no longer accepts `direction="column"` or `direction="column-reverse"` in the Upgrade to v9 migration guide
- Explains why (`Grid` subdivides layouts into columns) and points to `Stack` for vertical stacking
- Adds a minimal before/after migration example aligned with the existing Grid docs limitation section

Closes #48875

## Context

Maintainer confirmed in #48875 that #47564 removed these direction values but the Material UI v9 upgrade guide did not mention it yet. The same guidance already exists for `@mui/system`; this adds the corresponding note for Material UI.

## Test plan

- [x] Reviewed the added section against `docs/data/material/components/grid/grid.md` (Column direction limitation) and the system v9 guide wording
- [x] Confirmed no competing open PR for #48875 before opening
- Markdown-only docs change; no package code or API surface changes