### PR TITLE
[docs] Document `box-sx-prop` codemod

### DIFF
--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -3282,9 +3282,26 @@ npx @mui/codemod@latest v5.0.0/base-rename-components-to-slots <path>
 
 The associated breaking change was done in [#34693](https://github.com/mui/material-ui/pull/34693).
 
+#### `box-sx-prop`
+
+Moves supported Box system props into the `sx` prop.
+
+```diff
+-<Box border="1px dashed grey" p={2} />
++<Box sx={{ border: '1px dashed grey', p: 2 }} />
+```
+
+<!-- #npm-tag-reference -->
+
+```bash
+npx @mui/codemod@latest v5.0.0/box-sx-prop <path>
+```
+
+You can find more details about this breaking change in [the migration guide](https://mui.com/material-ui/migration/v5-component-changes/#box).
+
 #### `box-borderradius-values`
 
-Updates the Box API from separate system props to `sx`.
+Updates Box `borderRadius` values for the v5 sizing behavior.
 
 ```diff
 -<Box borderRadius="borderRadius">


### PR DESCRIPTION
The `box-sx-prop` transform exists, but the codemod README does not list it. Users following the v4-to-v5 migration guide can therefore miss the command that moves Box system props into `sx`. The neighboring `box-borderradius-values` entry also describes a different transform than the one it performs.

This update adds the command and a before/after example for `box-sx-prop`, and corrects the border-radius description.

Fixes #35864

Validation:

- `pnpm exec prettier --check packages/mui-codemod/README.md`
- `pnpm code-infra vale --vale-version 3.15.2 --filter='.Level=="error"' packages/mui-codemod/README.md`
- `pnpm -F @mui/codemod test --run box-sx-prop` (4 tests passed)
- `git diff --check`

Prepared with OpenAI Codex; the validation results above are from this checkout.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
