### PR TITLE
[docs][drawer] Clarify clipped AppBar spacing

### DIFF
--- a/docs/data/material/components/drawers/drawers.md
+++ b/docs/data/material/components/drawers/drawers.md
@@ -138,6 +138,7 @@ Apps focused on information consumption that use a left-to-right hierarchy.
 ### Clipped under the app bar
 
 Apps focused on productivity that require balance across the screen.
+
 The demo keeps the Drawer below the fixed App Bar by rendering an empty `Toolbar` at the top of the Drawer content.
 This spacer matches the App Bar height so navigation items are not covered by the App Bar.
 

--- a/docs/data/material/components/drawers/drawers.md
+++ b/docs/data/material/components/drawers/drawers.md
@@ -138,5 +138,7 @@ Apps focused on information consumption that use a left-to-right hierarchy.
 ### Clipped under the app bar
 
 Apps focused on productivity that require balance across the screen.
+The demo keeps the Drawer below the fixed App Bar by rendering an empty `Toolbar` at the top of the Drawer content.
+This spacer matches the App Bar height so navigation items are not covered by the App Bar.
 
 {{"demo": "ClippedDrawer.js", "iframe": true}}


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #41400

This clarifies the clipped Drawer demo on the Drawer docs page. The demo uses an empty `Toolbar` inside the permanent Drawer as a spacer so the fixed App Bar does not cover the first navigation items. The added text calls out that relationship directly before the demo, so readers do not have to infer it from the source.

Validation:

- `git diff --check` passed.
- `npx --yes prettier@3.9.6 --write docs/data/material/components/drawers/drawers.md` was run; it reformatted unrelated existing lines in the file, so those unrelated hunks were reverted and only the Drawer docs change remains.

Blockers:

- Full `pnpm install`, docs build, and site preview were not run locally because this was prepared in a sparse checkout for a one-file documentation change.
