### PR TITLE
[blog] Fix caret annotation broken by Prettier wrapping

### DIFF
--- a/docs/pages/blog/pattern-type-only-breaking-changes-minor-versions.md
+++ b/docs/pages/blog/pattern-type-only-breaking-changes-minor-versions.md
@@ -179,9 +179,8 @@ import type {} from '@mui/x-charts-premium/moduleAugmentation/rangeBarOnClick';
 function RangeBarChart() {
   const [seriesValues, setSeriesValues] = useState<
     RangeBarValueType | number | null | undefined
+    // ^^^^^^^^^^^^^^^ Correct the type
   >();
-  //                                               ^^^^^^^^^^^^^^^^^
-  //                                               Correct the type
 
   return (
     <BarChartPremium

--- a/docs/pages/blog/pattern-type-only-breaking-changes-minor-versions.md
+++ b/docs/pages/blog/pattern-type-only-breaking-changes-minor-versions.md
@@ -179,7 +179,7 @@ import type {} from '@mui/x-charts-premium/moduleAugmentation/rangeBarOnClick';
 function RangeBarChart() {
   const [seriesValues, setSeriesValues] = useState<
     RangeBarValueType | number | null | undefined
-    // ^^^^^^^^^^^^^^^ Correct the type
+    // ^^^^^^^^^^^^^^ Correct the type
   >();
 
   return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `Correct the type` annotation in the [opt-in type-only breaking changes post](https://github.com/mui/material-ui/blob/master/docs/pages/blog/pattern-type-only-breaking-changes-minor-versions.md) was written for a single-line `useState<...>()` call, but that line is 100 characters, so Prettier wrapped the generic across three lines and left the carets pointing at empty space two lines below their target.

This moves the annotation inside the type argument block, directly under `RangeBarValueType`, matching the `// ^^^` style already used elsewhere in the post. Verified to be Prettier-stable so it cannot drift again.

Preview: https://deploy-preview-48884--material-ui.netlify.app/blog/pattern-type-only-breaking-changes-minor-versions/