### PR TITLE
[code-infra] Fix team sync PR creation

### DIFF
--- a/.github/workflows/sync-team-members.yml
+++ b/.github/workflows/sync-team-members.yml
@@ -52,8 +52,9 @@ jobs:
             exit 0
           fi
 
-          # The repository ruleset exempts `docs-*` branches from creation restrictions.
-          BRANCH=docs-gha-sync-team-members
+          # `cherry-pick-*` is exempt from branch creation restrictions and required
+          # status checks. `docs-*` is only exempt from the former.
+          BRANCH=cherry-pick-sync-team-members
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git switch -C "$BRANCH"


### PR DESCRIPTION
The team member sync workflow cannot create its pull request branch because the repository rulesets reject `docs-*` branches until all required status checks exist.

Use a branch prefix exempt from both branch creation restrictions and required status checks so the workflow can push the generated update and open a pull request.

Fixes the failure in https://github.com/mui/material-ui/actions/runs/30792437918/job/91618634753.