### PR TITLE
[docs][autocomplete] Clarify how to render custom start and end adornments

### DIFF
--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -294,7 +294,7 @@ Pay particular attention to `params.slotProps.input` (including its `ref`) and `
 Autocomplete renders selected values through `params.slotProps.input.startAdornment`. When adding a custom start
 adornment, preserve the provided adornment:
 
-````tsx
+```tsx
 renderInput={(params) => (
   <TextField
     {...params}
@@ -312,6 +312,7 @@ renderInput={(params) => (
     }}
   />
 )}
+```
 
 Likewise, preserve `params.slotProps.input.endAdornment` when customizing it. It contains Autocomplete's built-in controls.
 
@@ -358,7 +359,7 @@ You can use it to change the default option filter behavior.
 
 ```js
 import { createFilterOptions } from '@mui/material/Autocomplete';
-````
+```
 
 ### `createFilterOptions(config) => filterOptions`
 

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -288,27 +288,32 @@ Fancy smaller inputs? Use the `size` prop.
 
 ### Custom input
 
-The `renderInput` prop allows you to customize the rendered input.
-The first argument of this render prop contains props that you need to forward.
-Pay specific attention to the `ref`, `slotProps.input`, and `slotProps.htmlInput` keys.
+The `renderInput` prop allows you to customize the rendered input. Its argument contains props that must be forwarded.
+Pay particular attention to `params.slotProps.input` (including its `ref`) and `params.slotProps.htmlInput`.
 
-When you customize `slotProps.input.startAdornment`, preserve
-`params.slotProps.input.startAdornment`; otherwise, selected values won't render when `multiple` is true:
+Autocomplete renders selected values through `params.slotProps.input.startAdornment`. When adding a custom start
+adornment, preserve the provided adornment:
 
-```tsx
-slotProps={{
-  ...params.slotProps,
-  input: {
-    ...params.slotProps.input,
-    startAdornment: (
-      <>
-        {customStartAdornment}
-        {params.slotProps.input.startAdornment}
-      </>
-    ),
-  },
-}}
-```
+````tsx
+renderInput={(params) => (
+  <TextField
+    {...params}
+    slotProps={{
+      ...params.slotProps,
+      input: {
+        ...params.slotProps.input,
+        startAdornment: (
+          <>
+            {customStartAdornment}
+            {params.slotProps.input.startAdornment}
+          </>
+        ),
+      },
+    }}
+  />
+)}
+
+Likewise, preserve `params.slotProps.input.endAdornment` when customizing it. It contains Autocomplete's built-in controls.
 
 :::warning
 If you're using a custom input component inside the Autocomplete, make sure that you forward the ref to the underlying DOM element.
@@ -353,7 +358,7 @@ You can use it to change the default option filter behavior.
 
 ```js
 import { createFilterOptions } from '@mui/material/Autocomplete';
-```
+````
 
 ### `createFilterOptions(config) => filterOptions`
 

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -290,7 +290,25 @@ Fancy smaller inputs? Use the `size` prop.
 
 The `renderInput` prop allows you to customize the rendered input.
 The first argument of this render prop contains props that you need to forward.
-Pay specific attention to the `ref` and `inputProps` keys.
+Pay specific attention to the `ref`, `slotProps.input`, and `slotProps.htmlInput` keys.
+
+When you customize `slotProps.input.startAdornment`, preserve
+`params.slotProps.input.startAdornment`; otherwise, selected values won't render when `multiple` is true:
+
+```tsx
+slotProps={{
+  ...params.slotProps,
+  input: {
+    ...params.slotProps.input,
+    startAdornment: (
+      <>
+        {customStartAdornment}
+        {params.slotProps.input.startAdornment}
+      </>
+    ),
+  },
+}}
+```
 
 :::warning
 If you're using a custom input component inside the Autocomplete, make sure that you forward the ref to the underlying DOM element.

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -295,23 +295,28 @@ Autocomplete renders selected values through `params.slotProps.input.startAdornm
 adornment, preserve the provided adornment:
 
 ```tsx
-renderInput={(params) => (
-  <TextField
-    {...params}
-    slotProps={{
-      ...params.slotProps,
-      input: {
-        ...params.slotProps.input,
-        startAdornment: (
-          <>
-            {customStartAdornment}
-            {params.slotProps.input.startAdornment}
-          </>
-        ),
-      },
-    }}
-  />
-)}
+const getInputSlotProps = (params) => ({
+  ...params.slotProps.input,
+  startAdornment: (
+    <>
+      {customStartAdornment}
+      {params.slotProps.input.startAdornment}
+    </>
+  ),
+});
+
+<Autocomplete
+  options={options}
+  renderInput={(params) => (
+    <TextField
+      {...params}
+      slotProps={{
+        ...params.slotProps,
+        input: getInputSlotProps(params),
+      }}
+    />
+  )}
+/>;
 ```
 
 Likewise, preserve `params.slotProps.input.endAdornment` when customizing it. It contains Autocomplete's built-in controls.


### PR DESCRIPTION
Fixes #22103

Clarifies that custom start adornments in `renderInput` must preserve `params.slotProps.input.startAdornment` so selected values continue to render in `multiple` mode.

Checks:
- `pnpm prettier`
- `pnpm code-infra vale --vale-version 3.15.2 docs/data/material/components/autocomplete/autocomplete.md` (0 errors)
- `git diff --check`

Preview: https://deploy-preview-48883--material-ui.netlify.app/material-ui/react-autocomplete/#custom-input